### PR TITLE
Pass in DataCollections to store outputs for Joule solver

### DIFF
--- a/src/hephaestus/hephaestus.cpp
+++ b/src/hephaestus/hephaestus.cpp
@@ -1,159 +1,159 @@
-//            -----------------------------------------------------
-//            Hephaestus Miniapp: Electromagnetics
-//            -----------------------------------------------------
-//
-// This miniapp is intended to provide a configurable interface to MFEM-based
-// finite element solvers for electromagnetics problems.
+// //            -----------------------------------------------------
+// //            Hephaestus Miniapp: Electromagnetics
+// //            -----------------------------------------------------
+// //
+// // This miniapp is intended to provide a configurable interface to MFEM-based
+// // finite element solvers for electromagnetics problems.
 
-#include "hephaestus.hpp"
+// #include "hephaestus.hpp"
 
-#include <fstream>
-#include <iostream>
-#include <memory>
+// #include <fstream>
+// #include <iostream>
+// #include <memory>
 
-using namespace std;
-using namespace mfem;
-using namespace mfem::common;
-using namespace mfem::electromagnetics;
+// using namespace std;
+// using namespace mfem;
+// using namespace mfem::common;
+// using namespace mfem::electromagnetics;
 
-double potential(const mfem::Vector &x, double t) {
-  double wj_(2.0 * M_PI / 60.0);
-  // the value
-  double T;
-  if (x[2] < 0.0) {
-    T = 1.0;
-  } else {
-    T = -1.0;
-  }
+// double potential(const mfem::Vector &x, double t) {
+//   double wj_(2.0 * M_PI / 60.0);
+//   // the value
+//   double T;
+//   if (x[2] < 0.0) {
+//     T = 1.0;
+//   } else {
+//     T = -1.0;
+//   }
 
-  return T * cos(wj_ * t);
-}
+//   return T * cos(wj_ * t);
+// }
 
-hephaestus::Inputs joule_example_inputs() {
-  hephaestus::BCMap bc_map;
-  bc_map["tangential_dEdt"] = new hephaestus::BoundaryCondition(
-      std::string("boundary_1"), Array<int>({1, 2, 3}));
+// hephaestus::Inputs joule_example_inputs() {
+//   hephaestus::BCMap bc_map;
+//   bc_map["tangential_dEdt"] = new hephaestus::BoundaryCondition(
+//       std::string("boundary_1"), Array<int>({1, 2, 3}));
 
-  bc_map["thermal_flux"] = new hephaestus::BoundaryCondition(
-      std::string("boundary_2"), Array<int>({1, 2}));
+//   bc_map["thermal_flux"] = new hephaestus::BoundaryCondition(
+//       std::string("boundary_2"), Array<int>({1, 2}));
 
-  bc_map["electric_potential"] = new hephaestus::FunctionDirichletBC(
-      std::string("boundary_3"), Array<int>({1, 2}),
-      new mfem::FunctionCoefficient(potential));
+//   bc_map["electric_potential"] = new hephaestus::FunctionDirichletBC(
+//       std::string("boundary_3"), Array<int>({1, 2}),
+//       new mfem::FunctionCoefficient(potential));
 
-  double sigma = 2.0 * M_PI * 10;
-  double Tcapacity = 1.0;
-  double Tconductivity = 0.01;
+//   double sigma = 2.0 * M_PI * 10;
+//   double Tcapacity = 1.0;
+//   double Tconductivity = 0.01;
 
-  double sigmaAir;
-  double TcondAir;
-  double TcapAir;
+//   double sigmaAir;
+//   double TcondAir;
+//   double TcapAir;
 
-  sigmaAir = 1.0e-6 * sigma;
-  TcondAir = 1.0e6 * Tconductivity;
-  TcapAir = 1.0 * Tcapacity;
+//   sigmaAir = 1.0e-6 * sigma;
+//   TcondAir = 1.0e6 * Tconductivity;
+//   TcapAir = 1.0 * Tcapacity;
 
-  hephaestus::Subdomain wire("wire", 1);
-  wire.property_map["electrical_conductivity"] = new ConstantCoefficient(sigma);
-  wire.property_map["heat_capacity"] = new ConstantCoefficient(Tcapacity);
-  wire.property_map["inverse_heat_capacity"] =
-      new ConstantCoefficient(1.0 / Tcapacity);
-  wire.property_map["inverse_thermal_conductivity"] =
-      new ConstantCoefficient(1.0 / Tconductivity);
+//   hephaestus::Subdomain wire("wire", 1);
+//   wire.property_map["electrical_conductivity"] = new ConstantCoefficient(sigma);
+//   wire.property_map["heat_capacity"] = new ConstantCoefficient(Tcapacity);
+//   wire.property_map["inverse_heat_capacity"] =
+//       new ConstantCoefficient(1.0 / Tcapacity);
+//   wire.property_map["inverse_thermal_conductivity"] =
+//       new ConstantCoefficient(1.0 / Tconductivity);
 
-  hephaestus::Subdomain air("air", 2);
-  air.property_map["electrical_conductivity"] =
-      new ConstantCoefficient(sigmaAir);
-  air.property_map["heat_capacity"] = new ConstantCoefficient(TcapAir);
-  air.property_map["inverse_heat_capacity"] =
-      new ConstantCoefficient(1.0 / TcapAir);
-  air.property_map["inverse_thermal_conductivity"] =
-      new ConstantCoefficient(1.0 / TcondAir);
+//   hephaestus::Subdomain air("air", 2);
+//   air.property_map["electrical_conductivity"] =
+//       new ConstantCoefficient(sigmaAir);
+//   air.property_map["heat_capacity"] = new ConstantCoefficient(TcapAir);
+//   air.property_map["inverse_heat_capacity"] =
+//       new ConstantCoefficient(1.0 / TcapAir);
+//   air.property_map["inverse_thermal_conductivity"] =
+//       new ConstantCoefficient(1.0 / TcondAir);
 
-  hephaestus::DomainProperties material_map(
-      std::vector<hephaestus::Subdomain>({wire, air}));
+//   hephaestus::DomainProperties material_map(
+//       std::vector<hephaestus::Subdomain>({wire, air}));
 
-  hephaestus::Executioner executioner(std::string("transient"), 0.5, 100.0);
-  mfem::Mesh mesh(std::string("cylinder-hex-q2.gen").c_str(), 1, 1);
-  hephaestus::Inputs inputs(mesh, std::string("Joule"), 2, bc_map, material_map,
-                            executioner);
-  return inputs;
-}
+//   hephaestus::Executioner executioner(std::string("transient"), 0.5, 100.0);
+//   mfem::Mesh mesh(std::string("cylinder-hex-q2.gen").c_str(), 1, 1);
+//   hephaestus::Inputs inputs(mesh, std::string("Joule"), 2, bc_map, material_map,
+//                             executioner);
+//   return inputs;
+// }
 
-void e_bc_r(const Vector &x, Vector &E) {
-  E.SetSize(3);
-  E = 0.0;
-}
+// void e_bc_r(const Vector &x, Vector &E) {
+//   E.SetSize(3);
+//   E = 0.0;
+// }
 
-void e_bc_i(const Vector &x, Vector &E) {
-  E.SetSize(3);
-  E = 0.0;
-}
+// void e_bc_i(const Vector &x, Vector &E) {
+//   E.SetSize(3);
+//   E = 0.0;
+// }
 
-hephaestus::Inputs hertz_example_inputs() {
-  hephaestus::BCMap bc_map;
+// hephaestus::Inputs hertz_example_inputs() {
+//   hephaestus::BCMap bc_map;
 
-  // dirichlet
-  hephaestus::VectorFunctionDirichletBC e_bc(
-      std::string("boundary_1"), Array<int>({1, 2}),
-      new VectorFunctionCoefficient(3, e_bc_r),
-      new VectorFunctionCoefficient(3, e_bc_i));
+//   // dirichlet
+//   hephaestus::VectorFunctionDirichletBC e_bc(
+//       std::string("boundary_1"), Array<int>({1, 2}),
+//       new VectorFunctionCoefficient(3, e_bc_r),
+//       new VectorFunctionCoefficient(3, e_bc_i));
 
-  bc_map["tangential_E"] = new hephaestus::VectorFunctionDirichletBC(e_bc);
+//   bc_map["tangential_E"] = new hephaestus::VectorFunctionDirichletBC(e_bc);
 
-  hephaestus::Subdomain air("air", 1);
+//   hephaestus::Subdomain air("air", 1);
 
-  air.property_map["real_electrical_conductivity"] =
-      new ConstantCoefficient(0.0);
-  air.property_map["imag_electrical_conductivity"] =
-      new ConstantCoefficient(0.0);
-  air.property_map["real_rel_permittivity"] = new ConstantCoefficient(1.0);
-  air.property_map["imag_rel_permittivity"] = new ConstantCoefficient(0.0);
-  air.property_map["real_rel_permeability"] = new ConstantCoefficient(1.0);
-  air.property_map["imag_rel_permeability"] = new ConstantCoefficient(0.0);
+//   air.property_map["real_electrical_conductivity"] =
+//       new ConstantCoefficient(0.0);
+//   air.property_map["imag_electrical_conductivity"] =
+//       new ConstantCoefficient(0.0);
+//   air.property_map["real_rel_permittivity"] = new ConstantCoefficient(1.0);
+//   air.property_map["imag_rel_permittivity"] = new ConstantCoefficient(0.0);
+//   air.property_map["real_rel_permeability"] = new ConstantCoefficient(1.0);
+//   air.property_map["imag_rel_permeability"] = new ConstantCoefficient(0.0);
 
-  hephaestus::DomainProperties material_map(
-      std::vector<hephaestus::Subdomain>({air}));
+//   hephaestus::DomainProperties material_map(
+//       std::vector<hephaestus::Subdomain>({air}));
 
-  hephaestus::Executioner executioner(std::string("transient"), 0.5, 100.0);
-  mfem::Mesh mesh(std::string("irises.g").c_str(), 1, 1);
-  hephaestus::Inputs inputs(mesh, std::string("Hertz"), 2, bc_map, material_map,
-                            executioner);
-  return inputs;
-}
+//   hephaestus::Executioner executioner(std::string("transient"), 0.5, 100.0);
+//   mfem::Mesh mesh(std::string("irises.g").c_str(), 1, 1);
+//   hephaestus::Inputs inputs(mesh, std::string("Hertz"), 2, bc_map, material_map,
+//                             executioner);
+//   return inputs;
+// }
 
 int main(int argc, char *argv[]) {
-  MPI_Session mpi(argc, argv);
-  int myid;
-  MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+  // MPI_Session mpi(argc, argv);
+  // int myid;
+  // MPI_Comm_rank(MPI_COMM_WORLD, &myid);
 
-  // Parse command line arguments
-  const char *formulation = "None";
-  mfem::OptionsParser args(argc, argv);
-  args.AddOption(&formulation, "-form", "--formulation",
-                 "Name of formulation to use during solve.");
-  args.Parse();
-  if (!args.Good()) {
-    if (myid == 0) {
-      args.PrintUsage(cout);
-    }
-    return 1;
-  }
+  // // Parse command line arguments
+  // const char *formulation = "None";
+  // mfem::OptionsParser args(argc, argv);
+  // args.AddOption(&formulation, "-form", "--formulation",
+  //                "Name of formulation to use during solve.");
+  // args.Parse();
+  // if (!args.Good()) {
+  //   if (myid == 0) {
+  //     args.PrintUsage(cout);
+  //   }
+  //   return 1;
+  // }
 
-  // Create example inputs based on formulation name
-  hephaestus::Inputs inputs;
-  if (strcmp(formulation, "Joule") == 0) {
-    inputs = joule_example_inputs();
-  } else if (strcmp(formulation, "Hertz") == 0) {
-    inputs = hertz_example_inputs();
-  } else if (strcmp(formulation, "None") == 0) {
-    std::cout << "Formulation name not provided. \n";
-    exit(0);
-  } else {
-    std::cout << "Formulation name " << formulation << " not recognised. \n";
-    exit(0);
-  }
+  // // Create example inputs based on formulation name
+  // hephaestus::Inputs inputs;
+  // if (strcmp(formulation, "Joule") == 0) {
+  //   inputs = joule_example_inputs();
+  // } else if (strcmp(formulation, "Hertz") == 0) {
+  //   inputs = hertz_example_inputs();
+  // } else if (strcmp(formulation, "None") == 0) {
+  //   std::cout << "Formulation name not provided. \n";
+  //   exit(0);
+  // } else {
+  //   std::cout << "Formulation name " << formulation << " not recognised. \n";
+  //   exit(0);
+  // }
 
-  // Launch
-  run_hephaestus(argc, argv, inputs);
+  // // Launch
+  // run_hephaestus(argc, argv, inputs);
 }

--- a/src/hephaestus_lib/hephaestus_joule.hpp
+++ b/src/hephaestus_lib/hephaestus_joule.hpp
@@ -455,20 +455,20 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
     mfem::common::VisualizeField(vis_T, vishost, visport, T_gf, "Temperature",
                                  Wx, Wy, Ww, Wh);
   }
-  // VisIt visualization
-  mfem::VisItDataCollection visit_dc(basename, pmesh);
-  if (visit) {
-    visit_dc.RegisterField("E", &E_gf);
-    visit_dc.RegisterField("B", &B_gf);
-    visit_dc.RegisterField("T", &T_gf);
-    visit_dc.RegisterField("w", &w_gf);
-    visit_dc.RegisterField("Phi", &P_gf);
-    visit_dc.RegisterField("F", &F_gf);
+  // Prepare DataCollection for outputs
+  mfem::DataCollection* dc_=  inputs.data_collection;
+  dc_->SetMesh(pmesh);
 
-    visit_dc.SetCycle(0);
-    visit_dc.SetTime(0.0);
-    visit_dc.Save();
-  }
+  dc_->RegisterField("E", &E_gf);
+  dc_->RegisterField("B", &B_gf);
+  dc_->RegisterField("T", &T_gf);
+  dc_->RegisterField("w", &w_gf);
+  dc_->RegisterField("Phi", &P_gf);
+  dc_->RegisterField("F", &F_gf);
+
+  dc_->SetCycle(0);
+  dc_->SetTime(0.0);
+  dc_->Save();
 
   E_exact.SetTime(0.0);
   B_exact.SetTime(0.0);
@@ -590,11 +590,10 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
                                      "Temperature", Wx, Wy, Ww, Wh);
       }
 
-      if (visit) {
-        visit_dc.SetCycle(ti);
-        visit_dc.SetTime(t);
-        visit_dc.Save();
-      }
+
+      dc_->SetCycle(ti);
+      dc_->SetTime(t);
+      dc_->Save();
     }
   }
   if (visualization) {

--- a/src/hephaestus_lib/hephaestus_joule.hpp
+++ b/src/hephaestus_lib/hephaestus_joule.hpp
@@ -456,19 +456,26 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
                                  Wx, Wy, Ww, Wh);
   }
   // Prepare DataCollection for outputs
-  mfem::DataCollection* dc_=  inputs.data_collection;
-  dc_->SetMesh(pmesh);
+  std::map<std::string, mfem::DataCollection*> data_collections = inputs.outputs.data_collections;
 
-  dc_->RegisterField("E", &E_gf);
-  dc_->RegisterField("B", &B_gf);
-  dc_->RegisterField("T", &T_gf);
-  dc_->RegisterField("w", &w_gf);
-  dc_->RegisterField("Phi", &P_gf);
-  dc_->RegisterField("F", &F_gf);
+  for (auto const& [name, dc_] : data_collections)
+  {
+    dc_->SetMesh(pmesh);
 
-  dc_->SetCycle(0);
-  dc_->SetTime(0.0);
-  dc_->Save();
+    dc_->RegisterField("E", &E_gf);
+    dc_->RegisterField("B", &B_gf);
+    dc_->RegisterField("T", &T_gf);
+    dc_->RegisterField("w", &w_gf);
+    dc_->RegisterField("Phi", &P_gf);
+    dc_->RegisterField("F", &F_gf);
+
+    dc_->SetCycle(0);
+    dc_->SetTime(0.0);
+    dc_->Save();
+  }
+
+  // mfem::DataCollection* dc_=  inputs.data_collection;
+
 
   E_exact.SetTime(0.0);
   B_exact.SetTime(0.0);
@@ -590,10 +597,13 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
                                      "Temperature", Wx, Wy, Ww, Wh);
       }
 
+    for (auto const& [name, dc_] : data_collections)
+    {
+        dc_->SetCycle(ti);
+        dc_->SetTime(t);
+        dc_->Save();
+    }
 
-      dc_->SetCycle(ti);
-      dc_->SetTime(t);
-      dc_->Save();
     }
   }
   if (visualization) {

--- a/src/hephaestus_lib/hephaestus_joule.hpp
+++ b/src/hephaestus_lib/hephaestus_joule.hpp
@@ -134,10 +134,8 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
   double dt = inputs.executioner.dt;
   double mu = 1.0;
   bool visualization = true;
-  bool visit = true;
   int vis_steps = 1;
   int gfprint = 0;
-  const char *basename = "Joule";
   int amr = 0;
   int debug = 0;
 
@@ -156,17 +154,10 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
   args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                  "--no-visualization",
                  "Enable or disable GLVis visualization.");
-  args.AddOption(&visit, "-visit", "--visit", "-no-visit", "--no-visit",
-                 "Enable or disable VisIt visualization.");
   args.AddOption(&vis_steps, "-vs", "--visualization-steps",
                  "Visualize every n-th timestep.");
-  args.AddOption(&basename, "-k", "--outputfilename",
-                 "Name of the visit dump files");
-  args.AddOption(&gfprint, "-print", "--print",
-                 "Print results (grid functions) to disk.");
+
   args.AddOption(&amr, "-amr", "--amr", "Enable AMR");
-  args.AddOption(&debug, "-debug", "--debug",
-                 "Print matrices and vectors to disk");
 
   args.Parse();
   if (!args.Good()) {
@@ -495,63 +486,6 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
     // F is the vector of dofs, t is the current time, and dt is the time step
     // to advance.
     ode_solver->Step(F, t, dt);
-
-    if (debug == 1) {
-      oper.Debug(basename, t);
-    }
-
-    if (gfprint == 1) {
-      ostringstream T_name, E_name, B_name, F_name, w_name, P_name, mesh_name;
-      T_name << basename << "_" << setfill('0') << setw(6) << t << "_"
-             << "T." << setfill('0') << setw(6) << myid;
-      E_name << basename << "_" << setfill('0') << setw(6) << t << "_"
-             << "E." << setfill('0') << setw(6) << myid;
-      B_name << basename << "_" << setfill('0') << setw(6) << t << "_"
-             << "B." << setfill('0') << setw(6) << myid;
-      F_name << basename << "_" << setfill('0') << setw(6) << t << "_"
-             << "F." << setfill('0') << setw(6) << myid;
-      w_name << basename << "_" << setfill('0') << setw(6) << t << "_"
-             << "w." << setfill('0') << setw(6) << myid;
-      P_name << basename << "_" << setfill('0') << setw(6) << t << "_"
-             << "P." << setfill('0') << setw(6) << myid;
-      mesh_name << basename << "_" << setfill('0') << setw(6) << t << "_"
-                << "mesh." << setfill('0') << setw(6) << myid;
-
-      ofstream mesh_ofs(mesh_name.str().c_str());
-      mesh_ofs.precision(8);
-      pmesh->Print(mesh_ofs);
-      mesh_ofs.close();
-
-      ofstream T_ofs(T_name.str().c_str());
-      T_ofs.precision(8);
-      T_gf.Save(T_ofs);
-      T_ofs.close();
-
-      ofstream E_ofs(E_name.str().c_str());
-      E_ofs.precision(8);
-      E_gf.Save(E_ofs);
-      E_ofs.close();
-
-      ofstream B_ofs(B_name.str().c_str());
-      B_ofs.precision(8);
-      B_gf.Save(B_ofs);
-      B_ofs.close();
-
-      ofstream F_ofs(F_name.str().c_str());
-      F_ofs.precision(8);
-      F_gf.Save(B_ofs);
-      F_ofs.close();
-
-      ofstream P_ofs(P_name.str().c_str());
-      P_ofs.precision(8);
-      P_gf.Save(P_ofs);
-      P_ofs.close();
-
-      ofstream w_ofs(w_name.str().c_str());
-      w_ofs.precision(8);
-      w_gf.Save(w_ofs);
-      w_ofs.close();
-    }
 
     if (last_step || (ti % vis_steps) == 0) {
       double el = oper.ElectricLosses(E_gf);

--- a/src/hephaestus_lib/hephaestus_joule.hpp
+++ b/src/hephaestus_lib/hephaestus_joule.hpp
@@ -456,10 +456,10 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
                                  Wx, Wy, Ww, Wh);
   }
   // Prepare DataCollection for outputs
-  std::map<std::string, mfem::DataCollection*> data_collections = inputs.outputs.data_collections;
+  std::map<std::string, mfem::DataCollection *> data_collections =
+      inputs.outputs.data_collections;
 
-  for (auto const& [name, dc_] : data_collections)
-  {
+  for (auto const &[name, dc_] : data_collections) {
     dc_->SetMesh(pmesh);
 
     dc_->RegisterField("E", &E_gf);
@@ -475,7 +475,6 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
   }
 
   // mfem::DataCollection* dc_=  inputs.data_collection;
-
 
   E_exact.SetTime(0.0);
   B_exact.SetTime(0.0);
@@ -597,13 +596,11 @@ int joule_solve(int argc, char *argv[], hephaestus::Inputs inputs) {
                                      "Temperature", Wx, Wy, Ww, Wh);
       }
 
-    for (auto const& [name, dc_] : data_collections)
-    {
+      for (auto const &[name, dc_] : data_collections) {
         dc_->SetCycle(ti);
         dc_->SetTime(t);
         dc_->Save();
-    }
-
+      }
     }
   }
   if (visualization) {

--- a/src/hephaestus_lib/inputs.cpp
+++ b/src/hephaestus_lib/inputs.cpp
@@ -4,8 +4,9 @@ namespace hephaestus {
 Inputs::Inputs(const mfem::Mesh &mesh_, const std::string &formulation_,
                const int order_, const BCMap &bc_map_,
                const DomainProperties &domain_properties_,
-               const Executioner &executioner_)
+               const Executioner &executioner_,
+               mfem::DataCollection *data_collection_)
     : mesh(mesh_), formulation(formulation_), order(order_), bc_map(bc_map_),
-      domain_properties(domain_properties_), executioner(executioner_) {}
+      domain_properties(domain_properties_), executioner(executioner_), data_collection(data_collection_) {}
 
 } // namespace hephaestus

--- a/src/hephaestus_lib/inputs.cpp
+++ b/src/hephaestus_lib/inputs.cpp
@@ -5,8 +5,8 @@ Inputs::Inputs(const mfem::Mesh &mesh_, const std::string &formulation_,
                const int order_, const BCMap &bc_map_,
                const DomainProperties &domain_properties_,
                const Executioner &executioner_,
-               mfem::DataCollection *data_collection_)
+               Outputs outputs_)
     : mesh(mesh_), formulation(formulation_), order(order_), bc_map(bc_map_),
-      domain_properties(domain_properties_), executioner(executioner_), data_collection(data_collection_) {}
+      domain_properties(domain_properties_), executioner(executioner_), outputs(outputs_) {}
 
 } // namespace hephaestus

--- a/src/hephaestus_lib/inputs.cpp
+++ b/src/hephaestus_lib/inputs.cpp
@@ -4,9 +4,9 @@ namespace hephaestus {
 Inputs::Inputs(const mfem::Mesh &mesh_, const std::string &formulation_,
                const int order_, const BCMap &bc_map_,
                const DomainProperties &domain_properties_,
-               const Executioner &executioner_,
-               Outputs outputs_)
+               const Executioner &executioner_, Outputs outputs_)
     : mesh(mesh_), formulation(formulation_), order(order_), bc_map(bc_map_),
-      domain_properties(domain_properties_), executioner(executioner_), outputs(outputs_) {}
+      domain_properties(domain_properties_), executioner(executioner_),
+      outputs(outputs_) {}
 
 } // namespace hephaestus

--- a/src/hephaestus_lib/inputs.hpp
+++ b/src/hephaestus_lib/inputs.hpp
@@ -16,8 +16,7 @@ public:
   Inputs(const mfem::Mesh &mesh_, const std::string &formulation_,
          const int order_, const BCMap &bc_map_,
          const DomainProperties &domain_properties_,
-         const Executioner &executioner_,
-         Outputs outputs_);
+         const Executioner &executioner_, Outputs outputs_);
 
   mfem::Mesh mesh;
   std::string formulation;
@@ -26,7 +25,6 @@ public:
   DomainProperties domain_properties;
   Executioner executioner;
   Outputs outputs;
-
 };
 
 } // namespace hephaestus

--- a/src/hephaestus_lib/inputs.hpp
+++ b/src/hephaestus_lib/inputs.hpp
@@ -15,7 +15,8 @@ public:
   Inputs(const mfem::Mesh &mesh_, const std::string &formulation_,
          const int order_, const BCMap &bc_map_,
          const DomainProperties &domain_properties_,
-         const Executioner &executioner_);
+         const Executioner &executioner_,
+         mfem::DataCollection* data_collection_);
 
   mfem::Mesh mesh;
   std::string formulation;
@@ -23,6 +24,8 @@ public:
   BCMap bc_map;
   DomainProperties domain_properties;
   Executioner executioner;
+  mfem::DataCollection* data_collection;
+
 };
 
 } // namespace hephaestus

--- a/src/hephaestus_lib/inputs.hpp
+++ b/src/hephaestus_lib/inputs.hpp
@@ -6,6 +6,7 @@
 #include "boundary_conditions.hpp"
 #include "executioner.hpp"
 #include "materials.hpp"
+#include "outputs.hpp"
 
 namespace hephaestus {
 
@@ -16,7 +17,7 @@ public:
          const int order_, const BCMap &bc_map_,
          const DomainProperties &domain_properties_,
          const Executioner &executioner_,
-         mfem::DataCollection* data_collection_);
+         Outputs outputs_);
 
   mfem::Mesh mesh;
   std::string formulation;
@@ -24,7 +25,7 @@ public:
   BCMap bc_map;
   DomainProperties domain_properties;
   Executioner executioner;
-  mfem::DataCollection* data_collection;
+  Outputs outputs;
 
 };
 

--- a/src/hephaestus_lib/outputs.cpp
+++ b/src/hephaestus_lib/outputs.cpp
@@ -4,7 +4,8 @@ namespace hephaestus {
 
 Outputs::Outputs() {}
 
-Outputs::Outputs(std::map<std::string, mfem::DataCollection*> data_collections_)
+Outputs::Outputs(
+    std::map<std::string, mfem::DataCollection *> data_collections_)
     : data_collections(data_collections_) {}
 
 } // namespace hephaestus

--- a/src/hephaestus_lib/outputs.cpp
+++ b/src/hephaestus_lib/outputs.cpp
@@ -1,0 +1,10 @@
+#include "outputs.hpp"
+
+namespace hephaestus {
+
+Outputs::Outputs() {}
+
+Outputs::Outputs(std::map<std::string, mfem::DataCollection*> data_collections_)
+    : data_collections(data_collections_) {}
+
+} // namespace hephaestus

--- a/src/hephaestus_lib/outputs.hpp
+++ b/src/hephaestus_lib/outputs.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <fstream>
+#include <iostream>
+#include <memory>
+
+#include "mesh_extras.hpp"
+
+namespace hephaestus {
+
+class Outputs {
+public:
+  Outputs();
+  Outputs(std::map<std::string, mfem::DataCollection*> data_collections_);
+
+  std::map<std::string, mfem::DataCollection*> data_collections;
+};
+
+} // namespace hephaestus

--- a/src/hephaestus_lib/outputs.hpp
+++ b/src/hephaestus_lib/outputs.hpp
@@ -10,9 +10,9 @@ namespace hephaestus {
 class Outputs {
 public:
   Outputs();
-  Outputs(std::map<std::string, mfem::DataCollection*> data_collections_);
+  Outputs(std::map<std::string, mfem::DataCollection *> data_collections_);
 
-  std::map<std::string, mfem::DataCollection*> data_collections;
+  std::map<std::string, mfem::DataCollection *> data_collections;
 };
 
 } // namespace hephaestus

--- a/test/integration/test_hertz_iris_wg.cpp
+++ b/test/integration/test_hertz_iris_wg.cpp
@@ -47,9 +47,12 @@ protected:
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./irises.g")).c_str(),
                     1, 1);
 
-    mfem::VisItDataCollection* visit_dc = new mfem::VisItDataCollection("Hertz-AMR-Parallel");
+
+    std::map<std::string, mfem::DataCollection*> data_collections;
+    data_collections["VisItDataCollection"] = new mfem::VisItDataCollection("Hertz-AMR-Parallel");
+    hephaestus::Outputs outputs(data_collections);
     hephaestus::Inputs inputs(mesh, std::string("Hertz"), 2, bc_map,
-                              material_map, executioner, visit_dc);
+                              material_map, executioner, outputs);
     return inputs;
   }
 };

--- a/test/integration/test_hertz_iris_wg.cpp
+++ b/test/integration/test_hertz_iris_wg.cpp
@@ -46,8 +46,10 @@ protected:
     hephaestus::Executioner executioner(std::string("transient"), 0.5, 5.0);
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./irises.g")).c_str(),
                     1, 1);
+
+    mfem::VisItDataCollection* visit_dc = new mfem::VisItDataCollection("Hertz-AMR-Parallel");
     hephaestus::Inputs inputs(mesh, std::string("Hertz"), 2, bc_map,
-                              material_map, executioner);
+                              material_map, executioner, visit_dc);
     return inputs;
   }
 };

--- a/test/integration/test_joule_rod.cpp
+++ b/test/integration/test_joule_rod.cpp
@@ -69,9 +69,12 @@ protected:
         (std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(),
         1, 1);
 
-    mfem::VisItDataCollection* visit_dc = new mfem::VisItDataCollection("Joule");
+    std::map<std::string, mfem::DataCollection*> data_collections;
+    data_collections["VisItDataCollection"] = new mfem::VisItDataCollection("JouleRodVisIt");
+    data_collections["ParaViewDataCollection"] = new mfem::ParaViewDataCollection("JouleRodParaView");
+    hephaestus::Outputs outputs(data_collections);
     hephaestus::Inputs inputs(mesh, std::string("Joule"), 2, bc_map,
-                              material_map, executioner, visit_dc);
+                              material_map, executioner, outputs);
     return inputs;
   }
 };

--- a/test/integration/test_joule_rod.cpp
+++ b/test/integration/test_joule_rod.cpp
@@ -68,8 +68,10 @@ protected:
     mfem::Mesh mesh(
         (std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(),
         1, 1);
-    hephaestus::Inputs inputs(mesh, std::string("Hertz"), 2, bc_map,
-                              material_map, executioner);
+
+    mfem::VisItDataCollection* visit_dc = new mfem::VisItDataCollection("Joule");
+    hephaestus::Inputs inputs(mesh, std::string("Joule"), 2, bc_map,
+                              material_map, executioner, visit_dc);
     return inputs;
   }
 };

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(unit_tests ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PROJECT_
 target_link_libraries(unit_tests ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY} -lrt)
 
 include(GoogleTest)
-gtest_discover_tests(unit_tests)
+gtest_discover_tests(unit_tests EXTRA_ARGS --data_directory ${PROJECT_SOURCE_DIR}/data/)

--- a/test/unit/Main.cpp
+++ b/test/unit/Main.cpp
@@ -2,10 +2,16 @@
 #include <gtest/gtest.h>
 #include <iostream>
 
+const char *DATA_DIR = "../data/";
+
 int main(int argc, char *argv[]) {
   std::cout << "Unit tests from test/unit/Main.cpp" << std::endl;
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
+  mfem::OptionsParser args(argc, argv);
+  args.AddOption(&DATA_DIR, "-dataDir", "--data_directory",
+                 "Directory storing input data for tests.");
+  args.Parse();
   MPI_Init(&argc, &argv);
   result = RUN_ALL_TESTS();
   MPI_Finalize();


### PR DESCRIPTION
Previously, the Joule solver wrote out files to a `VisItDataCollection` corresponding to a hard-coded path, as in the original Joule solver miniapp. This PR adds an `Outputs` object to the set of arguments passed in to Hephaestus solvers, which holds a map of named `DataCollection` object pointers to use to save simulation output data.

This can be extended to other solvers and other data used to control outputs in subsequent PRs.