### PR TITLE
Add initial A and AV form solvers

### DIFF
--- a/src/hephaestus_lib/aform_solver.cpp
+++ b/src/hephaestus_lib/aform_solver.cpp
@@ -1,0 +1,39 @@
+#include "aform_solver.hpp"
+
+namespace hephaestus {
+
+AFormSolver::AFormSolver(mfem::ParMesh &pmesh, int order,
+                         mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
+                         hephaestus::BCMap &bc_map,
+                         hephaestus::DomainProperties &domain_properties)
+    : HCurlSolver(pmesh, order, variables, bc_map, domain_properties) {}
+
+void AFormSolver::SetVariableNames() {
+  p_name = "electric_potential";
+  p_display_name = "Scalar Potential (V)";
+
+  u_name = "magnetic_vector_potential";
+  u_display_name = "Magnetic Vector Potential (A)";
+}
+
+void AFormSolver::SetMaterialCoefficients(
+    hephaestus::DomainProperties &domain_properties) {
+  if (domain_properties.scalar_property_map.count("magnetic_permeability") ==
+      0) {
+    domain_properties.scalar_property_map["magnetic_permeability"] =
+        new mfem::PWCoefficient(domain_properties.getGlobalScalarProperty(
+            std::string("magnetic_permeability")));
+  }
+  if (domain_properties.scalar_property_map.count("electrical_conductivity") ==
+      0) {
+    domain_properties.scalar_property_map["electrical_conductivity"] =
+        new mfem::PWCoefficient(domain_properties.getGlobalScalarProperty(
+            std::string("electrical_conductivity")));
+  }
+  alphaCoef = new mfem::TransformedCoefficient(
+      &oneCoef, domain_properties.scalar_property_map["magnetic_permeability"],
+      fracFunc);
+  betaCoef = domain_properties.scalar_property_map["electrical_conductivity"];
+}
+
+} // namespace hephaestus

--- a/src/hephaestus_lib/aform_solver.hpp
+++ b/src/hephaestus_lib/aform_solver.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include "../common/pfem_extras.hpp"
+#include "hcurl_solver.hpp"
+#include "inputs.hpp"
+
+namespace hephaestus {
+
+class AFormSolver : public hephaestus::HCurlSolver {
+  virtual void SetMaterialCoefficients(
+      hephaestus::DomainProperties &domain_properties) override;
+  virtual void SetVariableNames() override;
+
+public:
+  AFormSolver(mfem::ParMesh &pmesh, int order,
+              mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
+              hephaestus::BCMap &bc_map,
+              hephaestus::DomainProperties &domain_properties);
+
+  ~AFormSolver(){};
+};
+} // namespace hephaestus

--- a/src/hephaestus_lib/av_solver.cpp
+++ b/src/hephaestus_lib/av_solver.cpp
@@ -285,7 +285,6 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
 
   curl->Mult(u_, b_);
   curl->AddMult(du_, b_, dt);
-  std::cout << "finished";
 }
 
 void AVSolver::buildA0(mfem::Coefficient *betaCoef,

--- a/src/hephaestus_lib/av_solver.cpp
+++ b/src/hephaestus_lib/av_solver.cpp
@@ -1,0 +1,650 @@
+// Strong form
+// ∇⋅v0 = 0
+// ∇×(α∇×u) - βdu/dt = v0
+
+// Weak form
+// -(v0, ∇ p') + <n.v0, p'> = 0
+// (α∇×u, ∇×u') - (βdu/dt, u') - (v0, u') - <(α∇×u) × n, u'> = 0
+
+// v, v0 ∈ H(div) source field
+// u ∈ H(curl)
+// p ∈ H1
+
+///////
+// (σ(dA/dt + ∇ V), A') +(ν∇×A, ∇×A') - <(ν∇×A) × n, A'> - (J0, A') = 0
+// (σ(dA/dt + ∇ V), ∇ V') + <n.J, V'> = 0
+///////
+
+// (σ(dA/dt + ∇ V), A') +(ν∇×A, ∇×A') - <(ν∇×A) × n, A'> - (J0, A') = 0
+
+// // (σ dA/dt, A')
+// mfem::ParBilinearForm(HCurlFESpace_);
+// mfem::VectorFEMassIntegrator(sigmaCoef);
+
+// // (σ ∇ V, A')
+// mfem::ParMixedBilinearForm(H1FESpace_, HCurlFESpace_);
+// mfem::MixedVectorGradientIntegrator(sigmaCoef);
+
+// // (ν∇×A, ∇×A')
+// mfem::ParBilinearForm(HCurlFESpace_);
+// mfem::CurlCurlIntegrator(dtMuInvCoef);
+// mfem::ParLinearForm(HCurlFESpace_);
+// mfem::CurlCurlIntegrator(muInvCoef);
+
+// (σ(dA/dt + ∇ V), ∇ V') + <n.J, V'> = 0
+
+// (σdA/dt , ∇ V')
+// mfem::ParMixedBilinearForm(HCurlFESpace_, H1FESpace_)
+// mfem::MixedVectorWeakDivergenceIntegrator(sigmaCoef)
+
+// (σ ∇ V, ∇ V')
+// mfem::ParBilinearForm(H1FESpace_)
+// mfem::DiffusionIntegrator(sigmaCoef)
+
+#include "av_solver.hpp"
+
+namespace hephaestus {
+
+AVSolver::AVSolver(mfem::ParMesh &pmesh, int order,
+                   mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
+                   hephaestus::BCMap &bc_map,
+                   hephaestus::DomainProperties &domain_properties)
+    : myid_(0), num_procs_(1), pmesh_(&pmesh), _variables(variables),
+      _bc_map(bc_map), _domain_properties(domain_properties),
+      H1FESpace_(
+          new mfem::common::H1_ParFESpace(&pmesh, order, pmesh.Dimension())),
+      HCurlFESpace_(
+          new mfem::common::ND_ParFESpace(&pmesh, order, pmesh.Dimension())),
+      HDivFESpace_(
+          new mfem::common::RT_ParFESpace(&pmesh, order, pmesh.Dimension())),
+      blockAV(NULL), blockAVPr(NULL), a1(NULL), amg_a0(NULL), pcg_a0(NULL),
+      ams_a1(NULL), pcg_a1(NULL), m1(NULL), grad(NULL), curl(NULL),
+      weakCurl(NULL), curlCurl(NULL), sourceVecCoef(NULL), src_gf(NULL),
+      div_free_src_gf(NULL), hCurlMass(NULL), divFreeProj(NULL),
+      v_(mfem::ParGridFunction(H1FESpace_)),
+      a_(mfem::ParGridFunction(HCurlFESpace_)),
+      e_(mfem::ParGridFunction(HCurlFESpace_)),
+      b_(mfem::ParGridFunction(HDivFESpace_)),
+      dv_(mfem::ParGridFunction(H1FESpace_)),
+      da_(mfem::ParGridFunction(HCurlFESpace_)) {
+  // Initialize MPI variables
+  MPI_Comm_size(pmesh.GetComm(), &num_procs_);
+  MPI_Comm_rank(pmesh.GetComm(), &myid_);
+
+  true_offsets.SetSize(3);
+  true_offsets[0] = 0;
+  true_offsets[1] = H1FESpace_->GetVSize();
+  true_offsets[2] = HCurlFESpace_->GetVSize();
+  true_offsets.PartialSum();
+
+  block_trueOffsets.SetSize(3);
+  block_trueOffsets[0] = 0;
+  block_trueOffsets[1] = H1FESpace_->TrueVSize();
+  block_trueOffsets[2] = HCurlFESpace_->TrueVSize();
+  block_trueOffsets.PartialSum();
+
+  this->height = true_offsets[2];
+  this->width = true_offsets[2];
+}
+
+void AVSolver::Init(mfem::Vector &X) {
+  SetVariableNames();
+  _variables.Register(u_name, &a_, false);
+  _variables.Register(p_name, &v_, false);
+  _variables.Register(v_name, &b_, false);
+  _variables.Register(e_name, &e_, false);
+
+  // Define material property coefficients
+  dtCoef = mfem::ConstantCoefficient(1.0);
+  oneCoef = mfem::ConstantCoefficient(1.0);
+  negCoef = mfem::ConstantCoefficient(-1.0);
+
+  SetMaterialCoefficients(_domain_properties);
+  dtAlphaCoef = new mfem::TransformedCoefficient(&dtCoef, alphaCoef, prodFunc);
+  negBetaCoef = new mfem::TransformedCoefficient(&oneCoef, betaCoef, prodFunc);
+
+  x = new mfem::BlockVector(true_offsets);
+  rhs = new mfem::BlockVector(true_offsets);
+  trueX = new mfem::BlockVector(block_trueOffsets);
+  trueRhs = new mfem::BlockVector(block_trueOffsets);
+
+  // Variables
+  // v_, "electric_potential"
+  // a_, "magnetic_vector_potential"
+
+  // Coefficients
+  // σ, "electrical_conductivity"
+  // mu, "magnetic_permeability"
+
+  ///////
+  // (σ(dA/dt + ∇ V), ∇ V') + <n.J, V'> = 0
+  // (σ(dA/dt + ∇ V), A') + (ν∇×A, ∇×A') - <(ν∇×A) × n, A'> - (J0, A') = 0
+  ///////
+  // Bilinear for divergence free source field solve
+  // -(J0, ∇ V') + <n.J, V'> = 0  where J0 = -σ∇V
+  a0 = new mfem::ParBilinearForm(H1FESpace_);
+  a0->AddDomainIntegrator(new mfem::DiffusionIntegrator(*betaCoef));
+  a0->Assemble();
+
+  // (σdA/dt , ∇ V')
+  // mfem::ParMixedBilinearForm(HCurlFESpace_, H1FESpace_)
+  // mfem::MixedVectorWeakDivergenceIntegrator(sigmaCoef)
+  // TODO: SHOULD BE -BETACOEF
+  a01 = new mfem::ParMixedBilinearForm(HCurlFESpace_, H1FESpace_);
+  a01->AddDomainIntegrator(
+      new mfem::MixedVectorWeakDivergenceIntegrator(*negBetaCoef));
+  a01->Assemble();
+  // // (σ ∇ V, A')
+  // mfem::ParMixedBilinearForm(H1FESpace_, HCurlFESpace_);
+  // mfem::MixedVectorGradientIntegrator(sigmaCoef);
+  a10 = new mfem::ParMixedBilinearForm(H1FESpace_, HCurlFESpace_);
+  a10->AddDomainIntegrator(new mfem::MixedVectorGradientIntegrator(*betaCoef));
+  a10->Assemble();
+
+  this->buildM1(betaCoef);    // (σ dA/dt, A')
+  this->buildCurl(alphaCoef); // (ν∇×A, ∇×A')
+  this->buildGrad();
+  b0 = new mfem::ParLinearForm(H1FESpace_);
+  b1 = new mfem::ParLinearForm(HCurlFESpace_);
+  A0 = new mfem::HypreParMatrix;
+  A1 = new mfem::HypreParMatrix;
+  A01 = new mfem::HypreParMatrix;
+  A10 = new mfem::HypreParMatrix;
+  blockA = new mfem::HypreParMatrix;
+
+  X0 = new mfem::Vector;
+  X1 = new mfem::Vector;
+  B0 = new mfem::Vector;
+  B1 = new mfem::Vector;
+
+  mfem::Vector zero_vec(3);
+  zero_vec = 0.0;
+  mfem::VectorConstantCoefficient Zero_vec(zero_vec);
+  mfem::ConstantCoefficient Zero(0.0);
+
+  v_.MakeRef(H1FESpace_, const_cast<mfem::Vector &>(X), true_offsets[0]);
+  a_.MakeRef(HCurlFESpace_, const_cast<mfem::Vector &>(X), true_offsets[1]);
+
+  v_.ProjectCoefficient(Zero);
+  a_.ProjectCoefficient(Zero_vec);
+
+  // aux
+  e_.ProjectCoefficient(Zero_vec);
+  b_.ProjectCoefficient(Zero_vec);
+}
+
+/*
+This is the main computational code that computes dX/dt implicitly
+where X is the state vector containing A and V
+
+(M1+dt S1) E = WeakCurl^T B + Grad V
+        S0 V = 0
+*/
+void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
+                             mfem::Vector &dX_dt) {
+  dX_dt = 0.0;
+  dtCoef.constant = dt;
+  v_.MakeRef(H1FESpace_, const_cast<mfem::Vector &>(X), true_offsets[0]);
+  a_.MakeRef(HCurlFESpace_, const_cast<mfem::Vector &>(X), true_offsets[1]);
+  dv_.MakeRef(H1FESpace_, dX_dt, true_offsets[0]);
+  da_.MakeRef(HCurlFESpace_, dX_dt, true_offsets[1]);
+
+  _domain_properties.SetTime(this->GetTime());
+
+  std::cout << "b0 start" << std::endl;
+  mfem::ParGridFunction Phi_gf;
+  Phi_gf.MakeRef(H1FESpace_, trueX->GetBlock(0), 0);
+
+  mfem::Array<int> poisson_ess_tdof_list;
+  Phi_gf = 1.0;
+  *b0 = 0.0;
+  std::cout << "b0 update start" << std::endl;
+  // b0->Update(H1FESpace_, Phi_gf, 0);
+  std::cout << "b0 update end" << std::endl;
+  std::cout << "b0 bc start" << std::endl;
+
+  _bc_map.applyIntegratedBCs(p_name, *b0, pmesh_);
+  std::cout << "b0 ess start" << std::endl;
+  _bc_map.applyEssentialBCs(p_name, poisson_ess_tdof_list, Phi_gf, pmesh_);
+  std::cout << "b0 ess start" << std::endl;
+  std::cout << "b0 ess start" << std::endl;
+  std::cout << "b0 assemble" << std::endl;
+  b0->Assemble();
+
+  a0->EliminateEssentialBC(mfem::Array<int>({1, 1, 0}), Phi_gf, *b0);
+  std::cout << "b0 ess startt" << std::endl;
+  a0->Finalize();
+  A0 = a0->ParallelAssemble();
+
+  // _bc_map.applyEssentialBCs(p_name, poisson_ess_tdof_list, Phi_gf, pmesh_);
+  std::cout << "b0 parallel assemble" << std::endl;
+
+  // trueRhs->GetBlock(0).SyncAliasMemory(*trueRhs);
+
+  // a0->EliminateEssentialBC(ess_bdr, Phi_gf, *b0);
+  // a0->Finalize();
+
+  // b0->ParallelAssemble(Phi_gf.GetTrueVector());
+  std::cout << "b0 end" << std::endl;
+
+  mfem::ParGridFunction J_gf(HCurlFESpace_);
+  J_gf.MakeRef(HCurlFESpace_, trueX->GetBlock(1), 0);
+
+  mfem::Array<int> ess_tdof_list;
+  J_gf = 0.0;
+  // b1->Update(HCurlFESpace_, J_gf, 0);
+  *b1 = 0.0;
+  curlCurl->MultTranspose(a_, *b1); // b1 = (ν∇×A, ∇×A')
+  _bc_map.applyIntegratedBCs(u_name, *b1,
+                             pmesh_); // b1 = (ν∇×A, ∇×A') +  <(ν∇×A) × n, A'>
+  _bc_map.applyEssentialBCs(u_name, ess_tdof_list, J_gf, pmesh_);
+  b1->Assemble();
+
+  // b1->ParallelAssemble(J_gf.GetTrueVector());
+  std::cout << "b1 end" << std::endl;
+
+  // mVarf->EliminateEssentialBC(mark_bdr_attr_ess, trueX.GetBlock(0),
+  // trueRhs.GetBlock(0)); bVarf->EliminateTrialDofs(mark_bdr_attr_ess,
+  // trueX.GetBlock(0), trueRhs.GetBlock(1)); a01->Finalize();
+
+  std::cout << "a1 start" << std::endl;
+
+  mfem::Vector zero_vec(3);
+  zero_vec = 0.0;
+
+  if (a1 == NULL || fabs(dt - dt_A1) > 1.0e-12 * dt) {
+    this->buildA1(betaCoef, dtAlphaCoef);
+  }
+  std::cout << "Assembled" << std::endl;
+  std::cout << J_gf.Size() << std::endl;
+
+  a1->EliminateEssentialBC(mfem::Array<int>({1, 1, 1}), J_gf, *b1);
+  a1->Finalize();
+  A1 = a1->ParallelAssemble();
+
+  a01->EliminateTrialDofs(mfem::Array<int>({1, 1, 0}), J_gf, *b0);
+  a10->EliminateTrialDofs(mfem::Array<int>({1, 1, 1}), Phi_gf, *b1);
+
+  a01->Finalize();
+  A01 = a01->ParallelAssemble();
+
+  a10->Finalize();
+  A10 = a10->ParallelAssemble();
+
+  b0->ParallelAssemble(trueRhs->GetBlock(0));
+  b1->ParallelAssemble(trueRhs->GetBlock(1));
+
+  // A0->EliminateRowsCols(poisson_ess_tdof_list);
+  // A1->EliminateRowsCols(ess_tdof_list);
+  // A01->EliminateCols(ess_tdof_list);
+  // A01->EliminateRows(poisson_ess_tdof_list);
+  // A10->EliminateCols(poisson_ess_tdof_list);
+  // A10->EliminateRows(ess_tdof_list);
+
+  mfem::Array2D<mfem::HypreParMatrix *> hBlocks(2, 2);
+  hBlocks = NULL;
+  hBlocks(0, 0) = A0;
+  hBlocks(0, 1) = A01;
+  hBlocks(1, 0) = A10;
+  hBlocks(1, 1) = A1;
+
+  blockA = mfem::HypreParMatrixFromBlocks(hBlocks);
+  blockA->Mult(*trueRhs, *trueX);
+
+  // *trueX.Print();
+  true_offsets.Print();
+  block_trueOffsets.Print();
+  std::cout << "trueX = " << trueX->Size() << std::endl;
+  ;
+  std::cout << "true RHS = " << trueRhs->Size() << std::endl;
+  ;
+
+  std::cout << "da = " << da_.Size() << std::endl;
+  std::cout << "v = " << v_.Size() << std::endl;
+
+  // solver.Mult(*trueRhs, *trueX);
+  v_.Distribute(&(trueX->GetBlock(0)));
+  da_.Distribute(&(trueX->GetBlock(1)));
+
+  // A1 = HypreParMatrixFromBlocks(hBlocks);
+
+  // if (ams_a1 == NULL) {
+  //   mfem::ParFiniteElementSpace *prec_fespace =
+  //       (a1->StaticCondensationIsEnabled() ? a1->SCParFESpace()
+  //                                          : HCurlFESpace_);
+  //   ams_a1 = new mfem::HypreAMS(*A1, prec_fespace);
+  // }
+  // if (pcg_a1 == NULL) {
+  //   pcg_a1 = new mfem::HyprePCG(*A1);
+  //   pcg_a1->SetTol(1.0e-9);
+  //   pcg_a1->SetMaxIter(1000);
+  //   pcg_a1->SetPrintLevel(0);
+  //   pcg_a1->SetPreconditioner(*ams_a1);
+  // }
+  // // solve the system
+  // // dE = (A1)^-1 [-S1 E]
+  // pcg_a1->Mult(*B1, *X1);
+
+  // a1->RecoverFEMSolution(*X1, *b1, e_);
+
+  // ///
+
+  // if (blockAV == NULL) {
+  //   blockAV = new mfem::BlockOperator(block_trueOffsets);
+  //   blockAV->SetBlock(0, 0, a0->ParallelAssemble());
+  //   blockAV->SetBlock(0, 1, a01->ParallelAssemble());
+  //   blockAV->SetBlock(1, 0, a10->ParallelAssemble());
+  //   blockAV->SetBlock(1, 1, a1->ParallelAssemble());
+  // }
+
+  // if (amg_a0 == NULL) {
+  //   amg_a0 = new mfem::HypreBoomerAMG(*A0);
+  // }
+  // if (ams_a1 == NULL) {
+  //   mfem::ParFiniteElementSpace *prec_fespace =
+  //       (a1->StaticCondensationIsEnabled() ? a1->SCParFESpace()
+  //                                          : HCurlFESpace_);
+  //   ams_a1 = new mfem::HypreAMS(*A1, prec_fespace);
+  // }
+  // // OperatorHandle ;
+  // if (blockAVPr = NULL) {
+  //   blockAVPr = new mfem::BlockDiagonalPreconditioner(block_trueOffsets);
+  //   blockAVPr->SetDiagonalBlock(0, amg_a0);
+  //   blockAVPr->SetDiagonalBlock(1, ams_a1);
+  // }
+
+  // if (pcg_a0 == NULL) {
+  //   mfem::MINRESSolver solver(MPI_COMM_WORLD);
+  //   solver.SetAbsTol(1.0e-9);
+  //   //  solver.SetRelTol(rtol);
+  //   solver.SetMaxIter(1000);
+  //   solver.SetOperator(*blockAV);
+  //   // solver.SetPreconditioner(*blockAVPr);
+  //   //  solver.SetPrintLevel(verbose);
+  //   solver.Mult(*trueRhs, *trueX);
+  //   da_.Distribute(&(trueX->GetBlock(0)));
+  //   v_.Distribute(&(trueX->GetBlock(1)));
+
+  //   // pcg_a0 = new mfem::HyprePCG(MPI_COMM_WORLD);
+  //   // pcg_a0->SetTol(1.0e-9);
+  //   // pcg_a0->SetMaxIter(1000);
+  //   // pcg_a0->SetPrintLevel(0);
+  //   // pcg_a0->SetPreconditioner(dynamic_cast<mfem::HypreSolver
+  //   *>(blockAVPr));
+  //   // pcg_a0->SetOperator(*blockAV);
+  // }
+
+  // pcg_a0->Mult(*B0, *X0);
+  // solver.Mult(trueRhs, trueX);
+
+  // //  u->MakeTRef(R_space, x.GetBlock(0), 0);
+  // //  p->MakeTRef(W_space, x.GetBlock(1), 0);
+  // da_->Distribute(&(trueX.GetBlock(0)));
+  // v_->Distribute(&(trueX.GetBlock(1)));
+
+  // if (amg_a0 == NULL) {
+  //   amg_a0 = new mfem::HypreBoomerAMG(*A0);
+  // }
+  // if (pcg_a0 == NULL) {
+  //   pcg_a0 = new mfem::HyprePCG(*A0);
+  //   pcg_a0->SetTol(1.0e-9);
+  //   pcg_a0->SetMaxIter(1000);
+  //   pcg_a0->SetPrintLevel(0);
+  //   pcg_a0->SetPreconditioner(*amg_a0);
+  //   blockAVPr->SetDiagonalBlock(0, pcg_a0);
+  // }
+
+  // We only need to create the solver and preconditioner once
+  // if (ams_a1 == NULL) {
+  //   mfem::ParFiniteElementSpace *prec_fespace =
+  //       (a1->StaticCondensationIsEnabled() ? a1->SCParFESpace()
+  //                                          : HCurlFESpace_);
+  //   ams_a1 = new mfem::HypreAMS(*A1, prec_fespace);
+  // }
+  // if (pcg_a1 == NULL) {
+  //   pcg_a1 = new mfem::HyprePCG(*A1);
+  //   pcg_a1->SetTol(1.0e-9);
+  //   pcg_a1->SetMaxIter(1000);
+  //   pcg_a1->SetPrintLevel(0);
+  //   pcg_a1->SetPreconditioner(*ams_a1);
+  //   blockAVPr->SetDiagonalBlock(0, pcg_a1);
+  // }
+
+  // form the Laplacian and solve it
+
+  // a0->FormLinearSystem(poisson_ess_tdof_list, Phi_gf, *b0, *A0, *X0, *B0);
+
+  // if (amg_a0 == NULL) {
+  //   amg_a0 = new mfem::HypreBoomerAMG(*A0);
+  // }
+  // if (pcg_a0 == NULL) {
+  //   pcg_a0 = new mfem::HyprePCG(*A0);
+  //   pcg_a0->SetTol(1.0e-9);
+  //   pcg_a0->SetMaxIter(1000);
+  //   pcg_a0->SetPrintLevel(0);
+  //   pcg_a0->SetPreconditioner(*amg_a0);
+  // }
+  // pcg "Mult" operation is a solve
+  // X0 = A0^-1 * B0
+
+  // "undo" the static condensation saving result in grid function dP
+  // a0->RecoverFEMSolution(*X0, *b0, v_);
+  // dv_ = 0.0;
+  // pcg_a1->Mult(*B1, *X1);
+
+  // a1->RecoverFEMSolution(*X1, *b1, da_);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // (σ(dA/dt + ∇ V), A') + (ν∇×A, ∇×A') - <(ν∇×A) × n, A'> - (J0, A') = 0
+
+  // use a_ as a temporary, E = Grad P
+  // b1 = -dt * Grad V
+
+  // mfem::ParGridFunction J_gf(HCurlFESpace_);
+  // mfem::Array<int> ess_tdof_list;
+  // J_gf = 0.0;
+  // _bc_map.applyEssentialBCs(u_name, ess_tdof_list, J_gf, pmesh_);
+  // if (a1 == NULL || fabs(dt - dt_A1) > 1.0e-12 * dt) {
+  //   this->buildA1(betaCoef, dtAlphaCoef);
+  // }
+  // // a1 = (σ dA/dt, A') + dt (ν∇×dA/dt, ∇×A')
+  // // TODO: add  (σ ∇ V, A')
+  // a1->FormLinearSystem(ess_tdof_list, J_gf, *b1, *A1, *X1, *B1);
+
+  // // We only need to create the solver and preconditioner once
+  // if (ams_a1 == NULL) {
+  //   mfem::ParFiniteElementSpace *prec_fespace =
+  //       (a1->StaticCondensationIsEnabled() ? a1->SCParFESpace()
+  //                                          : HCurlFESpace_);
+  //   ams_a1 = new mfem::HypreAMS(*A1, prec_fespace);
+  // }
+  // if (pcg_a1 == NULL) {
+  //   pcg_a1 = new mfem::HyprePCG(*A1);
+  //   pcg_a1->SetTol(1.0e-9);
+  //   pcg_a1->SetMaxIter(1000);
+  //   pcg_a1->SetPrintLevel(0);
+  //   pcg_a1->SetPreconditioner(*ams_a1);
+  // }
+  // // solve the system
+  // // dE = (A1)^-1 [-S1 E]
+  // pcg_a1->Mult(*B1, *X1);
+
+  // a1->RecoverFEMSolution(*X1, *b1, da_);
+
+  // Auxiliary calculations
+  // Compute B = Curl(A)
+  curl->Mult(a_, b_);
+  // Compute e = -(dA/dt + ∇ V);
+  e_ = da_;
+  grad->AddMult(v_, e_, 1.0);
+  e_ *= -1.0;
+}
+
+void AVSolver::buildA1(mfem::Coefficient *Sigma, mfem::Coefficient *DtMuInv) {
+  if (a1 != NULL) {
+    delete a1;
+  }
+  // (σ(dA/dt, A') + dt (ν∇×dA/dt, ∇×A')
+  // First create and assemble the bilinear form.  For now we assume the mesh
+  // isn't moving, the materials are time independent, and dt is constant. So
+  // we only need to do this once.
+
+  a1 = new mfem::ParBilinearForm(HCurlFESpace_);
+  a1->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*Sigma));
+  a1->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*DtMuInv));
+  a1->Assemble();
+
+  // Don't finalize or parallel assemble this is done in FormLinearSystem.
+
+  dt_A1 = dtCoef.constant;
+}
+
+void AVSolver::buildM1(mfem::Coefficient *Sigma) {
+  if (m1 != NULL) {
+    delete m1;
+  }
+
+  m1 = new mfem::ParBilinearForm(HCurlFESpace_);
+  m1->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*Sigma));
+  m1->Assemble();
+
+  // Don't finalize or parallel assemble this is done in FormLinearSystem.
+}
+
+void AVSolver::buildGrad() {
+  if (grad != NULL) {
+    delete grad;
+  }
+
+  grad = new mfem::ParDiscreteLinearOperator(H1FESpace_, HCurlFESpace_);
+  grad->AddDomainInterpolator(new mfem::GradientInterpolator());
+  grad->Assemble();
+
+  // no ParallelAssemble since this will be applied to GridFunctions
+}
+
+void AVSolver::buildCurl(mfem::Coefficient *MuInv) {
+  if (curl != NULL) {
+    delete curl;
+  }
+  if (weakCurl != NULL) {
+    delete weakCurl;
+  }
+
+  curl = new mfem::ParDiscreteLinearOperator(HCurlFESpace_, HDivFESpace_);
+  curl->AddDomainInterpolator(new mfem::CurlInterpolator);
+  curl->Assemble();
+
+  weakCurl = new mfem::ParMixedBilinearForm(HCurlFESpace_, HDivFESpace_);
+  weakCurl->AddDomainIntegrator(new mfem::VectorFECurlIntegrator(*MuInv));
+  weakCurl->Assemble();
+
+  curlCurl = new mfem::ParBilinearForm(HCurlFESpace_);
+  curlCurl->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*MuInv));
+  curlCurl->Assemble();
+
+  // no ParallelAssemble since this will be applied to GridFunctions
+}
+
+void AVSolver::SetVariableNames() {
+  p_name = "electric_potential";
+  p_display_name = "Electric Scalar Potential (V)";
+
+  u_name = "magnetic_vector_potential";
+  u_display_name = "Magnetic Vector Potential (A)";
+
+  v_name = "magnetic_flux_density";
+  v_display_name = "Magnetic Flux Density (B)";
+
+  e_name = "electric_field";
+  e_display_name = "Electric Field (E)";
+}
+
+void AVSolver::SetMaterialCoefficients(
+    hephaestus::DomainProperties &domain_properties) {
+  alphaCoef = new mfem::TransformedCoefficient(
+      &oneCoef, domain_properties.scalar_property_map["magnetic_permeability"],
+      fracFunc);
+  betaCoef = domain_properties.scalar_property_map["electrical_conductivity"];
+}
+
+void AVSolver::SetSourceCoefficient(
+    hephaestus::DomainProperties &domain_properties) {
+  if (domain_properties.vector_property_map.find("source") !=
+      domain_properties.vector_property_map.end()) {
+    sourceVecCoef = domain_properties.vector_property_map["source"];
+  }
+}
+
+void AVSolver::buildSource() {
+  // Replace with class to calculate div free source from input
+  // VectorCoefficient
+  src_gf = new mfem::ParGridFunction(HCurlFESpace_);
+  div_free_src_gf = new mfem::ParGridFunction(HCurlFESpace_);
+  _variables.Register("source", div_free_src_gf, false);
+  // int irOrder = H1FESpace_->GetElementTransformation(0)->OrderW() +
+  //               2 * H1FESpace_->GetOrder();
+  int irOrder = H1FESpace_->GetElementTransformation(0)->OrderW() + 2 * 2;
+  divFreeProj = new mfem::common::DivergenceFreeProjector(
+      *H1FESpace_, *HCurlFESpace_, irOrder, NULL, NULL, NULL);
+  hCurlMass = new mfem::ParBilinearForm(HCurlFESpace_);
+  hCurlMass->AddDomainIntegrator(new mfem::VectorFEMassIntegrator());
+  hCurlMass->Assemble();
+}
+
+void AVSolver::RegisterOutputFields(mfem::DataCollection *dc_) {
+  dc_->SetMesh(pmesh_);
+  for (auto var = _variables.begin(); var != _variables.end(); ++var) {
+    dc_->RegisterField(var->first, var->second);
+  }
+}
+
+void AVSolver::WriteConsoleSummary(double t, int it) {
+  // Write a summary of the timestep to console.
+  if (myid_ == 0) {
+    std::cout << std::fixed;
+    std::cout << "step " << std::setw(6) << it << ",\tt = " << std::setw(6)
+              << std::setprecision(3) << t << std::endl;
+  }
+}
+
+void AVSolver::WriteOutputFields(mfem::DataCollection *dc_, int it) {
+  if (dc_) {
+    dc_->SetCycle(it);
+    dc_->SetTime(t);
+    dc_->Save();
+  }
+}
+
+void AVSolver::InitializeGLVis() {
+  if (myid_ == 0) {
+    std::cout << "Opening GLVis sockets." << std::endl;
+  }
+
+  for (auto var = _variables.begin(); var != _variables.end(); ++var) {
+    socks_[var->first] = new mfem::socketstream;
+    socks_[var->first]->precision(8);
+  }
+
+  if (myid_ == 0) {
+    std::cout << "GLVis sockets open." << std::endl;
+  }
+}
+
+void AVSolver::DisplayToGLVis() {
+  char vishost[] = "localhost";
+  int visport = 19916;
+
+  int Wx = 0, Wy = 0;                 // window position
+  int Ww = 350, Wh = 350;             // window size
+  int offx = Ww + 10, offy = Wh + 45; // window offsets
+
+  for (auto var = _variables.begin(); var != _variables.end(); ++var) {
+    mfem::common::VisualizeField(*socks_[var->first], vishost, visport,
+                                 *(var->second), (var->first).c_str(), Wx, Wy,
+                                 Ww, Wh);
+    Wx += offx;
+  }
+}
+
+} // namespace hephaestus

--- a/src/hephaestus_lib/av_solver.cpp
+++ b/src/hephaestus_lib/av_solver.cpp
@@ -51,10 +51,10 @@ AVSolver::AVSolver(mfem::ParMesh &pmesh, int order,
           new mfem::common::H1_ParFESpace(&pmesh, order, pmesh.Dimension())),
       HCurlFESpace_(
           new mfem::common::ND_ParFESpace(&pmesh, order, pmesh.Dimension())),
-      a0(NULL), amg_a0(NULL), pcg_a0(NULL), ams_a0(NULL), pcg_a1(NULL),
-      m1(NULL), grad(NULL), curl(NULL), curlCurl(NULL), sourceVecCoef(NULL),
-      src_gf(NULL), div_free_src_gf(NULL), hCurlMass(NULL), divFreeProj(NULL),
-      p_(mfem::ParGridFunction(H1FESpace_)),
+      a0(NULL), a1(NULL), amg_a0(NULL), pcg_a0(NULL), ams_a0(NULL),
+      pcg_a1(NULL), m1(NULL), grad(NULL), curl(NULL), curlCurl(NULL),
+      sourceVecCoef(NULL), src_gf(NULL), div_free_src_gf(NULL), hCurlMass(NULL),
+      divFreeProj(NULL), p_(mfem::ParGridFunction(H1FESpace_)),
       u_(mfem::ParGridFunction(HCurlFESpace_)),
       dp_(mfem::ParGridFunction(H1FESpace_)),
       du_(mfem::ParGridFunction(HCurlFESpace_)) {
@@ -186,6 +186,7 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
   // - (s0_{n+1}, u') - <(α∇×u_{n+1}) × n, u'> = 0
   mfem::BlockVector x(true_offsets), rhs(true_offsets);
   mfem::BlockVector trueX(block_trueOffsets), trueRhs(block_trueOffsets);
+  trueX = 0.0;
   // b0->Update(HCurlFESpace_, rhs.GetBlock(0), 0);
   // a1(du/dt_{n+1}, u') = b1(u')
   // a1(u, u') = (βu, u') + (αdt∇×u, ∇×u')
@@ -214,7 +215,7 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
     hCurlMass->AddMult(*div_free_src_gf, *b0);
   }
 
-  b0->SyncAliasMemory(rhs);
+  // b0->SyncAliasMemory(rhs);
   // trueRhs.GetBlock(0).SyncAliasMemory(trueRhs);
 
   // a1(du/dt_{n+1}, u') = (βdu/dt_{n+1}, u') + (αdt∇×du/dt_{n+1}, ∇×u')

--- a/src/hephaestus_lib/av_solver.cpp
+++ b/src/hephaestus_lib/av_solver.cpp
@@ -52,14 +52,18 @@ AVSolver::AVSolver(mfem::ParMesh &pmesh, int order,
           new mfem::common::H1_ParFESpace(&pmesh, order, pmesh.Dimension())),
       HCurlFESpace_(
           new mfem::common::ND_ParFESpace(&pmesh, order, pmesh.Dimension())),
+      HDivFESpace_(
+          new mfem::common::RT_ParFESpace(&pmesh, order, pmesh.Dimension())),
       a0(NULL), a1(NULL), a01(NULL), a10(NULL), amg_a0(NULL), pcg_a0(NULL),
-      ams_a0(NULL), pcg_a1(NULL), m1(NULL), grad(NULL), curl(NULL),
-      curlCurl(NULL), sourceVecCoef(NULL), src_gf(NULL), div_free_src_gf(NULL),
-      hCurlMass(NULL), divFreeProj(NULL), p_(mfem::ParGridFunction(H1FESpace_)),
+      ams_a0(NULL), pcg_a1(NULL), m1(NULL), negBetaCoef(NULL), grad(NULL),
+      curl(NULL), curlCurl(NULL), sourceVecCoef(NULL), src_gf(NULL),
+      div_free_src_gf(NULL), hCurlMass(NULL), divFreeProj(NULL),
+      p_(mfem::ParGridFunction(H1FESpace_)),
       u_(mfem::ParGridFunction(HCurlFESpace_)),
       dp_(mfem::ParGridFunction(H1FESpace_)),
       du_(mfem::ParGridFunction(HCurlFESpace_)),
-      e_(mfem::ParGridFunction(HCurlFESpace_)) {
+      e_(mfem::ParGridFunction(HCurlFESpace_)),
+      b_(mfem::ParGridFunction(HDivFESpace_)) {
   // Initialize MPI variables
   MPI_Comm_size(pmesh.GetComm(), &num_procs_);
   MPI_Comm_rank(pmesh.GetComm(), &myid_);
@@ -85,14 +89,13 @@ void AVSolver::Init(mfem::Vector &X) {
   _variables.Register(u_name, &u_, false);
   _variables.Register(p_name, &p_, false);
   _variables.Register(e_name, &e_, false);
+  _variables.Register(b_name, &b_, false);
 
   // Define material property coefficients
   dtCoef = mfem::ConstantCoefficient(1.0);
   oneCoef = mfem::ConstantCoefficient(1.0);
-  negCoef = mfem::ConstantCoefficient(-1.0);
   SetMaterialCoefficients(_domain_properties);
   dtAlphaCoef = new mfem::TransformedCoefficient(&dtCoef, alphaCoef, prodFunc);
-  negBetaCoef = new mfem::TransformedCoefficient(&negCoef, betaCoef, prodFunc);
   SetSourceCoefficient(_domain_properties);
   if (sourceVecCoef) {
     buildSource();
@@ -102,6 +105,9 @@ void AVSolver::Init(mfem::Vector &X) {
   this->buildGrad();          // (s0_{n+1}, u')
   b0 = new mfem::ParLinearForm(HCurlFESpace_);
   b1 = new mfem::ParLinearForm(H1FESpace_);
+  b01 = new mfem::ParLinearForm(HCurlFESpace_);
+  b10 = new mfem::ParLinearForm(H1FESpace_);
+
   A0 = new mfem::HypreParMatrix;
   A1 = new mfem::HypreParMatrix;
   A01 = new mfem::HypreParMatrix;
@@ -154,57 +160,26 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
 
   _domain_properties.SetTime(this->GetTime());
 
-  // // -(s0_{n+1}, ∇ p') + <n.s0_{n+1}, p'> = 0
-  // // a0(p_{n+1}, p') = b0(p')
-  // // a0(p, p') = (β ∇ p, ∇ p')
-  // // b0(p') = <n.s0, p'>
-  // mfem::ParGridFunction Phi_gf(H1FESpace_);
-  // mfem::Array<int> poisson_ess_tdof_list;
-  // Phi_gf = 0.0;
-  // *b0 = 0.0;
-  // _bc_map.applyEssentialBCs(p_name, poisson_ess_tdof_list, Phi_gf, pmesh_);
-  // _bc_map.applyIntegratedBCs(p_name, *b0, pmesh_);
-  // b0->Assemble();
-  // a0->FormLinearSystem(poisson_ess_tdof_list, Phi_gf, *b0, *A0, *X0, *B0);
-
-  // if (amg_a0 == NULL) {
-  //   amg_a0 = new mfem::HypreBoomerAMG(*A0);
-  // }
-  // if (pcg_a0 == NULL) {
-  //   pcg_a0 = new mfem::HyprePCG(*A0);
-  //   pcg_a0->SetTol(1.0e-9);
-  //   pcg_a0->SetMaxIter(1000);
-  //   pcg_a0->SetPrintLevel(0);
-  //   pcg_a0->SetPreconditioner(*amg_a0);
-  // }
-  // // pcg "Mult" operation is a solve
-  // // X0 = A0^-1 * B0
-  // pcg_a0->Mult(*B0, *X0);
-
-  // // "undo" the static condensation saving result in grid function dP
-  // a0->RecoverFEMSolution(*X0, *b0, p_);
-  dp_ = 0.0;
   //////////////////////////////////////////////////////////////////////////////
-  // (α∇×u_{n}, ∇×u') + (αdt∇×du/dt_{n+1}, ∇×u') + (βdu/dt_{n+1}, u')
-  // - (s0_{n+1}, u') - <(α∇×u_{n+1}) × n, u'> = 0
   mfem::BlockVector x(true_offsets), rhs(true_offsets);
   mfem::BlockVector trueX(block_trueOffsets), trueRhs(block_trueOffsets);
   trueX = 0.0;
   *b0 = 0.0;
-  // b0->Update(HCurlFESpace_, rhs.GetBlock(0), 0);
+
+  // // -(s0_{n+1}, ∇ p') + <n.s0_{n+1}, p'> = 0
+  // // a0(p_{n+1}, p') = b0(p')
+  // // a0(p, p') = (β ∇ p, ∇ p')
+  // // b0(p') = <n.s0, p'>
+
+  // (α∇×u_{n}, ∇×u') + (αdt∇×du/dt_{n+1}, ∇×u') + (βdu/dt_{n+1}, u')
+  // - (s0_{n+1}, u') - <(α∇×u_{n+1}) × n, u'> = 0
   // a1(du/dt_{n+1}, u') = b1(u')
   // a1(u, u') = (βu, u') + (αdt∇×u, ∇×u')
   // b1(u') = (s0_{n+1}, u') - (α∇×u_{n}, ∇×u') + <(α∇×u_{n+1}) × n, u'>
 
   // (α∇×u_{n}, ∇×u')
-  // v_ is a grid function but curlCurl is not parallel assembled so is OK
   curlCurl->MultTranspose(u_, *b0);
   *b0 *= -1.0;
-
-  // use du_ as a temporary
-  // (s0_{n+1}, u')
-  // grad->Mult(p_, du_);
-  // m1->AddMult(du_, *b1, 1.0);
 
   mfem::ParGridFunction J_gf(HCurlFESpace_);
   mfem::Array<int> ess_tdof_list;
@@ -221,24 +196,6 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
     hCurlMass->AddMult(*div_free_src_gf, *b0);
   }
 
-  // b0->SyncAliasMemory(rhs);
-  // trueRhs.GetBlock(0).SyncAliasMemory(trueRhs);
-
-  // a1(du/dt_{n+1}, u') = (βdu/dt_{n+1}, u') + (αdt∇×du/dt_{n+1}, ∇×u')
-  // if (a0 == NULL || fabs(dt - dt_A0) > 1.0e-12 * dt) {
-  this->buildA0(betaCoef, dtAlphaCoef);
-  // }
-  // a0->EliminateEssentialBC(mfem::Array<int>({1, 1, 1}), J_gf, *b0);
-
-  // a0->EliminateEssentialBC(mfem::Array<int>({1, 1, 1}), J_gf, *b0);
-  // a0->Finalize();
-  // A0 = a0->ParallelAssemble();
-
-  // a0->FormSystemMatrix(ess_tdof_list, *A0);
-  // A0->EliminateRowsCols(ess_tdof_list);
-
-  // a0->FormLinearSystem(ess_tdof_list, J_gf, *b0, *A0, *X0, *B0);
-
   mfem::ParGridFunction Phi_gf(H1FESpace_);
   mfem::Array<int> poisson_ess_tdof_list;
   Phi_gf = 0.0;
@@ -247,40 +204,13 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
   _bc_map.applyIntegratedBCs(p_name, *b1, pmesh_);
   b1->Assemble();
 
-  // a1->EliminateEssentialBC(mfem::Array<int>({1, 1, 1}), Phi_gf, *b1);
-  // a1->Finalize();
-  // A1 = a1->ParallelAssemble();
+  if (a0 == NULL || a10 == NULL || fabs(dt - dt_A0) > 1.0e-12 * dt) {
+    this->buildA0(betaCoef, dtAlphaCoef);
+  }
 
-  delete a10;
-  delete a01;
-  delete a1;
-
-  // a1(V, V') = (σ ∇ V, ∇ V')
-  a1 = new mfem::ParBilinearForm(H1FESpace_);
-  a1->AddDomainIntegrator(new mfem::DiffusionIntegrator(*negBetaCoef));
-  a1->Assemble();
-
-  // (σdA/dt , ∇ V')
-  a01 = new mfem::ParMixedBilinearForm(HCurlFESpace_, H1FESpace_);
-  a01->AddDomainIntegrator(
-      new mfem::VectorFEWeakDivergenceIntegrator(*negBetaCoef));
-  a01->Assemble();
-
-  // (σ ∇ V, dA'/dt)
-  a10 = new mfem::ParMixedBilinearForm(H1FESpace_, HCurlFESpace_);
-  a10->AddDomainIntegrator(new mfem::MixedVectorGradientIntegrator(*betaCoef));
-  a10->Assemble();
-
-  // a01->EliminateTrialDofs(mfem::Array<int>({1, 1, 1}), J_gf, *b1);
-  // a01->Finalize();
-  // A01 = a01->ParallelAssemble();
-
-  // a10->EliminateTrialDofs(mfem::Array<int>({1, 1, 1}), Phi_gf, *b0);
-  // a10->Finalize();
-  // A10 = a10->ParallelAssemble();
-
-  mfem::ParLinearForm *b01 = new mfem::ParLinearForm(HCurlFESpace_);
-  mfem::ParLinearForm *b10 = new mfem::ParLinearForm(H1FESpace_);
+  if (a1 == NULL || a01 == NULL || fabs(dt - dt_A1) > 1.0e-12 * dt) {
+    this->buildA1(betaCoef);
+  }
 
   *b01 = 0.0;
   *b10 = 0.0;
@@ -294,28 +224,16 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
 
   a01->FormRectangularLinearSystem(ess_tdof_list, poisson_ess_tdof_list, J_gf,
                                    *b10, *A01, *X0, *B1);
-
   a10->FormRectangularLinearSystem(poisson_ess_tdof_list, ess_tdof_list, Phi_gf,
                                    *b01, *A10, *X1, *B0);
   trueRhs.GetBlock(1) += *B1;
-
   trueRhs.GetBlock(0) += *B0;
 
-  // b0->ParallelAssemble(trueRhs.GetBlock(0));
   trueX.GetBlock(0).SyncAliasMemory(trueX);
   trueX.GetBlock(1).SyncAliasMemory(trueX);
 
   trueRhs.GetBlock(0).SyncAliasMemory(trueRhs);
   trueRhs.GetBlock(1).SyncAliasMemory(trueRhs);
-
-  // A0->EliminateRowsCols(ess_tdof_list, trueX.GetBlock(0),
-  // trueRhs.GetBlock(0)); A1->EliminateRowsCols(poisson_ess_tdof_list,
-  // trueX.GetBlock(1),
-  //                       trueRhs.GetBlock(1));
-  // A01->EliminateCols(ess_tdof_list);
-  // A01->EliminateRows(poisson_ess_tdof_list);
-  // A10->EliminateRows(ess_tdof_list);
-  // A10->EliminateCols(poisson_ess_tdof_list);
 
   mfem::Array2D<mfem::HypreParMatrix *> hBlocks(2, 2);
   hBlocks = NULL;
@@ -323,29 +241,37 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
   hBlocks(0, 1) = A10;
   hBlocks(1, 0) = A01;
   hBlocks(1, 1) = A1;
-
   blockA = mfem::HypreParMatrixFromBlocks(hBlocks);
 
-  // We only need to create the solver and preconditioner once
-  // if (ams_a0 == NULL) {
-  //   ams_a0 = new mfem::HypreAMS(*blockA, HCurlFESpace_);
-  //   ams_a0->SetSingularProblem();
-  // }
   mfem::MUMPSSolver mumps;
   mumps.SetPrintLevel(0);
   mumps.SetMatrixSymType(mfem::MUMPSSolver::MatType::UNSYMMETRIC);
   mumps.SetOperator(*blockA);
   mumps.Mult(trueRhs, trueX);
 
-  // if (pcg_a0 == NULL) {
-  //   pcg_a0 = new mfem::HyprePCG(*blockA);
-  //   pcg_a0->SetTol(1.0e-16);
-  //   pcg_a0->SetMaxIter(1000);
-  //   pcg_a0->SetPrintLevel(0);
-  //   // pcg_a0->SetPreconditioner(*ams_a0);
+  // We only need to create the solver and preconditioner once
+  // mfem::BlockOperator B(true_offsets, true_offsets);
+  // B.SetBlock(0, 0, A0);
+  // B.SetBlock(0, 1, A10);
+  // B.SetBlock(1, 0, A01);
+  // B.SetBlock(1, 1, A1);
+  // if (ams_a0 == NULL) {
+  //   ams_a0 = new mfem::HypreAMS(*A0, HCurlFESpace_);
+  //   ams_a0->SetSingularProblem();
   // }
-  // // solve the system
-  // pcg_a0->Mult(trueRhs, trueX);
+  // if (amg_a0 == NULL) {
+  //   amg_a0 = new mfem::HypreBoomerAMG(*A1);
+  // }
+  // mfem::BlockDiagonalPreconditioner P(block_trueOffsets);
+  // P.SetDiagonalBlock(0, ams_a0);
+
+  // mfem::CGSolver pcg(MPI_COMM_WORLD);
+  // pcg.SetOperator(B);
+  // pcg.SetPreconditioner(P);
+  // pcg.SetRelTol(1e-4);
+  // pcg.SetMaxIter(1000);
+  // pcg.SetPrintLevel(1);
+  // pcg.Mult(trueRhs, trueX);
 
   trueX.GetBlock(0).SyncAliasMemory(trueX);
   trueX.GetBlock(1).SyncAliasMemory(trueX);
@@ -356,51 +282,88 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
   grad->Mult(p_, e_);
   e_ += du_;
   e_ *= -1.0;
-  // du_ = trueX;
-  // a0->RecoverFEMSolution((trueX.GetBlock(0)), *b0, du_);
+
+  curl->Mult(u_, b_);
+  curl->AddMult(du_, b_, dt);
+  std::cout << "finished";
 }
 
-void AVSolver::buildA0(mfem::Coefficient *Sigma, mfem::Coefficient *DtMuInv) {
+void AVSolver::buildA0(mfem::Coefficient *betaCoef,
+                       mfem::Coefficient *dtAlphaCoef) {
   if (a0 != NULL) {
     delete a0;
   }
+  if (a10 != NULL) {
+    delete a10;
+  }
 
-  // First create and assemble the bilinear form.  For now we assume the mesh
-  // isn't moving, the materials are time independent, and dt is constant. So
-  // we only need to do this once.
-
+  // a0(dA/dt, dA'/dt) = (βdA/dt_{n+1}, dA'/dt) + (αdt∇×dA/dt_{n+1}, ∇×dA'/dt)
   a0 = new mfem::ParBilinearForm(HCurlFESpace_);
-  a0->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*Sigma));
-  a0->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*DtMuInv));
+  a0->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*betaCoef));
+  a0->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*dtAlphaCoef));
   a0->Assemble();
 
-  // Don't finalize or parallel assemble this is done in FormLinearSystem.
+  // a10(V, dA'/dt) = (σ ∇ V, dA'/dt)
+  a10 = new mfem::ParMixedBilinearForm(H1FESpace_, HCurlFESpace_);
+  a10->AddDomainIntegrator(new mfem::MixedVectorGradientIntegrator(*betaCoef));
+  a10->Assemble();
 
   dt_A0 = dtCoef.constant;
 }
 
+void AVSolver::buildA1(mfem::Coefficient *betaCoef) {
+  if (a1 != NULL) {
+    delete a1;
+  }
+  if (a01 != NULL) {
+    delete a01;
+  }
+  if (negBetaCoef != NULL) {
+    delete negBetaCoef;
+  }
+
+  negCoef = mfem::ConstantCoefficient(-1.0);
+  negBetaCoef = new mfem::TransformedCoefficient(&negCoef, betaCoef, prodFunc);
+
+  // a1(V, V') = (σ ∇ V, ∇ V')
+  a1 = new mfem::ParBilinearForm(H1FESpace_);
+  a1->AddDomainIntegrator(new mfem::DiffusionIntegrator(*negBetaCoef));
+  a1->Assemble();
+
+  // (σdA/dt, ∇ V')
+  a01 = new mfem::ParMixedBilinearForm(HCurlFESpace_, H1FESpace_);
+  a01->AddDomainIntegrator(
+      new mfem::VectorFEWeakDivergenceIntegrator(*negBetaCoef));
+  a01->Assemble();
+
+  dt_A1 = dtCoef.constant;
+}
+
 void AVSolver::buildGrad() {
+  // Discrete Grad operator
   if (grad != NULL) {
     delete grad;
   }
-
   grad = new mfem::ParDiscreteLinearOperator(H1FESpace_, HCurlFESpace_);
   grad->AddDomainInterpolator(new mfem::GradientInterpolator());
   grad->Assemble();
-
-  // no ParallelAssemble since this will be applied to GridFunctions
 }
 
 void AVSolver::buildCurl(mfem::Coefficient *MuInv) {
   if (curlCurl != NULL) {
     delete curlCurl;
   }
-
   curlCurl = new mfem::ParBilinearForm(HCurlFESpace_);
   curlCurl->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*MuInv));
   curlCurl->Assemble();
 
-  // no ParallelAssemble since this will be applied to GridFunctions
+  // Discrete Curl operator
+  if (curl != NULL) {
+    delete curl;
+  }
+  curl = new mfem::ParDiscreteLinearOperator(HCurlFESpace_, HDivFESpace_);
+  curl->AddDomainInterpolator(new mfem::CurlInterpolator());
+  curl->Assemble();
 }
 
 void AVSolver::SetVariableNames() {
@@ -412,23 +375,25 @@ void AVSolver::SetVariableNames() {
 
   e_name = "electric_field";
   e_display_name = "Electric Field";
+
+  b_name = "magnetic_flux_density";
+  b_display_name = "Magnetic Flux Density";
 }
 
 void AVSolver::SetMaterialCoefficients(
     hephaestus::DomainProperties &domain_properties) {
-  // if (domain_properties.scalar_property_map.count("magnetic_permeability") ==
-  //     0) {
-  //   domain_properties.scalar_property_map["magnetic_permeability"] =
-  //       new mfem::PWCoefficient(domain_properties.getGlobalScalarProperty(
-  //           std::string("magnetic_permeability")));
-  // }
-  // if (domain_properties.scalar_property_map.count("electrical_conductivity")
-  // ==
-  //     0) {
-  //   domain_properties.scalar_property_map["electrical_conductivity"] =
-  //       new mfem::PWCoefficient(domain_properties.getGlobalScalarProperty(
-  //           std::string("electrical_conductivity")));
-  // }
+  if (domain_properties.scalar_property_map.count("magnetic_permeability") ==
+      0) {
+    domain_properties.scalar_property_map["magnetic_permeability"] =
+        new mfem::PWCoefficient(domain_properties.getGlobalScalarProperty(
+            std::string("magnetic_permeability")));
+  }
+  if (domain_properties.scalar_property_map.count("electrical_conductivity") ==
+      0) {
+    domain_properties.scalar_property_map["electrical_conductivity"] =
+        new mfem::PWCoefficient(domain_properties.getGlobalScalarProperty(
+            std::string("electrical_conductivity")));
+  }
   alphaCoef = new mfem::TransformedCoefficient(
       &oneCoef, domain_properties.scalar_property_map["magnetic_permeability"],
       fracFunc);

--- a/src/hephaestus_lib/av_solver.cpp
+++ b/src/hephaestus_lib/av_solver.cpp
@@ -1,45 +1,41 @@
-// Strong form
-// ∇⋅v0 = 0
-// ∇×(α∇×u) - βdu/dt = v0
+// Solves the equations
+// ∇⋅s0 = 0
+// ∇×(α∇×u) + βdu/dt = s0
 
-// Weak form
-// -(v0, ∇ p') + <n.v0, p'> = 0
-// (α∇×u, ∇×u') - (βdu/dt, u') - (v0, u') - <(α∇×u) × n, u'> = 0
-
-// v, v0 ∈ H(div) source field
+// where
+// s0 ∈ H(div) source field
 // u ∈ H(curl)
 // p ∈ H1
 
-///////
-// (σ(dA/dt + ∇ V), A') +(ν∇×A, ∇×A') - <(ν∇×A) × n, A'> - (J0, A') = 0
-// (σ(dA/dt + ∇ V), ∇ V') + <n.J, V'> = 0
-///////
+// Dirichlet boundaries constrain du/dt
+// Integrated boundaries constrain (α∇×u) × n
 
-// (σ(dA/dt + ∇ V), A') +(ν∇×A, ∇×A') - <(ν∇×A) × n, A'> - (J0, A') = 0
+// Weak form (Space discretisation)
+// -(s0, ∇ p') + <n.s0, p'> = 0
+// (α∇×u, ∇×u') + (βdu/dt, u') - (s0, u') - <(α∇×u) × n, u'> = 0
 
-// // (σ dA/dt, A')
-// mfem::ParBilinearForm(HCurlFESpace_);
-// mfem::VectorFEMassIntegrator(sigmaCoef);
+// Time discretisation using implicit scheme:
+// Unknowns
+// s0_{n+1} ∈ H(div) source field, where s0 = -β∇p
+// du/dt_{n+1} ∈ H(curl)
+// p_{n+1} ∈ H1
 
-// // (σ ∇ V, A')
-// mfem::ParMixedBilinearForm(H1FESpace_, HCurlFESpace_);
-// mfem::MixedVectorGradientIntegrator(sigmaCoef);
+// Fully discretised equations
+// -(s0_{n+1}, ∇ p') + <n.s0_{n+1}, p'> = 0
+// (α∇×u_{n}, ∇×u') + (αdt∇×du/dt_{n+1}, ∇×u') + (βdu/dt_{n+1}, u')
+// - (s0_{n+1}, u') - <(α∇×u_{n+1}) × n, u'> = 0
+// using
+// u_{n+1} = u_{n} + dt du/dt_{n+1}
 
-// // (ν∇×A, ∇×A')
-// mfem::ParBilinearForm(HCurlFESpace_);
-// mfem::CurlCurlIntegrator(dtMuInvCoef);
-// mfem::ParLinearForm(HCurlFESpace_);
-// mfem::CurlCurlIntegrator(muInvCoef);
+// Rewritten as
+// a0(p_{n+1}, p') = b0(p')
+// a1(du/dt_{n+1}, u') = b1(u')
 
-// (σ(dA/dt + ∇ V), ∇ V') + <n.J, V'> = 0
-
-// (σdA/dt , ∇ V')
-// mfem::ParMixedBilinearForm(HCurlFESpace_, H1FESpace_)
-// mfem::MixedVectorWeakDivergenceIntegrator(sigmaCoef)
-
-// (σ ∇ V, ∇ V')
-// mfem::ParBilinearForm(H1FESpace_)
-// mfem::DiffusionIntegrator(sigmaCoef)
+// where
+// a0(p, p') = (β ∇ p, ∇ p')
+// b0(p') = <n.s0, p'>
+// a1(u, u') = (βu, u') + (αdt∇×u, ∇×u')
+// b1(u') = (s0_{n+1}, u') - (α∇×u_{n}, ∇×u') + <(α∇×u_{n+1}) × n, u'>
 
 #include "av_solver.hpp"
 
@@ -55,18 +51,13 @@ AVSolver::AVSolver(mfem::ParMesh &pmesh, int order,
           new mfem::common::H1_ParFESpace(&pmesh, order, pmesh.Dimension())),
       HCurlFESpace_(
           new mfem::common::ND_ParFESpace(&pmesh, order, pmesh.Dimension())),
-      HDivFESpace_(
-          new mfem::common::RT_ParFESpace(&pmesh, order, pmesh.Dimension())),
-      blockAV(NULL), blockAVPr(NULL), a1(NULL), amg_a0(NULL), pcg_a0(NULL),
-      ams_a1(NULL), pcg_a1(NULL), m1(NULL), grad(NULL), curl(NULL),
-      weakCurl(NULL), curlCurl(NULL), sourceVecCoef(NULL), src_gf(NULL),
-      div_free_src_gf(NULL), hCurlMass(NULL), divFreeProj(NULL),
-      v_(mfem::ParGridFunction(H1FESpace_)),
-      a_(mfem::ParGridFunction(HCurlFESpace_)),
-      e_(mfem::ParGridFunction(HCurlFESpace_)),
-      b_(mfem::ParGridFunction(HDivFESpace_)),
-      dv_(mfem::ParGridFunction(H1FESpace_)),
-      da_(mfem::ParGridFunction(HCurlFESpace_)) {
+      a1(NULL), amg_a0(NULL), pcg_a0(NULL), ams_a1(NULL), pcg_a1(NULL),
+      m1(NULL), grad(NULL), curl(NULL), curlCurl(NULL), sourceVecCoef(NULL),
+      src_gf(NULL), div_free_src_gf(NULL), hCurlMass(NULL), divFreeProj(NULL),
+      p_(mfem::ParGridFunction(H1FESpace_)),
+      u_(mfem::ParGridFunction(HCurlFESpace_)),
+      dp_(mfem::ParGridFunction(H1FESpace_)),
+      du_(mfem::ParGridFunction(HCurlFESpace_)) {
   // Initialize MPI variables
   MPI_Comm_size(pmesh.GetComm(), &num_procs_);
   MPI_Comm_rank(pmesh.GetComm(), &myid_);
@@ -77,81 +68,38 @@ AVSolver::AVSolver(mfem::ParMesh &pmesh, int order,
   true_offsets[2] = HCurlFESpace_->GetVSize();
   true_offsets.PartialSum();
 
-  block_trueOffsets.SetSize(3);
-  block_trueOffsets[0] = 0;
-  block_trueOffsets[1] = H1FESpace_->TrueVSize();
-  block_trueOffsets[2] = HCurlFESpace_->TrueVSize();
-  block_trueOffsets.PartialSum();
-
   this->height = true_offsets[2];
   this->width = true_offsets[2];
 }
 
 void AVSolver::Init(mfem::Vector &X) {
   SetVariableNames();
-  _variables.Register(u_name, &a_, false);
-  _variables.Register(p_name, &v_, false);
-  _variables.Register(v_name, &b_, false);
-  _variables.Register(e_name, &e_, false);
+  _variables.Register(u_name, &u_, false);
+  _variables.Register(p_name, &p_, false);
 
   // Define material property coefficients
   dtCoef = mfem::ConstantCoefficient(1.0);
   oneCoef = mfem::ConstantCoefficient(1.0);
-  negCoef = mfem::ConstantCoefficient(-1.0);
-
   SetMaterialCoefficients(_domain_properties);
   dtAlphaCoef = new mfem::TransformedCoefficient(&dtCoef, alphaCoef, prodFunc);
-  negBetaCoef = new mfem::TransformedCoefficient(&oneCoef, betaCoef, prodFunc);
 
-  x = new mfem::BlockVector(true_offsets);
-  rhs = new mfem::BlockVector(true_offsets);
-  trueX = new mfem::BlockVector(block_trueOffsets);
-  trueRhs = new mfem::BlockVector(block_trueOffsets);
+  SetSourceCoefficient(_domain_properties);
+  if (sourceVecCoef) {
+    buildSource();
+  }
 
-  // Variables
-  // v_, "electric_potential"
-  // a_, "magnetic_vector_potential"
-
-  // Coefficients
-  // σ, "electrical_conductivity"
-  // mu, "magnetic_permeability"
-
-  ///////
-  // (σ(dA/dt + ∇ V), ∇ V') + <n.J, V'> = 0
-  // (σ(dA/dt + ∇ V), A') + (ν∇×A, ∇×A') - <(ν∇×A) × n, A'> - (J0, A') = 0
-  ///////
-  // Bilinear for divergence free source field solve
-  // -(J0, ∇ V') + <n.J, V'> = 0  where J0 = -σ∇V
+  // a0(p, p') = (β ∇ p, ∇ p')
   a0 = new mfem::ParBilinearForm(H1FESpace_);
   a0->AddDomainIntegrator(new mfem::DiffusionIntegrator(*betaCoef));
   a0->Assemble();
 
-  // (σdA/dt , ∇ V')
-  // mfem::ParMixedBilinearForm(HCurlFESpace_, H1FESpace_)
-  // mfem::MixedVectorWeakDivergenceIntegrator(sigmaCoef)
-  // TODO: SHOULD BE -BETACOEF
-  a01 = new mfem::ParMixedBilinearForm(HCurlFESpace_, H1FESpace_);
-  a01->AddDomainIntegrator(
-      new mfem::MixedVectorWeakDivergenceIntegrator(*negBetaCoef));
-  a01->Assemble();
-  // // (σ ∇ V, A')
-  // mfem::ParMixedBilinearForm(H1FESpace_, HCurlFESpace_);
-  // mfem::MixedVectorGradientIntegrator(sigmaCoef);
-  a10 = new mfem::ParMixedBilinearForm(H1FESpace_, HCurlFESpace_);
-  a10->AddDomainIntegrator(new mfem::MixedVectorGradientIntegrator(*betaCoef));
-  a10->Assemble();
-
-  this->buildM1(betaCoef);    // (σ dA/dt, A')
-  this->buildCurl(alphaCoef); // (ν∇×A, ∇×A')
-  this->buildGrad();
+  this->buildM1(betaCoef);    // (βu, u')
+  this->buildCurl(alphaCoef); // (α∇×u_{n}, ∇×u')
+  this->buildGrad();          // (s0_{n+1}, u')
   b0 = new mfem::ParLinearForm(H1FESpace_);
   b1 = new mfem::ParLinearForm(HCurlFESpace_);
   A0 = new mfem::HypreParMatrix;
   A1 = new mfem::HypreParMatrix;
-  A01 = new mfem::HypreParMatrix;
-  A10 = new mfem::HypreParMatrix;
-  blockA = new mfem::HypreParMatrix;
-
   X0 = new mfem::Vector;
   X1 = new mfem::Vector;
   B0 = new mfem::Vector;
@@ -162,329 +110,132 @@ void AVSolver::Init(mfem::Vector &X) {
   mfem::VectorConstantCoefficient Zero_vec(zero_vec);
   mfem::ConstantCoefficient Zero(0.0);
 
-  v_.MakeRef(H1FESpace_, const_cast<mfem::Vector &>(X), true_offsets[0]);
-  a_.MakeRef(HCurlFESpace_, const_cast<mfem::Vector &>(X), true_offsets[1]);
+  p_.MakeRef(H1FESpace_, const_cast<mfem::Vector &>(X), true_offsets[0]);
+  u_.MakeRef(HCurlFESpace_, const_cast<mfem::Vector &>(X), true_offsets[1]);
 
-  v_.ProjectCoefficient(Zero);
-  a_.ProjectCoefficient(Zero_vec);
-
-  // aux
-  e_.ProjectCoefficient(Zero_vec);
-  b_.ProjectCoefficient(Zero_vec);
+  p_.ProjectCoefficient(Zero);
+  u_.ProjectCoefficient(Zero_vec);
 }
 
 /*
 This is the main computational code that computes dX/dt implicitly
-where X is the state vector containing A and V
+where X is the state vector containing p, u and v.
 
-(M1+dt S1) E = WeakCurl^T B + Grad V
-        S0 V = 0
+Unknowns
+s0_{n+1} ∈ H(div) source field, where s0 = -β∇p
+du/dt_{n+1} ∈ H(curl)
+p_{n+1} ∈ H1
+
+Fully discretised equations
+-(s0_{n+1}, ∇ p') + <n.s0_{n+1}, p'> = 0
+(α∇×u_{n}, ∇×u') + (αdt∇×du/dt_{n+1}, ∇×u') + (βdu/dt_{n+1}, u')
+- (s0_{n+1}, u') - <(α∇×u_{n+1}) × n, u'> = 0
+using
+u_{n+1} = u_{n} + dt du/dt_{n+1}
 */
 void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
                              mfem::Vector &dX_dt) {
   dX_dt = 0.0;
   dtCoef.constant = dt;
-  v_.MakeRef(H1FESpace_, const_cast<mfem::Vector &>(X), true_offsets[0]);
-  a_.MakeRef(HCurlFESpace_, const_cast<mfem::Vector &>(X), true_offsets[1]);
-  dv_.MakeRef(H1FESpace_, dX_dt, true_offsets[0]);
-  da_.MakeRef(HCurlFESpace_, dX_dt, true_offsets[1]);
+
+  p_.MakeRef(H1FESpace_, const_cast<mfem::Vector &>(X), true_offsets[0]);
+  u_.MakeRef(HCurlFESpace_, const_cast<mfem::Vector &>(X), true_offsets[1]);
+
+  dp_.MakeRef(H1FESpace_, dX_dt, true_offsets[0]);
+  du_.MakeRef(HCurlFESpace_, dX_dt, true_offsets[1]);
 
   _domain_properties.SetTime(this->GetTime());
 
-  std::cout << "b0 start" << std::endl;
-  mfem::ParGridFunction Phi_gf;
-  Phi_gf.MakeRef(H1FESpace_, trueX->GetBlock(0), 0);
-
+  // -(s0_{n+1}, ∇ p') + <n.s0_{n+1}, p'> = 0
+  // a0(p_{n+1}, p') = b0(p')
+  // a0(p, p') = (β ∇ p, ∇ p')
+  // b0(p') = <n.s0, p'>
+  mfem::ParGridFunction Phi_gf(H1FESpace_);
   mfem::Array<int> poisson_ess_tdof_list;
-  Phi_gf = 1.0;
+  Phi_gf = 0.0;
   *b0 = 0.0;
-  std::cout << "b0 update start" << std::endl;
-  // b0->Update(H1FESpace_, Phi_gf, 0);
-  std::cout << "b0 update end" << std::endl;
-  std::cout << "b0 bc start" << std::endl;
-
-  _bc_map.applyIntegratedBCs(p_name, *b0, pmesh_);
-  std::cout << "b0 ess start" << std::endl;
   _bc_map.applyEssentialBCs(p_name, poisson_ess_tdof_list, Phi_gf, pmesh_);
-  std::cout << "b0 ess start" << std::endl;
-  std::cout << "b0 ess start" << std::endl;
-  std::cout << "b0 assemble" << std::endl;
+  _bc_map.applyIntegratedBCs(p_name, *b0, pmesh_);
   b0->Assemble();
+  a0->FormLinearSystem(poisson_ess_tdof_list, Phi_gf, *b0, *A0, *X0, *B0);
 
-  a0->EliminateEssentialBC(mfem::Array<int>({1, 1, 0}), Phi_gf, *b0);
-  std::cout << "b0 ess startt" << std::endl;
-  a0->Finalize();
-  A0 = a0->ParallelAssemble();
+  if (amg_a0 == NULL) {
+    amg_a0 = new mfem::HypreBoomerAMG(*A0);
+  }
+  if (pcg_a0 == NULL) {
+    pcg_a0 = new mfem::HyprePCG(*A0);
+    pcg_a0->SetTol(1.0e-9);
+    pcg_a0->SetMaxIter(1000);
+    pcg_a0->SetPrintLevel(0);
+    pcg_a0->SetPreconditioner(*amg_a0);
+  }
+  // pcg "Mult" operation is a solve
+  // X0 = A0^-1 * B0
+  pcg_a0->Mult(*B0, *X0);
 
-  // _bc_map.applyEssentialBCs(p_name, poisson_ess_tdof_list, Phi_gf, pmesh_);
-  std::cout << "b0 parallel assemble" << std::endl;
+  // "undo" the static condensation saving result in grid function dP
+  a0->RecoverFEMSolution(*X0, *b0, p_);
+  dp_ = 0.0;
+  //////////////////////////////////////////////////////////////////////////////
+  // (α∇×u_{n}, ∇×u') + (αdt∇×du/dt_{n+1}, ∇×u') + (βdu/dt_{n+1}, u')
+  // - (s0_{n+1}, u') - <(α∇×u_{n+1}) × n, u'> = 0
 
-  // trueRhs->GetBlock(0).SyncAliasMemory(*trueRhs);
+  // a1(du/dt_{n+1}, u') = b1(u')
+  // a1(u, u') = (βu, u') + (αdt∇×u, ∇×u')
+  // b1(u') = (s0_{n+1}, u') - (α∇×u_{n}, ∇×u') + <(α∇×u_{n+1}) × n, u'>
 
-  // a0->EliminateEssentialBC(ess_bdr, Phi_gf, *b0);
-  // a0->Finalize();
+  // (α∇×u_{n}, ∇×u')
+  // v_ is a grid function but curlCurl is not parallel assembled so is OK
+  curlCurl->MultTranspose(u_, *b1);
+  *b1 *= -1.0;
 
-  // b0->ParallelAssemble(Phi_gf.GetTrueVector());
-  std::cout << "b0 end" << std::endl;
+  // use du_ as a temporary
+  // (s0_{n+1}, u')
+  grad->Mult(p_, du_);
+  m1->AddMult(du_, *b1, 1.0);
+  if (src_gf) {
+    src_gf->ProjectCoefficient(*sourceVecCoef);
+    // Compute the discretely divergence-free portion of src_gf
+    divFreeProj->Mult(*src_gf, *div_free_src_gf);
+    // Compute the dual of div_free_src_gf
+    hCurlMass->AddMult(*div_free_src_gf, *b1);
+  }
 
   mfem::ParGridFunction J_gf(HCurlFESpace_);
-  J_gf.MakeRef(HCurlFESpace_, trueX->GetBlock(1), 0);
-
   mfem::Array<int> ess_tdof_list;
   J_gf = 0.0;
-  // b1->Update(HCurlFESpace_, J_gf, 0);
-  *b1 = 0.0;
-  curlCurl->MultTranspose(a_, *b1); // b1 = (ν∇×A, ∇×A')
-  _bc_map.applyIntegratedBCs(u_name, *b1,
-                             pmesh_); // b1 = (ν∇×A, ∇×A') +  <(ν∇×A) × n, A'>
   _bc_map.applyEssentialBCs(u_name, ess_tdof_list, J_gf, pmesh_);
-  b1->Assemble();
+  _bc_map.applyIntegratedBCs(u_name, *b1, pmesh_);
 
-  // b1->ParallelAssemble(J_gf.GetTrueVector());
-  std::cout << "b1 end" << std::endl;
-
-  // mVarf->EliminateEssentialBC(mark_bdr_attr_ess, trueX.GetBlock(0),
-  // trueRhs.GetBlock(0)); bVarf->EliminateTrialDofs(mark_bdr_attr_ess,
-  // trueX.GetBlock(0), trueRhs.GetBlock(1)); a01->Finalize();
-
-  std::cout << "a1 start" << std::endl;
-
-  mfem::Vector zero_vec(3);
-  zero_vec = 0.0;
-
+  // a1(du/dt_{n+1}, u') = (βdu/dt_{n+1}, u') + (αdt∇×du/dt_{n+1}, ∇×u')
   if (a1 == NULL || fabs(dt - dt_A1) > 1.0e-12 * dt) {
     this->buildA1(betaCoef, dtAlphaCoef);
   }
-  std::cout << "Assembled" << std::endl;
-  std::cout << J_gf.Size() << std::endl;
-
-  a1->EliminateEssentialBC(mfem::Array<int>({1, 1, 1}), J_gf, *b1);
-  a1->Finalize();
-  A1 = a1->ParallelAssemble();
-
-  a01->EliminateTrialDofs(mfem::Array<int>({1, 1, 0}), J_gf, *b0);
-  a10->EliminateTrialDofs(mfem::Array<int>({1, 1, 1}), Phi_gf, *b1);
-
-  a01->Finalize();
-  A01 = a01->ParallelAssemble();
-
-  a10->Finalize();
-  A10 = a10->ParallelAssemble();
-
-  b0->ParallelAssemble(trueRhs->GetBlock(0));
-  b1->ParallelAssemble(trueRhs->GetBlock(1));
-
-  // A0->EliminateRowsCols(poisson_ess_tdof_list);
-  // A1->EliminateRowsCols(ess_tdof_list);
-  // A01->EliminateCols(ess_tdof_list);
-  // A01->EliminateRows(poisson_ess_tdof_list);
-  // A10->EliminateCols(poisson_ess_tdof_list);
-  // A10->EliminateRows(ess_tdof_list);
-
-  mfem::Array2D<mfem::HypreParMatrix *> hBlocks(2, 2);
-  hBlocks = NULL;
-  hBlocks(0, 0) = A0;
-  hBlocks(0, 1) = A01;
-  hBlocks(1, 0) = A10;
-  hBlocks(1, 1) = A1;
-
-  blockA = mfem::HypreParMatrixFromBlocks(hBlocks);
-  blockA->Mult(*trueRhs, *trueX);
-
-  // *trueX.Print();
-  true_offsets.Print();
-  block_trueOffsets.Print();
-  std::cout << "trueX = " << trueX->Size() << std::endl;
-  ;
-  std::cout << "true RHS = " << trueRhs->Size() << std::endl;
-  ;
-
-  std::cout << "da = " << da_.Size() << std::endl;
-  std::cout << "v = " << v_.Size() << std::endl;
-
-  // solver.Mult(*trueRhs, *trueX);
-  v_.Distribute(&(trueX->GetBlock(0)));
-  da_.Distribute(&(trueX->GetBlock(1)));
-
-  // A1 = HypreParMatrixFromBlocks(hBlocks);
-
-  // if (ams_a1 == NULL) {
-  //   mfem::ParFiniteElementSpace *prec_fespace =
-  //       (a1->StaticCondensationIsEnabled() ? a1->SCParFESpace()
-  //                                          : HCurlFESpace_);
-  //   ams_a1 = new mfem::HypreAMS(*A1, prec_fespace);
-  // }
-  // if (pcg_a1 == NULL) {
-  //   pcg_a1 = new mfem::HyprePCG(*A1);
-  //   pcg_a1->SetTol(1.0e-9);
-  //   pcg_a1->SetMaxIter(1000);
-  //   pcg_a1->SetPrintLevel(0);
-  //   pcg_a1->SetPreconditioner(*ams_a1);
-  // }
-  // // solve the system
-  // // dE = (A1)^-1 [-S1 E]
-  // pcg_a1->Mult(*B1, *X1);
-
-  // a1->RecoverFEMSolution(*X1, *b1, e_);
-
-  // ///
-
-  // if (blockAV == NULL) {
-  //   blockAV = new mfem::BlockOperator(block_trueOffsets);
-  //   blockAV->SetBlock(0, 0, a0->ParallelAssemble());
-  //   blockAV->SetBlock(0, 1, a01->ParallelAssemble());
-  //   blockAV->SetBlock(1, 0, a10->ParallelAssemble());
-  //   blockAV->SetBlock(1, 1, a1->ParallelAssemble());
-  // }
-
-  // if (amg_a0 == NULL) {
-  //   amg_a0 = new mfem::HypreBoomerAMG(*A0);
-  // }
-  // if (ams_a1 == NULL) {
-  //   mfem::ParFiniteElementSpace *prec_fespace =
-  //       (a1->StaticCondensationIsEnabled() ? a1->SCParFESpace()
-  //                                          : HCurlFESpace_);
-  //   ams_a1 = new mfem::HypreAMS(*A1, prec_fespace);
-  // }
-  // // OperatorHandle ;
-  // if (blockAVPr = NULL) {
-  //   blockAVPr = new mfem::BlockDiagonalPreconditioner(block_trueOffsets);
-  //   blockAVPr->SetDiagonalBlock(0, amg_a0);
-  //   blockAVPr->SetDiagonalBlock(1, ams_a1);
-  // }
-
-  // if (pcg_a0 == NULL) {
-  //   mfem::MINRESSolver solver(MPI_COMM_WORLD);
-  //   solver.SetAbsTol(1.0e-9);
-  //   //  solver.SetRelTol(rtol);
-  //   solver.SetMaxIter(1000);
-  //   solver.SetOperator(*blockAV);
-  //   // solver.SetPreconditioner(*blockAVPr);
-  //   //  solver.SetPrintLevel(verbose);
-  //   solver.Mult(*trueRhs, *trueX);
-  //   da_.Distribute(&(trueX->GetBlock(0)));
-  //   v_.Distribute(&(trueX->GetBlock(1)));
-
-  //   // pcg_a0 = new mfem::HyprePCG(MPI_COMM_WORLD);
-  //   // pcg_a0->SetTol(1.0e-9);
-  //   // pcg_a0->SetMaxIter(1000);
-  //   // pcg_a0->SetPrintLevel(0);
-  //   // pcg_a0->SetPreconditioner(dynamic_cast<mfem::HypreSolver
-  //   *>(blockAVPr));
-  //   // pcg_a0->SetOperator(*blockAV);
-  // }
-
-  // pcg_a0->Mult(*B0, *X0);
-  // solver.Mult(trueRhs, trueX);
-
-  // //  u->MakeTRef(R_space, x.GetBlock(0), 0);
-  // //  p->MakeTRef(W_space, x.GetBlock(1), 0);
-  // da_->Distribute(&(trueX.GetBlock(0)));
-  // v_->Distribute(&(trueX.GetBlock(1)));
-
-  // if (amg_a0 == NULL) {
-  //   amg_a0 = new mfem::HypreBoomerAMG(*A0);
-  // }
-  // if (pcg_a0 == NULL) {
-  //   pcg_a0 = new mfem::HyprePCG(*A0);
-  //   pcg_a0->SetTol(1.0e-9);
-  //   pcg_a0->SetMaxIter(1000);
-  //   pcg_a0->SetPrintLevel(0);
-  //   pcg_a0->SetPreconditioner(*amg_a0);
-  //   blockAVPr->SetDiagonalBlock(0, pcg_a0);
-  // }
+  a1->FormLinearSystem(ess_tdof_list, J_gf, *b1, *A1, *X1, *B1);
 
   // We only need to create the solver and preconditioner once
-  // if (ams_a1 == NULL) {
-  //   mfem::ParFiniteElementSpace *prec_fespace =
-  //       (a1->StaticCondensationIsEnabled() ? a1->SCParFESpace()
-  //                                          : HCurlFESpace_);
-  //   ams_a1 = new mfem::HypreAMS(*A1, prec_fespace);
-  // }
-  // if (pcg_a1 == NULL) {
-  //   pcg_a1 = new mfem::HyprePCG(*A1);
-  //   pcg_a1->SetTol(1.0e-9);
-  //   pcg_a1->SetMaxIter(1000);
-  //   pcg_a1->SetPrintLevel(0);
-  //   pcg_a1->SetPreconditioner(*ams_a1);
-  //   blockAVPr->SetDiagonalBlock(0, pcg_a1);
-  // }
+  if (ams_a1 == NULL) {
+    ams_a1 = new mfem::HypreAMS(*A1, HCurlFESpace_);
+    ams_a1->SetSingularProblem();
+  }
+  if (pcg_a1 == NULL) {
+    pcg_a1 = new mfem::HyprePCG(*A1);
+    pcg_a1->SetTol(1.0e-16);
+    pcg_a1->SetMaxIter(1000);
+    pcg_a1->SetPrintLevel(0);
+    pcg_a1->SetPreconditioner(*ams_a1);
+  }
+  // solve the system
+  pcg_a1->Mult(*B1, *X1);
 
-  // form the Laplacian and solve it
-
-  // a0->FormLinearSystem(poisson_ess_tdof_list, Phi_gf, *b0, *A0, *X0, *B0);
-
-  // if (amg_a0 == NULL) {
-  //   amg_a0 = new mfem::HypreBoomerAMG(*A0);
-  // }
-  // if (pcg_a0 == NULL) {
-  //   pcg_a0 = new mfem::HyprePCG(*A0);
-  //   pcg_a0->SetTol(1.0e-9);
-  //   pcg_a0->SetMaxIter(1000);
-  //   pcg_a0->SetPrintLevel(0);
-  //   pcg_a0->SetPreconditioner(*amg_a0);
-  // }
-  // pcg "Mult" operation is a solve
-  // X0 = A0^-1 * B0
-
-  // "undo" the static condensation saving result in grid function dP
-  // a0->RecoverFEMSolution(*X0, *b0, v_);
-  // dv_ = 0.0;
-  // pcg_a1->Mult(*B1, *X1);
-
-  // a1->RecoverFEMSolution(*X1, *b1, da_);
-
-  //////////////////////////////////////////////////////////////////////////////
-  // (σ(dA/dt + ∇ V), A') + (ν∇×A, ∇×A') - <(ν∇×A) × n, A'> - (J0, A') = 0
-
-  // use a_ as a temporary, E = Grad P
-  // b1 = -dt * Grad V
-
-  // mfem::ParGridFunction J_gf(HCurlFESpace_);
-  // mfem::Array<int> ess_tdof_list;
-  // J_gf = 0.0;
-  // _bc_map.applyEssentialBCs(u_name, ess_tdof_list, J_gf, pmesh_);
-  // if (a1 == NULL || fabs(dt - dt_A1) > 1.0e-12 * dt) {
-  //   this->buildA1(betaCoef, dtAlphaCoef);
-  // }
-  // // a1 = (σ dA/dt, A') + dt (ν∇×dA/dt, ∇×A')
-  // // TODO: add  (σ ∇ V, A')
-  // a1->FormLinearSystem(ess_tdof_list, J_gf, *b1, *A1, *X1, *B1);
-
-  // // We only need to create the solver and preconditioner once
-  // if (ams_a1 == NULL) {
-  //   mfem::ParFiniteElementSpace *prec_fespace =
-  //       (a1->StaticCondensationIsEnabled() ? a1->SCParFESpace()
-  //                                          : HCurlFESpace_);
-  //   ams_a1 = new mfem::HypreAMS(*A1, prec_fespace);
-  // }
-  // if (pcg_a1 == NULL) {
-  //   pcg_a1 = new mfem::HyprePCG(*A1);
-  //   pcg_a1->SetTol(1.0e-9);
-  //   pcg_a1->SetMaxIter(1000);
-  //   pcg_a1->SetPrintLevel(0);
-  //   pcg_a1->SetPreconditioner(*ams_a1);
-  // }
-  // // solve the system
-  // // dE = (A1)^-1 [-S1 E]
-  // pcg_a1->Mult(*B1, *X1);
-
-  // a1->RecoverFEMSolution(*X1, *b1, da_);
-
-  // Auxiliary calculations
-  // Compute B = Curl(A)
-  curl->Mult(a_, b_);
-  // Compute e = -(dA/dt + ∇ V);
-  e_ = da_;
-  grad->AddMult(v_, e_, 1.0);
-  e_ *= -1.0;
+  a1->RecoverFEMSolution(*X1, *b1, du_);
 }
 
 void AVSolver::buildA1(mfem::Coefficient *Sigma, mfem::Coefficient *DtMuInv) {
   if (a1 != NULL) {
     delete a1;
   }
-  // (σ(dA/dt, A') + dt (ν∇×dA/dt, ∇×A')
+
   // First create and assemble the bilinear form.  For now we assume the mesh
   // isn't moving, the materials are time independent, and dt is constant. So
   // we only need to do this once.
@@ -524,20 +275,9 @@ void AVSolver::buildGrad() {
 }
 
 void AVSolver::buildCurl(mfem::Coefficient *MuInv) {
-  if (curl != NULL) {
-    delete curl;
+  if (curlCurl != NULL) {
+    delete curlCurl;
   }
-  if (weakCurl != NULL) {
-    delete weakCurl;
-  }
-
-  curl = new mfem::ParDiscreteLinearOperator(HCurlFESpace_, HDivFESpace_);
-  curl->AddDomainInterpolator(new mfem::CurlInterpolator);
-  curl->Assemble();
-
-  weakCurl = new mfem::ParMixedBilinearForm(HCurlFESpace_, HDivFESpace_);
-  weakCurl->AddDomainIntegrator(new mfem::VectorFECurlIntegrator(*MuInv));
-  weakCurl->Assemble();
 
   curlCurl = new mfem::ParBilinearForm(HCurlFESpace_);
   curlCurl->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*MuInv));
@@ -548,16 +288,10 @@ void AVSolver::buildCurl(mfem::Coefficient *MuInv) {
 
 void AVSolver::SetVariableNames() {
   p_name = "electric_potential";
-  p_display_name = "Electric Scalar Potential (V)";
+  p_display_name = "Electric Scalar Potential";
 
   u_name = "magnetic_vector_potential";
-  u_display_name = "Magnetic Vector Potential (A)";
-
-  v_name = "magnetic_flux_density";
-  v_display_name = "Magnetic Flux Density (B)";
-
-  e_name = "electric_field";
-  e_display_name = "Electric Field (E)";
+  u_display_name = "Magnetic Vector Potential";
 }
 
 void AVSolver::SetMaterialCoefficients(

--- a/src/hephaestus_lib/av_solver.hpp
+++ b/src/hephaestus_lib/av_solver.hpp
@@ -22,8 +22,7 @@ public:
 
   void Init(mfem::Vector &X) override;
 
-  void buildA1(mfem::Coefficient *sigma, mfem::Coefficient *dtMuInv);
-  void buildM1(mfem::Coefficient *sigma);
+  void buildA0(mfem::Coefficient *sigma, mfem::Coefficient *dtMuInv);
   void buildCurl(mfem::Coefficient *muInv);
   void buildGrad();
   void buildSource();
@@ -62,19 +61,20 @@ protected:
   mfem::ParBilinearForm *a0, *a1, *m1;
   mfem::HypreParMatrix *A0, *A1;
   mfem::Vector *X0, *X1, *B0, *B1;
+  mfem::Array<int> block_trueOffsets;
 
   mfem::ParDiscreteLinearOperator *grad;
   mfem::ParDiscreteLinearOperator *curl;
   mfem::ParBilinearForm *curlCurl;
   mutable mfem::HypreSolver *amg_a0;
   mutable mfem::HyprePCG *pcg_a0;
-  mutable mfem::HypreAMS *ams_a1;
+  mutable mfem::HypreAMS *ams_a0;
   mutable mfem::HyprePCG *pcg_a1;
 
   // temporary work vectors
   mfem::ParLinearForm *b0, *b1;
 
-  double dt_A1;
+  double dt_A0;
   mfem::ConstantCoefficient dtCoef;  // Coefficient for timestep scaling
   mfem::ConstantCoefficient oneCoef; // Auxiliary coefficient
   mfem::Coefficient *alphaCoef;

--- a/src/hephaestus_lib/av_solver.hpp
+++ b/src/hephaestus_lib/av_solver.hpp
@@ -76,11 +76,11 @@ protected:
   mfem::ParLinearForm *b0, *b1;
 
   double dt_A0;
-  mfem::ConstantCoefficient dtCoef;  // Coefficient for timestep scaling
-  mfem::ConstantCoefficient oneCoef; // Auxiliary coefficient
+  mfem::ConstantCoefficient dtCoef; // Coefficient for timestep scaling
+  mfem::ConstantCoefficient oneCoef, negCoef; // Auxiliary coefficient
   mfem::Coefficient *alphaCoef;
   mfem::Coefficient *dtAlphaCoef;
-  mfem::Coefficient *betaCoef;
+  mfem::Coefficient *betaCoef, *negBetaCoef;
 
   mfem::VectorCoefficient *sourceVecCoef;
   mfem::ParGridFunction *src_gf, *div_free_src_gf; // Source field

--- a/src/hephaestus_lib/av_solver.hpp
+++ b/src/hephaestus_lib/av_solver.hpp
@@ -1,0 +1,110 @@
+#pragma once
+#include "../common/pfem_extras.hpp"
+#include "formulation.hpp"
+#include "inputs.hpp"
+
+namespace hephaestus {
+
+class AVSolver : public TransientFormulation {
+  virtual void
+  SetMaterialCoefficients(hephaestus::DomainProperties &domain_properties);
+  virtual void
+  SetSourceCoefficient(hephaestus::DomainProperties &domain_properties);
+  virtual void SetVariableNames();
+
+public:
+  AVSolver(mfem::ParMesh &pmesh, int order,
+           mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
+           hephaestus::BCMap &bc_map,
+           hephaestus::DomainProperties &domain_properties);
+
+  ~AVSolver(){};
+
+  void Init(mfem::Vector &X) override;
+
+  void buildA1(mfem::Coefficient *sigma, mfem::Coefficient *dtMuInv);
+  void buildM1(mfem::Coefficient *sigma);
+  void buildCurl(mfem::Coefficient *muInv);
+  void buildGrad();
+  void buildSource();
+
+  void ImplicitSolve(const double dt, const mfem::Vector &X,
+                     mfem::Vector &dX_dt) override;
+
+  void RegisterOutputFields(mfem::DataCollection *dc_) override;
+
+  void WriteOutputFields(mfem::DataCollection *dc_, int it = 0) override;
+
+  virtual void WriteConsoleSummary(double t, int it) override;
+
+  void InitializeGLVis() override;
+
+  void DisplayToGLVis() override;
+  mfem::common::H1_ParFESpace *H1FESpace_;
+  mfem::common::ND_ParFESpace *HCurlFESpace_;
+  mfem::common::RT_ParFESpace *HDivFESpace_;
+
+  mfem::Array<int> block_trueOffsets;
+
+  double ElectricLosses() const;
+
+  std::string u_name, p_name, v_name, e_name;
+  std::string u_display_name, p_display_name, v_display_name, e_display_name;
+
+  mfem::ParGridFunction a_, da_; // Magnetic Vector Potential (HCurl)
+  mfem::ParGridFunction v_, dv_; // Scalar Potential (H1)
+  mfem::ParGridFunction b_, db_; // Magnetic Flux (HDiv)
+  mfem::ParGridFunction e_, de_; // Electric Field (HCurl)
+
+protected:
+  int myid_;
+  int num_procs_;
+  mfem::ParMesh *pmesh_;
+  mfem::NamedFieldsMap<mfem::ParGridFunction> &_variables;
+  hephaestus::BCMap _bc_map;
+  hephaestus::DomainProperties _domain_properties;
+
+  mfem::ParBilinearForm *a0, *a1, *a00, *a11, *m1;
+  mfem::ParMixedBilinearForm *a01, *a10;
+  mfem::BlockOperator *blockAV;
+  mfem::BlockDiagonalPreconditioner *blockAVPr;
+  mfem::BlockVector *x, *rhs;
+  mfem::BlockVector *trueX, *trueRhs;
+
+  mfem::HypreParMatrix *A0, *A1, *A10, *A01, *blockA;
+  mfem::Vector *X0, *X1, *B0, *B1;
+
+  mfem::ParDiscreteLinearOperator *grad;
+  mfem::ParDiscreteLinearOperator *curl;
+  mfem::ParMixedBilinearForm *weakCurl;
+  mfem::ParBilinearForm *curlCurl;
+
+  mutable mfem::HypreSolver *amg_a0;
+  mutable mfem::HyprePCG *pcg_a0;
+  mutable mfem::HypreSolver *ams_a1;
+  mutable mfem::HyprePCG *pcg_a1;
+
+  // temporary work vectors
+  mfem::ParLinearForm *b0, *b1;
+
+  mfem::ParGridFunction *jr_; // Raw Volumetric Current Density (HCurl)
+  mfem::ParGridFunction *bd_; // Dual of B (HCurl)
+  mfem::ParGridFunction *jd_; // Dual of J, the rhs vector (HCurl)
+
+  double dt_A1;
+  mfem::ConstantCoefficient dtCoef; // Coefficient for timestep scaling
+  mfem::ConstantCoefficient oneCoef, negCoef; // Auxiliary coefficient
+  mfem::Coefficient *alphaCoef;               // Reluctivity Coefficient
+  mfem::Coefficient *dtAlphaCoef;
+  mfem::Coefficient *betaCoef,
+      *negBetaCoef; // Electric Conductivity Coefficient
+
+  mfem::VectorCoefficient *sourceVecCoef;
+  mfem::ParGridFunction *src_gf, *div_free_src_gf; // Source field
+  mfem::ParBilinearForm *hCurlMass;
+  mfem::common::DivergenceFreeProjector *divFreeProj;
+
+  // Sockets used to communicate with GLVis
+  std::map<std::string, mfem::socketstream *> socks_;
+};
+} // namespace hephaestus

--- a/src/hephaestus_lib/av_solver.hpp
+++ b/src/hephaestus_lib/av_solver.hpp
@@ -59,7 +59,8 @@ protected:
   hephaestus::DomainProperties _domain_properties;
 
   mfem::ParBilinearForm *a0, *a1, *m1;
-  mfem::HypreParMatrix *A0, *A1;
+  mfem::ParMixedBilinearForm *a01, *a10;
+  mfem::HypreParMatrix *A0, *A1, *A10, *A01, *blockA;
   mfem::Vector *X0, *X1, *B0, *B1;
   mfem::Array<int> block_trueOffsets;
 

--- a/src/hephaestus_lib/av_solver.hpp
+++ b/src/hephaestus_lib/av_solver.hpp
@@ -54,6 +54,7 @@ public:
 protected:
   int myid_;
   int num_procs_;
+  const int order_;
   mfem::ParMesh *pmesh_;
   mfem::NamedFieldsMap<mfem::ParGridFunction> &_variables;
   hephaestus::BCMap _bc_map;

--- a/src/hephaestus_lib/av_solver.hpp
+++ b/src/hephaestus_lib/av_solver.hpp
@@ -42,19 +42,14 @@ public:
   void DisplayToGLVis() override;
   mfem::common::H1_ParFESpace *H1FESpace_;
   mfem::common::ND_ParFESpace *HCurlFESpace_;
-  mfem::common::RT_ParFESpace *HDivFESpace_;
-
-  mfem::Array<int> block_trueOffsets;
 
   double ElectricLosses() const;
 
-  std::string u_name, p_name, v_name, e_name;
-  std::string u_display_name, p_display_name, v_display_name, e_display_name;
-
-  mfem::ParGridFunction a_, da_; // Magnetic Vector Potential (HCurl)
-  mfem::ParGridFunction v_, dv_; // Scalar Potential (H1)
-  mfem::ParGridFunction b_, db_; // Magnetic Flux (HDiv)
-  mfem::ParGridFunction e_, de_; // Electric Field (HCurl)
+  std::string u_name, p_name;
+  std::string u_display_name, p_display_name;
+  mfem::ParGridFunction u_, du_; // HCurl vector field
+  mfem::ParGridFunction p_, dp_; // H1 scalar potential
+  std::map<std::string, mfem::socketstream *> socks_;
 
 protected:
   int myid_;
@@ -64,40 +59,27 @@ protected:
   hephaestus::BCMap _bc_map;
   hephaestus::DomainProperties _domain_properties;
 
-  mfem::ParBilinearForm *a0, *a1, *a00, *a11, *m1;
-  mfem::ParMixedBilinearForm *a01, *a10;
-  mfem::BlockOperator *blockAV;
-  mfem::BlockDiagonalPreconditioner *blockAVPr;
-  mfem::BlockVector *x, *rhs;
-  mfem::BlockVector *trueX, *trueRhs;
-
-  mfem::HypreParMatrix *A0, *A1, *A10, *A01, *blockA;
+  mfem::ParBilinearForm *a0, *a1, *m1;
+  mfem::HypreParMatrix *A0, *A1;
   mfem::Vector *X0, *X1, *B0, *B1;
 
   mfem::ParDiscreteLinearOperator *grad;
   mfem::ParDiscreteLinearOperator *curl;
-  mfem::ParMixedBilinearForm *weakCurl;
   mfem::ParBilinearForm *curlCurl;
-
   mutable mfem::HypreSolver *amg_a0;
   mutable mfem::HyprePCG *pcg_a0;
-  mutable mfem::HypreSolver *ams_a1;
+  mutable mfem::HypreAMS *ams_a1;
   mutable mfem::HyprePCG *pcg_a1;
 
   // temporary work vectors
   mfem::ParLinearForm *b0, *b1;
 
-  mfem::ParGridFunction *jr_; // Raw Volumetric Current Density (HCurl)
-  mfem::ParGridFunction *bd_; // Dual of B (HCurl)
-  mfem::ParGridFunction *jd_; // Dual of J, the rhs vector (HCurl)
-
   double dt_A1;
-  mfem::ConstantCoefficient dtCoef; // Coefficient for timestep scaling
-  mfem::ConstantCoefficient oneCoef, negCoef; // Auxiliary coefficient
-  mfem::Coefficient *alphaCoef;               // Reluctivity Coefficient
+  mfem::ConstantCoefficient dtCoef;  // Coefficient for timestep scaling
+  mfem::ConstantCoefficient oneCoef; // Auxiliary coefficient
+  mfem::Coefficient *alphaCoef;
   mfem::Coefficient *dtAlphaCoef;
-  mfem::Coefficient *betaCoef,
-      *negBetaCoef; // Electric Conductivity Coefficient
+  mfem::Coefficient *betaCoef;
 
   mfem::VectorCoefficient *sourceVecCoef;
   mfem::ParGridFunction *src_gf, *div_free_src_gf; // Source field
@@ -105,6 +87,5 @@ protected:
   mfem::common::DivergenceFreeProjector *divFreeProj;
 
   // Sockets used to communicate with GLVis
-  std::map<std::string, mfem::socketstream *> socks_;
 };
 } // namespace hephaestus

--- a/src/hephaestus_lib/av_solver.hpp
+++ b/src/hephaestus_lib/av_solver.hpp
@@ -44,10 +44,11 @@ public:
 
   double ElectricLosses() const;
 
-  std::string u_name, p_name;
-  std::string u_display_name, p_display_name;
+  std::string u_name, p_name, e_name;
+  std::string u_display_name, p_display_name, e_display_name;
   mfem::ParGridFunction u_, du_; // HCurl vector field
   mfem::ParGridFunction p_, dp_; // H1 scalar potential
+  mfem::ParGridFunction e_;      // HCurl Electric Field
   std::map<std::string, mfem::socketstream *> socks_;
 
 protected:

--- a/src/hephaestus_lib/av_solver.hpp
+++ b/src/hephaestus_lib/av_solver.hpp
@@ -22,7 +22,8 @@ public:
 
   void Init(mfem::Vector &X) override;
 
-  void buildA0(mfem::Coefficient *sigma, mfem::Coefficient *dtMuInv);
+  void buildA0(mfem::Coefficient *betaCoef, mfem::Coefficient *dtAlphaCoef);
+  void buildA1(mfem::Coefficient *betaCoef);
   void buildCurl(mfem::Coefficient *muInv);
   void buildGrad();
   void buildSource();
@@ -41,14 +42,16 @@ public:
   void DisplayToGLVis() override;
   mfem::common::H1_ParFESpace *H1FESpace_;
   mfem::common::ND_ParFESpace *HCurlFESpace_;
+  mfem::common::RT_ParFESpace *HDivFESpace_;
 
   double ElectricLosses() const;
 
-  std::string u_name, p_name, e_name;
-  std::string u_display_name, p_display_name, e_display_name;
+  std::string u_name, p_name, e_name, b_name;
+  std::string u_display_name, p_display_name, e_display_name, b_display_name;
   mfem::ParGridFunction u_, du_; // HCurl vector field
   mfem::ParGridFunction p_, dp_; // H1 scalar potential
   mfem::ParGridFunction e_;      // HCurl Electric Field
+  mfem::ParGridFunction b_;      // HDiv Magnetic Flux Density
   std::map<std::string, mfem::socketstream *> socks_;
 
 protected:
@@ -75,9 +78,9 @@ protected:
   mutable mfem::HyprePCG *pcg_a1;
 
   // temporary work vectors
-  mfem::ParLinearForm *b0, *b1;
+  mfem::ParLinearForm *b0, *b1, *b01, *b10;
 
-  double dt_A0;
+  double dt_A0, dt_A1;
   mfem::ConstantCoefficient dtCoef; // Coefficient for timestep scaling
   mfem::ConstantCoefficient oneCoef, negCoef; // Auxiliary coefficient
   mfem::Coefficient *alphaCoef;

--- a/src/hephaestus_lib/executioner.cpp
+++ b/src/hephaestus_lib/executioner.cpp
@@ -99,41 +99,7 @@ void TransientExecutioner::Solve(const hephaestus::InputParameters &params) {
       }
       postprocessors.Update(t);
     }
-    delete ode_solver;
   }
 }
-
-// TransientExecutioner::Step(const hephaestus::InputParameters &params) {
-//   // Check if current time step is final
-//   if (t + dt >= t_final - dt / 2) {
-//     last_step = true;
-//   }
-
-//   // Advance time step.
-//   ode_solver->Step(F, t, dt);
-
-//   // Output data
-//   if (last_step || (it % vis_steps) == 0) {
-
-//     // Output timestep summary to console
-//     formulation->WriteConsoleSummary(t, it);
-
-//     // Make sure all ranks have sent their 'v' solution before initiating
-//     // another set of GLVis connections (one from each rank):
-//     MPI_Barrier(pmesh.GetComm());
-//     auxkernels.Solve(t);
-
-//     // Send output fields to GLVis for visualisation
-//     if (visualization) {
-//       formulation->DisplayToGLVis();
-//     }
-
-//     // Save output fields at timestep to DataCollections
-//     for (auto const &[name, dc_] : data_collections) {
-//       formulation->WriteOutputFields(dc_, it);
-//     }
-//     postprocessors.Update(t);
-//   }
-// }
 
 } // namespace hephaestus

--- a/src/hephaestus_lib/factory.cpp
+++ b/src/hephaestus_lib/factory.cpp
@@ -16,9 +16,15 @@ hephaestus::TransientFormulation *Factory::createTransientFormulation(
   } else if (formulation == "HForm") {
     return new hephaestus::HFormSolver(pmesh, order, variables, bc_map,
                                        domain_properties);
+  } else if (formulation == "AForm") {
+    return new hephaestus::AFormSolver(pmesh, order, variables, bc_map,
+                                       domain_properties);
   } else if (formulation == "EForm") {
     return new hephaestus::EFormSolver(pmesh, order, variables, bc_map,
                                        domain_properties);
+  } else if (formulation == "AVForm") {
+    return new hephaestus::AVSolver(pmesh, order, variables, bc_map,
+                                    domain_properties);
   } else {
     std::cout << "Formulation name " << formulation << " not recognised. \n";
   }

--- a/src/hephaestus_lib/factory.hpp
+++ b/src/hephaestus_lib/factory.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include "../common/pfem_extras.hpp"
+#include "aform_solver.hpp"
+#include "av_solver.hpp"
 #include "eb_dual_solver.hpp"
 #include "eform_solver.hpp"
 #include "hform_solver.hpp"

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -1,0 +1,189 @@
+// Based on an H form MMS test provided by Joseph Dean
+
+#include "auxkernels.hpp"
+#include "executioner.hpp"
+
+#include "hephaestus_transient.hpp"
+#include "postprocessors.hpp"
+
+#include <gtest/gtest.h>
+
+extern const char *DATA_DIR;
+
+class TestAFormSource : public testing::Test {
+protected:
+  static double estimate_convergence_rate(HYPRE_BigInt n_i, HYPRE_BigInt n_imo,
+                                          double error_i, double error_imo,
+                                          int dim) {
+    return std::log(error_i / error_imo) /
+           std::log(std::pow(n_imo / static_cast<double>(n_i), 1.0 / dim));
+  }
+
+  static double potential_ground(const mfem::Vector &x, double t) {
+    return 0.0;
+  }
+
+  static void hdot_bc(const mfem::Vector &x, double t, mfem::Vector &H) {
+    H(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI);
+    H(1) = 0;
+    H(2) = 0;
+  }
+
+  static void A_exact_expr(const mfem::Vector &x, double t,
+                           mfem::Vector &A_exact) {
+    A_exact(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI) * t;
+    A_exact(1) = 0;
+    A_exact(2) = 0;
+  }
+  static double mu_expr(const mfem::Vector &x) {
+    double variation_scale = 0.5;
+    double mu =
+        1.0 / (1.0 + variation_scale * cos(M_PI * x(0)) * cos(M_PI * x(1)));
+    return mu;
+  }
+  // Source field
+  static void source_field(const mfem::Vector &x, double t, mfem::Vector &f) {
+    double variation_scale = 0.5;
+    f(0) = t * M_PI * M_PI * sin(M_PI * x(1)) * sin(M_PI * x(2)) *
+               (3 * variation_scale * cos(M_PI * x(0)) * cos(M_PI * x(1)) + 2) +
+           sin(M_PI * x(1)) * sin(M_PI * x(2));
+    f(1) = -variation_scale * M_PI * M_PI * t * sin(M_PI * x(0)) *
+           cos(M_PI * x(1)) * cos(M_PI * x(1)) * sin(M_PI * x(2));
+    f(2) = -0.5 * variation_scale * M_PI * M_PI * t * sin(M_PI * x(0)) *
+           sin(2 * M_PI * x(1)) * cos(M_PI * x(2));
+  }
+
+  hephaestus::InputParameters test_params() {
+    hephaestus::Subdomain wire("wire", 1);
+    wire.property_map["electrical_conductivity"] =
+        new mfem::ConstantCoefficient(1.0);
+    hephaestus::Subdomain air("air", 2);
+    air.property_map["electrical_conductivity"] =
+        new mfem::ConstantCoefficient(1.0);
+
+    hephaestus::DomainProperties domain_properties(
+        std::vector<hephaestus::Subdomain>({wire, air}));
+
+    domain_properties.scalar_property_map["magnetic_permeability"] =
+        new mfem::FunctionCoefficient(mu_expr);
+
+    hephaestus::BCMap bc_map;
+    mfem::VectorFunctionCoefficient *adotVecCoef =
+        new mfem::VectorFunctionCoefficient(3, hdot_bc);
+    bc_map["tangential_dAdt"] = new hephaestus::VectorFunctionDirichletBC(
+        std::string("magnetic_vector_potential"), mfem::Array<int>({1, 2, 3}),
+        adotVecCoef);
+    domain_properties.vector_property_map["surface_tangential_dAdt"] =
+        adotVecCoef;
+    domain_properties.scalar_property_map["electrical_conductivity"] =
+        new mfem::ConstantCoefficient(1.0);
+
+    bc_map["ground_potential"] = new hephaestus::FunctionDirichletBC(
+        std::string("magnetic_potential"), mfem::Array<int>({1, 2, 3}),
+        new mfem::FunctionCoefficient(potential_ground));
+
+    mfem::VectorFunctionCoefficient *JSrcCoef =
+        new mfem::VectorFunctionCoefficient(3, source_field);
+    domain_properties.vector_property_map["source"] = JSrcCoef;
+
+    mfem::VectorFunctionCoefficient *A_exact =
+        new mfem::VectorFunctionCoefficient(3, A_exact_expr);
+    domain_properties.vector_property_map["a_exact_coeff"] = A_exact;
+
+    mfem::Mesh mesh(
+        (std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
+
+    std::map<std::string, mfem::DataCollection *> data_collections;
+    data_collections["VisItDataCollection"] =
+        new mfem::VisItDataCollection("AFormVisIt");
+    hephaestus::Outputs outputs(data_collections);
+
+    hephaestus::InputParameters hcurlvarparams;
+    hcurlvarparams.SetParam("VariableName",
+                            std::string("analytic_vector_potential"));
+    hcurlvarparams.SetParam("FESpaceName", std::string("HCurl"));
+    hcurlvarparams.SetParam("FESpaceType", std::string("Nedelec"));
+    hcurlvarparams.SetParam("order", 2);
+    hcurlvarparams.SetParam("components", 3);
+    hephaestus::Variables variables;
+    variables.AddVariable(hcurlvarparams);
+
+    hephaestus::InputParameters l2errpostprocparams;
+    l2errpostprocparams.SetParam("VariableName",
+                                 std::string("magnetic_vector_potential"));
+    l2errpostprocparams.SetParam("VectorCoefficientName",
+                                 std::string("a_exact_coeff"));
+    hephaestus::Postprocessors postprocessors;
+    postprocessors.Register(
+        "L2ErrorPostprocessor",
+        new hephaestus::L2ErrorVectorPostprocessor(l2errpostprocparams), true);
+
+    hephaestus::InputParameters vectorcoeffauxparams;
+    vectorcoeffauxparams.SetParam("VariableName",
+                                  std::string("analytic_vector_potential"));
+    vectorcoeffauxparams.SetParam("VectorCoefficientName",
+                                  std::string("a_exact_coeff"));
+
+    hephaestus::AuxKernels auxkernels;
+    auxkernels.Register(
+        "VectorCoefficientAuxKernel",
+        new hephaestus::VectorCoefficientAuxKernel(vectorcoeffauxparams), true);
+
+    hephaestus::InputParameters exec_params;
+    exec_params.SetParam("TimeStep", float(0.05));
+    exec_params.SetParam("StartTime", float(0.00));
+    exec_params.SetParam("EndTime", float(0.05));
+    hephaestus::TransientExecutioner *executioner =
+        new hephaestus::TransientExecutioner(exec_params);
+
+    hephaestus::InputParameters params;
+    params.SetParam("Mesh", mfem::ParMesh(MPI_COMM_WORLD, mesh));
+    params.SetParam("Executioner", executioner);
+    params.SetParam("Order", 2);
+    params.SetParam("BoundaryConditions", bc_map);
+    params.SetParam("DomainProperties", domain_properties);
+    params.SetParam("Variables", variables);
+    params.SetParam("AuxKernels", auxkernels);
+    params.SetParam("Postprocessors", postprocessors);
+    params.SetParam("Outputs", outputs);
+    params.SetParam("FormulationName", std::string("AForm"));
+
+    return params;
+  }
+};
+
+TEST_F(TestAFormSource, CheckRun) {
+  hephaestus::InputParameters params(test_params());
+  mfem::ParMesh unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
+
+  int num_conv_refinements = 3;
+  for (int par_ref_levels = 0; par_ref_levels < num_conv_refinements;
+       ++par_ref_levels) {
+
+    mfem::ParMesh pmesh(unrefined_pmesh);
+
+    for (int l = 0; l < par_ref_levels; l++) {
+      pmesh.UniformRefinement();
+    }
+    params.SetParam("Mesh", pmesh);
+
+    hephaestus::TransientExecutioner *executioner(
+        params.GetParam<hephaestus::TransientExecutioner *>("Executioner"));
+    executioner->Solve(params);
+  }
+
+  hephaestus::L2ErrorVectorPostprocessor l2errpostprocessor =
+      *(dynamic_cast<hephaestus::L2ErrorVectorPostprocessor *>(
+          params.GetParam<hephaestus::Postprocessors>("Postprocessors")
+              .Get("L2ErrorPostprocessor")));
+
+  double r;
+  for (std::size_t i = 1; i < l2errpostprocessor.ndofs.Size(); ++i) {
+    r = estimate_convergence_rate(
+        l2errpostprocessor.ndofs[i], l2errpostprocessor.ndofs[i - 1],
+        l2errpostprocessor.l2_errs[i], l2errpostprocessor.l2_errs[i - 1], 3);
+    std::cout << r << std::endl;
+    ASSERT_TRUE(r > params.GetParam<int>("Order"));
+    ASSERT_TRUE(r < params.GetParam<int>("Order") + 1.0);
+  }
+}

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -1,0 +1,118 @@
+#include "auxkernels.hpp"
+#include "executioner.hpp"
+
+#include "hephaestus_transient.hpp"
+#include "postprocessors.hpp"
+
+#include <gtest/gtest.h>
+
+extern const char *DATA_DIR;
+
+class TestAVFormRod : public testing::Test {
+protected:
+  static double potential_high(const mfem::Vector &x, double t) {
+    double wj_(2.0 * M_PI / 60.0);
+    return 2 * cos(wj_ * t);
+  }
+  static double potential_ground(const mfem::Vector &x, double t) {
+    return 0.0;
+  }
+
+  static void adot_bc(const mfem::Vector &x, double t, mfem::Vector &dAdt) {
+    dAdt = 0.0;
+  }
+
+  static void source_current(const mfem::Vector &x, double t, mfem::Vector &J) {
+    J = 0.0;
+  }
+
+  hephaestus::InputParameters test_params() {
+    double sigma = 2.0 * M_PI * 10;
+
+    double sigmaAir;
+
+    sigmaAir = 1.0e-6 * sigma;
+
+    hephaestus::Subdomain wire("wire", 1);
+    wire.property_map["electrical_conductivity"] =
+        new mfem::ConstantCoefficient(sigma);
+
+    hephaestus::Subdomain air("air", 2);
+    air.property_map["electrical_conductivity"] =
+        new mfem::ConstantCoefficient(sigmaAir);
+
+    hephaestus::DomainProperties domain_properties(
+        std::vector<hephaestus::Subdomain>({wire, air}));
+
+    domain_properties.scalar_property_map["magnetic_permeability"] =
+        new mfem::ConstantCoefficient(1.0);
+
+    hephaestus::BCMap bc_map;
+    mfem::VectorFunctionCoefficient *adotVecCoef =
+        new mfem::VectorFunctionCoefficient(3, adot_bc);
+    bc_map["tangential_dAdt"] = new hephaestus::VectorFunctionDirichletBC(
+        std::string("magnetic_vector_potential"), mfem::Array<int>({1, 2, 3}),
+        adotVecCoef);
+    domain_properties.vector_property_map["surface_tangential_dAdt"] =
+        adotVecCoef;
+
+    mfem::Array<int> high_terminal(1);
+    high_terminal[0] = 1;
+    bc_map["high_potential"] = new hephaestus::FunctionDirichletBC(
+        std::string("electric_potential"), high_terminal,
+        new mfem::FunctionCoefficient(potential_high));
+
+    mfem::Array<int> ground_terminal(1);
+    ground_terminal[0] = 2;
+    bc_map["ground_potential"] = new hephaestus::FunctionDirichletBC(
+        std::string("electric_potential"), ground_terminal,
+        new mfem::FunctionCoefficient(potential_ground));
+
+    mfem::VectorFunctionCoefficient *JSrcCoef =
+        new mfem::VectorFunctionCoefficient(3, source_current);
+
+    mfem::Mesh mesh(
+        (std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(),
+        1, 1);
+
+    std::map<std::string, mfem::DataCollection *> data_collections;
+    data_collections["VisItDataCollection"] =
+        new mfem::VisItDataCollection("AVFormVisIt");
+    data_collections["ParaViewDataCollection"] =
+        new mfem::ParaViewDataCollection("AVFormParaView");
+
+    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Variables variables;
+    hephaestus::Postprocessors postprocessors;
+    hephaestus::AuxKernels auxkernels;
+
+    hephaestus::InputParameters exec_params;
+    exec_params.SetParam("TimeStep", float(0.5));
+    exec_params.SetParam("StartTime", float(0.00));
+    exec_params.SetParam("EndTime", float(2.5));
+    hephaestus::TransientExecutioner *executioner =
+        new hephaestus::TransientExecutioner(exec_params);
+
+    hephaestus::InputParameters params;
+    params.SetParam("Mesh", mfem::ParMesh(MPI_COMM_WORLD, mesh));
+    params.SetParam("Executioner", executioner);
+    params.SetParam("Order", 3);
+    params.SetParam("BoundaryConditions", bc_map);
+    params.SetParam("DomainProperties", domain_properties);
+    params.SetParam("Variables", variables);
+    params.SetParam("AuxKernels", auxkernels);
+    params.SetParam("Postprocessors", postprocessors);
+    params.SetParam("Outputs", outputs);
+    params.SetParam("FormulationName", std::string("AVForm"));
+
+    return params;
+  }
+};
+
+TEST_F(TestAVFormRod, CheckRun) {
+  hephaestus::InputParameters params(test_params());
+
+  hephaestus::TransientExecutioner *executioner(
+      params.GetParam<hephaestus::TransientExecutioner *>("Executioner"));
+  executioner->Solve(params);
+}

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -20,19 +20,18 @@ protected:
   }
 
   static double potential_ground(const mfem::Vector &x, double t) {
-    // return 0.0;
-    return (x(0) - 4.0) * t * sin(M_PI * x(1)) * sin(M_PI * x(2));
+    return -x(0);
   }
 
   static void adot_bc(const mfem::Vector &x, double t, mfem::Vector &H) {
-    H(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI);
+    H(0) = 1 + sin(x(1) * M_PI) * sin(x(2) * M_PI);
     H(1) = 0;
     H(2) = 0;
   }
 
   static void A_exact_expr(const mfem::Vector &x, double t,
                            mfem::Vector &A_exact) {
-    A_exact(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI) * t;
+    A_exact(0) = (1 + sin(x(1) * M_PI) * sin(x(2) * M_PI)) * t;
     A_exact(1) = 0;
     A_exact(2) = 0;
   }
@@ -42,10 +41,9 @@ protected:
         1.0 / (1.0 + variation_scale * cos(M_PI * x(0)) * cos(M_PI * x(1)));
     return mu;
   }
-  // Source field (not divergence free)
+  // Source field (not discretely divergence free)
   static void source_field(const mfem::Vector &x, double t, mfem::Vector &f) {
-    f(0) = t * 2 * M_PI * M_PI * sin(M_PI * x(1)) * sin(M_PI * x(2)) +
-           sin(M_PI * x(1)) * sin(M_PI * x(2));
+    f(0) = sin(M_PI * x(1)) * sin(M_PI * x(2)) * (t * 2 * M_PI * M_PI + 1);
     f(1) = 0.0;
     f(2) = 0.0;
   }
@@ -79,23 +77,24 @@ protected:
     //     std::string("electric_potential"), mfem::Array<int>({1, 2, 3}),
     //     new mfem::FunctionCoefficient(potential_ground));
 
-    // mfem::Array<int> ground_terminal(1);
-    // ground_terminal[0] = 1;
-    // mfem::FunctionCoefficient *ground_coeff =
-    //     new mfem::FunctionCoefficient(potential_ground);
-    // bc_map["ground_potential"] = new hephaestus::FunctionDirichletBC(
-    //     std::string("electric_potential"), ground_terminal, ground_coeff);
-    // domain_properties.scalar_property_map["ground_potential"] = ground_coeff;
-
-    mfem::Array<int> high_terminal(1);
-    high_terminal[0] = 2;
-    mfem::VectorFunctionCoefficient *jVecCoef =
-        new mfem::VectorFunctionCoefficient(3, source_field);
-    bc_map["current_inlet"] = new hephaestus::IntegratedBC(
+    mfem::Array<int> ground_terminal(1);
+    ground_terminal[0] = 1;
+    mfem::FunctionCoefficient *ground_coeff =
+        new mfem::FunctionCoefficient(potential_ground);
+    bc_map["ground_potential"] = new hephaestus::FunctionDirichletBC(
         std::string("electric_potential"), mfem::Array<int>({1, 2, 3}),
-        new mfem::BoundaryNormalLFIntegrator(*jVecCoef));
-    domain_properties.vector_property_map["surface_normal_current_density"] =
-        jVecCoef;
+        ground_coeff);
+    domain_properties.scalar_property_map["ground_potential"] = ground_coeff;
+
+    // mfem::Array<int> high_terminal(1);
+    // high_terminal[0] = 2;
+    // mfem::VectorFunctionCoefficient *jVecCoef =
+    //     new mfem::VectorFunctionCoefficient(3, source_field);
+    // bc_map["current_inlet"] = new hephaestus::IntegratedBC(
+    //     std::string("electric_potential"), mfem::Array<int>({1, 2, 3}),
+    //     new mfem::BoundaryNormalLFIntegrator(*jVecCoef));
+    // domain_properties.vector_property_map["surface_normal_current_density"] =
+    //     jVecCoef;
 
     mfem::VectorFunctionCoefficient *JSrcCoef =
         new mfem::VectorFunctionCoefficient(3, source_field);
@@ -110,7 +109,7 @@ protected:
 
     std::map<std::string, mfem::DataCollection *> data_collections;
     data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("AFormVisIt");
+        new mfem::VisItDataCollection("AVFormVisIt");
     hephaestus::Outputs outputs(data_collections);
 
     hephaestus::InputParameters hcurlvarparams;
@@ -171,7 +170,7 @@ TEST_F(TestAVFormSource, CheckRun) {
   hephaestus::InputParameters params(test_params());
   mfem::ParMesh unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
 
-  int num_conv_refinements = 3;
+  int num_conv_refinements = 4;
   for (int par_ref_levels = 0; par_ref_levels < num_conv_refinements;
        ++par_ref_levels) {
 
@@ -198,7 +197,7 @@ TEST_F(TestAVFormSource, CheckRun) {
         l2errpostprocessor.ndofs[i], l2errpostprocessor.ndofs[i - 1],
         l2errpostprocessor.l2_errs[i], l2errpostprocessor.l2_errs[i - 1], 3);
     std::cout << r << std::endl;
-    // ASSERT_TRUE(r > params.GetParam<int>("Order"));
-    // ASSERT_TRUE(r < params.GetParam<int>("Order") + 1.0);
+    ASSERT_TRUE(r > params.GetParam<int>("Order"));
+    ASSERT_TRUE(r < params.GetParam<int>("Order") + 1.0);
   }
 }

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -117,7 +117,7 @@ protected:
                             std::string("analytic_vector_potential"));
     hcurlvarparams.SetParam("FESpaceName", std::string("HCurl"));
     hcurlvarparams.SetParam("FESpaceType", std::string("Nedelec"));
-    hcurlvarparams.SetParam("order", 2);
+    hcurlvarparams.SetParam("order", 4);
     hcurlvarparams.SetParam("components", 3);
     hephaestus::Variables variables;
     variables.AddVariable(hcurlvarparams);
@@ -170,7 +170,7 @@ TEST_F(TestAVFormSource, CheckRun) {
   hephaestus::InputParameters params(test_params());
   mfem::ParMesh unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
 
-  int num_conv_refinements = 4;
+  int num_conv_refinements = 3;
   for (int par_ref_levels = 0; par_ref_levels < num_conv_refinements;
        ++par_ref_levels) {
 

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -41,7 +41,7 @@ protected:
         1.0 / (1.0 + variation_scale * cos(M_PI * x(0)) * cos(M_PI * x(1)));
     return mu;
   }
-  // Source field (not discretely divergence free)
+
   static void source_field(const mfem::Vector &x, double t, mfem::Vector &f) {
     f(0) = sin(M_PI * x(1)) * sin(M_PI * x(2)) * (t * 2 * M_PI * M_PI + 1);
     f(1) = 0.0;
@@ -73,10 +73,6 @@ protected:
     domain_properties.scalar_property_map["electrical_conductivity"] =
         new mfem::ConstantCoefficient(1.0);
 
-    // bc_map["ground_potential"] = new hephaestus::FunctionDirichletBC(
-    //     std::string("electric_potential"), mfem::Array<int>({1, 2, 3}),
-    //     new mfem::FunctionCoefficient(potential_ground));
-
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 1;
     mfem::FunctionCoefficient *ground_coeff =
@@ -85,16 +81,6 @@ protected:
         std::string("electric_potential"), mfem::Array<int>({1, 2, 3}),
         ground_coeff);
     domain_properties.scalar_property_map["ground_potential"] = ground_coeff;
-
-    // mfem::Array<int> high_terminal(1);
-    // high_terminal[0] = 2;
-    // mfem::VectorFunctionCoefficient *jVecCoef =
-    //     new mfem::VectorFunctionCoefficient(3, source_field);
-    // bc_map["current_inlet"] = new hephaestus::IntegratedBC(
-    //     std::string("electric_potential"), mfem::Array<int>({1, 2, 3}),
-    //     new mfem::BoundaryNormalLFIntegrator(*jVecCoef));
-    // domain_properties.vector_property_map["surface_normal_current_density"] =
-    //     jVecCoef;
 
     mfem::VectorFunctionCoefficient *JSrcCoef =
         new mfem::VectorFunctionCoefficient(3, source_field);

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -1,0 +1,189 @@
+// Based on an H form MMS test provided by Joseph Dean
+
+#include "auxkernels.hpp"
+#include "executioner.hpp"
+
+#include "hephaestus_transient.hpp"
+#include "postprocessors.hpp"
+
+#include <gtest/gtest.h>
+
+extern const char *DATA_DIR;
+
+class TestAVFormSource : public testing::Test {
+protected:
+  static double estimate_convergence_rate(HYPRE_BigInt n_i, HYPRE_BigInt n_imo,
+                                          double error_i, double error_imo,
+                                          int dim) {
+    return std::log(error_i / error_imo) /
+           std::log(std::pow(n_imo / static_cast<double>(n_i), 1.0 / dim));
+  }
+
+  static double potential_ground(const mfem::Vector &x, double t) {
+    return 0.0;
+  }
+
+  static void adot_bc(const mfem::Vector &x, double t, mfem::Vector &H) {
+    H(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI);
+    H(1) = 0;
+    H(2) = 0;
+  }
+
+  static void A_exact_expr(const mfem::Vector &x, double t,
+                           mfem::Vector &A_exact) {
+    A_exact(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI) * t;
+    A_exact(1) = 0;
+    A_exact(2) = 0;
+  }
+  static double mu_expr(const mfem::Vector &x) {
+    double variation_scale = 0.0;
+    double mu =
+        1.0 / (1.0 + variation_scale * cos(M_PI * x(0)) * cos(M_PI * x(1)));
+    return mu;
+  }
+  // Source field
+  static void source_field(const mfem::Vector &x, double t, mfem::Vector &f) {
+    double variation_scale = 0.0;
+    f(0) = t * M_PI * M_PI * sin(M_PI * x(1)) * sin(M_PI * x(2)) *
+               (3 * variation_scale * cos(M_PI * x(0)) * cos(M_PI * x(1)) + 2) +
+           sin(M_PI * x(1)) * sin(M_PI * x(2));
+    f(1) = -variation_scale * M_PI * M_PI * t * sin(M_PI * x(0)) *
+           cos(M_PI * x(1)) * cos(M_PI * x(1)) * sin(M_PI * x(2));
+    f(2) = -0.5 * variation_scale * M_PI * M_PI * t * sin(M_PI * x(0)) *
+           sin(2 * M_PI * x(1)) * cos(M_PI * x(2));
+  }
+
+  hephaestus::InputParameters test_params() {
+    hephaestus::Subdomain wire("wire", 1);
+    wire.property_map["electrical_conductivity"] =
+        new mfem::ConstantCoefficient(1.0);
+    hephaestus::Subdomain air("air", 2);
+    air.property_map["electrical_conductivity"] =
+        new mfem::ConstantCoefficient(1.0);
+
+    hephaestus::DomainProperties domain_properties(
+        std::vector<hephaestus::Subdomain>({wire, air}));
+
+    domain_properties.scalar_property_map["magnetic_permeability"] =
+        new mfem::FunctionCoefficient(mu_expr);
+
+    hephaestus::BCMap bc_map;
+    mfem::VectorFunctionCoefficient *adotVecCoef =
+        new mfem::VectorFunctionCoefficient(3, adot_bc);
+    bc_map["tangential_dAdt"] = new hephaestus::VectorFunctionDirichletBC(
+        std::string("magnetic_vector_potential"), mfem::Array<int>({1, 2, 3}),
+        adotVecCoef);
+    domain_properties.vector_property_map["surface_tangential_dAdt"] =
+        adotVecCoef;
+    domain_properties.scalar_property_map["electrical_conductivity"] =
+        new mfem::ConstantCoefficient(1.0);
+
+    bc_map["ground_potential"] = new hephaestus::FunctionDirichletBC(
+        std::string("electric_potential"), mfem::Array<int>({1, 2, 3}),
+        new mfem::FunctionCoefficient(potential_ground));
+
+    mfem::VectorFunctionCoefficient *JSrcCoef =
+        new mfem::VectorFunctionCoefficient(3, source_field);
+    domain_properties.vector_property_map["source"] = JSrcCoef;
+
+    mfem::VectorFunctionCoefficient *A_exact =
+        new mfem::VectorFunctionCoefficient(3, A_exact_expr);
+    domain_properties.vector_property_map["a_exact_coeff"] = A_exact;
+
+    mfem::Mesh mesh(
+        (std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
+
+    std::map<std::string, mfem::DataCollection *> data_collections;
+    data_collections["VisItDataCollection"] =
+        new mfem::VisItDataCollection("AFormVisIt");
+    hephaestus::Outputs outputs(data_collections);
+
+    hephaestus::InputParameters hcurlvarparams;
+    hcurlvarparams.SetParam("VariableName",
+                            std::string("analytic_vector_potential"));
+    hcurlvarparams.SetParam("FESpaceName", std::string("HCurl"));
+    hcurlvarparams.SetParam("FESpaceType", std::string("Nedelec"));
+    hcurlvarparams.SetParam("order", 2);
+    hcurlvarparams.SetParam("components", 3);
+    hephaestus::Variables variables;
+    variables.AddVariable(hcurlvarparams);
+
+    hephaestus::InputParameters l2errpostprocparams;
+    l2errpostprocparams.SetParam("VariableName",
+                                 std::string("magnetic_vector_potential"));
+    l2errpostprocparams.SetParam("VectorCoefficientName",
+                                 std::string("a_exact_coeff"));
+    hephaestus::Postprocessors postprocessors;
+    postprocessors.Register(
+        "L2ErrorPostprocessor",
+        new hephaestus::L2ErrorVectorPostprocessor(l2errpostprocparams), true);
+
+    hephaestus::InputParameters vectorcoeffauxparams;
+    vectorcoeffauxparams.SetParam("VariableName",
+                                  std::string("analytic_vector_potential"));
+    vectorcoeffauxparams.SetParam("VectorCoefficientName",
+                                  std::string("a_exact_coeff"));
+
+    hephaestus::AuxKernels auxkernels;
+    auxkernels.Register(
+        "VectorCoefficientAuxKernel",
+        new hephaestus::VectorCoefficientAuxKernel(vectorcoeffauxparams), true);
+
+    hephaestus::InputParameters exec_params;
+    exec_params.SetParam("TimeStep", float(0.05));
+    exec_params.SetParam("StartTime", float(0.00));
+    exec_params.SetParam("EndTime", float(0.05));
+    hephaestus::TransientExecutioner *executioner =
+        new hephaestus::TransientExecutioner(exec_params);
+
+    hephaestus::InputParameters params;
+    params.SetParam("Mesh", mfem::ParMesh(MPI_COMM_WORLD, mesh));
+    params.SetParam("Executioner", executioner);
+    params.SetParam("Order", 2);
+    params.SetParam("BoundaryConditions", bc_map);
+    params.SetParam("DomainProperties", domain_properties);
+    params.SetParam("Variables", variables);
+    params.SetParam("AuxKernels", auxkernels);
+    params.SetParam("Postprocessors", postprocessors);
+    params.SetParam("Outputs", outputs);
+    params.SetParam("FormulationName", std::string("AVForm"));
+
+    return params;
+  }
+};
+
+TEST_F(TestAVFormSource, CheckRun) {
+  hephaestus::InputParameters params(test_params());
+  mfem::ParMesh unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
+
+  int num_conv_refinements = 2;
+  for (int par_ref_levels = 0; par_ref_levels < num_conv_refinements;
+       ++par_ref_levels) {
+
+    mfem::ParMesh pmesh(unrefined_pmesh);
+
+    for (int l = 0; l < par_ref_levels; l++) {
+      pmesh.UniformRefinement();
+    }
+    params.SetParam("Mesh", pmesh);
+
+    hephaestus::TransientExecutioner *executioner(
+        params.GetParam<hephaestus::TransientExecutioner *>("Executioner"));
+    executioner->Solve(params);
+  }
+
+  hephaestus::L2ErrorVectorPostprocessor l2errpostprocessor =
+      *(dynamic_cast<hephaestus::L2ErrorVectorPostprocessor *>(
+          params.GetParam<hephaestus::Postprocessors>("Postprocessors")
+              .Get("L2ErrorPostprocessor")));
+
+  double r;
+  for (std::size_t i = 1; i < l2errpostprocessor.ndofs.Size(); ++i) {
+    r = estimate_convergence_rate(
+        l2errpostprocessor.ndofs[i], l2errpostprocessor.ndofs[i - 1],
+        l2errpostprocessor.l2_errs[i], l2errpostprocessor.l2_errs[i - 1], 3);
+    std::cout << r << std::endl;
+    ASSERT_TRUE(r > params.GetParam<int>("Order"));
+    ASSERT_TRUE(r < params.GetParam<int>("Order") + 1.0);
+  }
+}


### PR DESCRIPTION
Add initial A and AV form solvers in the time domain. 

AV form solver currently only works with MUMPS enabled, and does not currently support systems with closed current sources. Future examples and tests shall address this.

