### PR TITLE
Use GMRES solver for AV Formulation when MUMPS is not available

### DIFF
--- a/src/hephaestus_lib/executioner.cpp
+++ b/src/hephaestus_lib/executioner.cpp
@@ -60,6 +60,8 @@ void TransientExecutioner::Solve(
     formulation->DisplayToGLVis();
   }
   // Begin time evolution
+  t = t_initial;
+  last_step = false;
   for (int it = 1; !last_step; it++) {
     // Check if current time step is final
     if (t + dt >= t_final - dt / 2) {

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -91,7 +91,7 @@ protected:
     hephaestus::InputParameters params;
     params.SetParam("Mesh", mfem::ParMesh(MPI_COMM_WORLD, mesh));
     params.SetParam("Executioner", executioner);
-    params.SetParam("Order", 3);
+    params.SetParam("Order", 2);
     params.SetParam("BoundaryConditions", bc_map);
     params.SetParam("DomainProperties", domain_properties);
     params.SetParam("Variables", variables);


### PR DESCRIPTION
Default to using GMRES solver for AV formulation solves if MUMPS is not available for MFEM. 

Also fixes bug arising when TransientExecutioner is re-used for multiple solves. 