### PR TITLE
Add ScalarPotentialSource solver

### DIFF
--- a/src/hephaestus_lib/aform_solver.cpp
+++ b/src/hephaestus_lib/aform_solver.cpp
@@ -12,14 +12,10 @@ AFormSolver::AFormSolver(
                   sources, solver_options) {}
 
 void AFormSolver::RegisterVariables() {
-  p_name = "electric_potential";
-  p_display_name = "Scalar Potential (V)";
-
   u_name = "magnetic_vector_potential";
   u_display_name = "Magnetic Vector Potential (A)";
 
   _variables.Register(u_name, &u_, false);
-  _variables.Register(p_name, &p_, false);
   _variables.Register("magnetic_flux_density", &curl_u_, false);
 }
 

--- a/src/hephaestus_lib/av_solver.cpp
+++ b/src/hephaestus_lib/av_solver.cpp
@@ -187,7 +187,7 @@ void AVSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
   _bc_map.applyIntegratedBCs(u_name, *b0, pmesh_);
   b0->Assemble();
 
-  _sources.ApplySources(b0);
+  _sources.ApplyKernels(b0);
 
   mfem::ParGridFunction Phi_gf(H1FESpace_);
   mfem::Array<int> poisson_ess_tdof_list;

--- a/src/hephaestus_lib/av_solver.cpp
+++ b/src/hephaestus_lib/av_solver.cpp
@@ -98,7 +98,7 @@ void AVSolver::Init(mfem::Vector &X) {
   SetMaterialCoefficients(_domain_properties);
   dtAlphaCoef = new mfem::TransformedCoefficient(&dtCoef, alphaCoef, prodFunc);
 
-  _sources.Init(_variables, _fespaces, _domain_properties);
+  _sources.Init(_variables, _fespaces, _bc_map, _domain_properties);
 
   this->buildCurl(alphaCoef); // (α∇×u_{n}, ∇×u')
   this->buildGrad();          // (s0_{n+1}, u')

--- a/src/hephaestus_lib/dual_solver.hpp
+++ b/src/hephaestus_lib/dual_solver.hpp
@@ -44,13 +44,10 @@ public:
   mfem::common::ND_ParFESpace *HCurlFESpace_;
   mfem::common::RT_ParFESpace *HDivFESpace_;
 
-  double ElectricLosses() const;
-
-  std::string u_name, p_name, v_name;
-  std::string u_display_name, p_display_name, v_display_name;
+  std::string u_name, v_name;
+  std::string u_display_name, v_display_name;
 
   mfem::ParGridFunction u_, du_; // HCurl vector field
-  mfem::ParGridFunction p_, dp_; // H1 scalar potential
   mfem::ParGridFunction v_, dv_; // HDiv vector field
 
   // Sockets used to communicate with GLVis
@@ -62,24 +59,21 @@ protected:
   mfem::ParMesh *pmesh_;
   mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &_fespaces;
   mfem::NamedFieldsMap<mfem::ParGridFunction> &_variables;
+  hephaestus::Sources &_sources;
   hephaestus::BCMap _bc_map;
   hephaestus::DomainProperties _domain_properties;
   hephaestus::InputParameters _solver_options;
 
-  mfem::ParBilinearForm *a0, *a1, *m1;
-  mfem::HypreParMatrix *A0, *A1;
-  mfem::Vector *X0, *X1, *B0, *B1;
+  mfem::ParBilinearForm *a1;
+  mfem::HypreParMatrix *A1;
+  mfem::Vector *X1, *B1;
 
-  mfem::ParDiscreteLinearOperator *grad;
   mfem::ParDiscreteLinearOperator *curl;
   mfem::ParMixedBilinearForm *weakCurl;
-  mutable mfem::HypreSolver *amg_a0;
-  mutable mfem::HyprePCG *pcg_a0;
-  mutable hephaestus::DefaultH1PCGSolver *a0_solver;
   mutable hephaestus::DefaultHCurlPCGSolver *a1_solver;
 
   // temporary work vectors
-  mfem::ParLinearForm *b0, *b1;
+  mfem::ParLinearForm *b1;
 
   double dt_A1;
   mfem::ConstantCoefficient dtCoef;  // Coefficient for timestep scaling

--- a/src/hephaestus_lib/eb_dual_solver.cpp
+++ b/src/hephaestus_lib/eb_dual_solver.cpp
@@ -12,9 +12,6 @@ EBDualSolver::EBDualSolver(
                  sources, solver_options) {}
 
 void EBDualSolver::RegisterVariables() {
-  p_name = "electric_potential";
-  p_display_name = "Scalar Potential (V)";
-
   u_name = "electric_field";
   u_display_name = "Electric Field (E)";
 
@@ -23,7 +20,6 @@ void EBDualSolver::RegisterVariables() {
 
   _variables.Register(u_name, &u_, false);
   _variables.Register(v_name, &v_, false);
-  _variables.Register(p_name, &p_, false);
 }
 
 void EBDualSolver::SetMaterialCoefficients(
@@ -47,26 +43,4 @@ void EBDualSolver::SetMaterialCoefficients(
   betaCoef = domain_properties.scalar_property_map["electrical_conductivity"];
 }
 
-void EBDualSolver::WriteConsoleSummary(double t, int it) {
-  // Write a summary of the timestep to console.
-
-  // Output Ohmic losses to console
-  double el = this->ElectricLosses();
-  if (myid_ == 0) {
-    std::cout << std::fixed;
-    std::cout << "step " << std::setw(6) << it << ",\tt = " << std::setw(6)
-              << std::setprecision(3) << t
-              << ",\tdot(E, J) = " << std::setprecision(8) << el << std::endl;
-  }
-}
-
-double EBDualSolver::ElectricLosses() const {
-  double el = m1->InnerProduct(u_, u_);
-
-  double global_el;
-  MPI_Allreduce(&el, &global_el, 1, MPI_DOUBLE, MPI_SUM,
-                m1->ParFESpace()->GetComm());
-
-  return el;
-}
 } // namespace hephaestus

--- a/src/hephaestus_lib/eb_dual_solver.hpp
+++ b/src/hephaestus_lib/eb_dual_solver.hpp
@@ -20,8 +20,5 @@ public:
                hephaestus::InputParameters &solver_options);
 
   ~EBDualSolver(){};
-
-  virtual void WriteConsoleSummary(double t, int it) override;
-  double ElectricLosses() const;
 };
 } // namespace hephaestus

--- a/src/hephaestus_lib/eform_solver.cpp
+++ b/src/hephaestus_lib/eform_solver.cpp
@@ -12,14 +12,10 @@ EFormSolver::EFormSolver(
                   sources, solver_options) {}
 
 void EFormSolver::RegisterVariables() {
-  p_name = "electric_potential";
-  p_display_name = "Electric Potential (V)";
-
   u_name = "electric_field";
   u_display_name = "Electric Field (E)";
 
   _variables.Register(u_name, &u_, false);
-  _variables.Register(p_name, &p_, false);
   _variables.Register("-dB_dt", &curl_u_, false);
 }
 

--- a/src/hephaestus_lib/hcurl_solver.cpp
+++ b/src/hephaestus_lib/hcurl_solver.cpp
@@ -81,8 +81,6 @@ HCurlSolver::HCurlSolver(
     std::cout << "Total number of         DOFs: " << size_h1 + size_nd
               << std::endl;
     std::cout << "------------------------------------" << std::endl;
-    std::cout << "Total number of         DOFs: " << size_h1 + size_nd
-              << std::endl;
     std::cout << "Total number of H1      DOFs: " << size_h1 << std::endl;
     std::cout << "Total number of H(Curl) DOFs: " << size_nd << std::endl;
     std::cout << "------------------------------------" << std::endl;
@@ -101,7 +99,7 @@ void HCurlSolver::Init(mfem::Vector &X) {
   SetMaterialCoefficients(_domain_properties);
   dtAlphaCoef = new mfem::TransformedCoefficient(&dtCoef, alphaCoef, prodFunc);
 
-  _sources.Init(_variables, _fespaces, _domain_properties);
+  _sources.Init(_variables, _fespaces, _bc_map, _domain_properties);
 
   // a0(p, p') = (β ∇ p, ∇ p')
   a0 = new mfem::ParBilinearForm(H1FESpace_);

--- a/src/hephaestus_lib/hcurl_solver.cpp
+++ b/src/hephaestus_lib/hcurl_solver.cpp
@@ -153,7 +153,7 @@ void HCurlSolver::ImplicitSolve(const double dt, const mfem::Vector &X,
   curlCurl->MultTranspose(u_, *b1);
   *b1 *= -1.0;
 
-  _sources.ApplySources(b1);
+  _sources.ApplyKernels(b1);
 
   mfem::ParGridFunction J_gf(HCurlFESpace_);
   mfem::Array<int> ess_tdof_list;

--- a/src/hephaestus_lib/hcurl_solver.hpp
+++ b/src/hephaestus_lib/hcurl_solver.hpp
@@ -66,20 +66,16 @@ protected:
   hephaestus::DomainProperties _domain_properties;
   hephaestus::InputParameters _solver_options;
 
-  mfem::ParBilinearForm *a0, *a1, *m1;
-  mfem::HypreParMatrix *A0, *A1;
-  mfem::Vector *X0, *X1, *B0, *B1;
+  mfem::ParBilinearForm *a1;
+  mfem::HypreParMatrix *A1;
+  mfem::Vector *X1, *B1;
 
-  mfem::ParDiscreteLinearOperator *grad;
   mfem::ParDiscreteLinearOperator *curl;
   mfem::ParBilinearForm *curlCurl;
-  mutable mfem::HypreSolver *amg_a0;
-  mutable mfem::HyprePCG *pcg_a0;
-  mutable hephaestus::DefaultH1PCGSolver *a0_solver;
   mutable hephaestus::DefaultHCurlPCGSolver *a1_solver;
 
   // temporary work vectors
-  mfem::ParLinearForm *b0, *b1;
+  mfem::ParLinearForm *b1;
 
   double dt_A1;
   mfem::ConstantCoefficient dtCoef;  // Coefficient for timestep scaling

--- a/src/hephaestus_lib/hcurl_solver.hpp
+++ b/src/hephaestus_lib/hcurl_solver.hpp
@@ -48,10 +48,10 @@ public:
 
   double ElectricLosses() const;
 
-  std::string u_name, p_name;
-  std::string u_display_name, p_display_name;
+  std::string u_name;
+  std::string u_display_name;
   mfem::ParGridFunction u_, du_; // HCurl vector field
-  mfem::ParGridFunction p_, dp_; // H1 scalar potential
+  mfem::ParGridFunction p_;      // H1 scalar potential
   mfem::ParGridFunction curl_u_; // HDiv Magnetic Flux Density
   std::map<std::string, mfem::socketstream *> socks_;
 

--- a/src/hephaestus_lib/hform_solver.cpp
+++ b/src/hephaestus_lib/hform_solver.cpp
@@ -12,14 +12,10 @@ HFormSolver::HFormSolver(
                   sources, solver_options) {}
 
 void HFormSolver::RegisterVariables() {
-  p_name = "magnetic_potential";
-  p_display_name = "Scalar Potential (V)";
-
   u_name = "magnetic_field";
   u_display_name = "Magnetic Field (H)";
 
   _variables.Register(u_name, &u_, false);
-  _variables.Register(p_name, &p_, false);
   _variables.Register("current_density", &curl_u_, false);
 }
 

--- a/src/hephaestus_lib/hj_dual_solver.cpp
+++ b/src/hephaestus_lib/hj_dual_solver.cpp
@@ -12,9 +12,6 @@ HJDualSolver::HJDualSolver(
                  sources, solver_options) {}
 
 void HJDualSolver::RegisterVariables() {
-  p_name = "magnetic_potential";
-  p_display_name = "Scalar Potential (V)";
-
   u_name = "magnetic_field";
   u_display_name = "Magnetic Field (H)";
 
@@ -23,7 +20,6 @@ void HJDualSolver::RegisterVariables() {
 
   _variables.Register(u_name, &u_, false);
   _variables.Register(v_name, &v_, false);
-  _variables.Register(p_name, &p_, false);
 }
 
 void HJDualSolver::SetMaterialCoefficients(

--- a/src/hephaestus_lib/inputs.hpp
+++ b/src/hephaestus_lib/inputs.hpp
@@ -41,6 +41,7 @@ public:
       std::cout << "Exception raised when trying to cast required parameter "
                 << param_name << '\n';
       std::cout << e.what() << '\n';
+      exit;
     }
     return param;
   };

--- a/src/hephaestus_lib/sources.cpp
+++ b/src/hephaestus_lib/sources.cpp
@@ -5,9 +5,10 @@ namespace hephaestus {
 void Sources::Init(
     mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
     const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
+    hephaestus::BCMap &bc_map,
     hephaestus::DomainProperties &domain_properties) {
   for (const auto &[name, source] : GetMap()) {
-    source->Init(variables, fespaces, domain_properties);
+    source->Init(variables, fespaces, bc_map, domain_properties);
   }
 }
 void Sources::ApplySources(mfem::ParLinearForm *lf) {
@@ -15,6 +16,97 @@ void Sources::ApplySources(mfem::ParLinearForm *lf) {
     source->ApplySource(lf);
   }
 }
+
+// Create a scalar potential source that can add terms of the form
+// J0_{n+1} ∈ H(div) source field, where J0 = -β∇p and β is a conductivity
+// coefficient.
+ScalarPotentialSource::ScalarPotentialSource(
+    const hephaestus::InputParameters &params)
+    : src_gf_name(params.GetParam<std::string>("SourceName")),
+      potential_gf_name(params.GetParam<std::string>("PotentialName")),
+      hcurl_fespace_name(params.GetParam<std::string>("HCurlFESpaceName")),
+      h1_fespace_name(params.GetParam<std::string>("H1FESpaceName")),
+      beta_coef_name(params.GetParam<std::string>("ConductivityCoefName")),
+      solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+          "SolverOptions", hephaestus::InputParameters())) {}
+
+void ScalarPotentialSource::Init(
+    mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
+    const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
+    hephaestus::BCMap &bc_map,
+    hephaestus::DomainProperties &domain_properties) {
+  H1FESpace_ = fespaces.Get(h1_fespace_name);
+  HCurlFESpace_ = fespaces.Get(hcurl_fespace_name);
+  p_ = variables.Get(potential_gf_name);
+  _bc_map = &bc_map;
+
+  betaCoef = domain_properties.scalar_property_map["beta_coef_name"];
+
+  this->buildGrad();
+  this->buildM1(betaCoef);
+  // a0(p, p') = (β ∇ p, ∇ p')
+  a0 = new mfem::ParBilinearForm(H1FESpace_);
+  a0->AddDomainIntegrator(new mfem::DiffusionIntegrator(*betaCoef));
+  a0->Assemble();
+  b0 = new mfem::ParLinearForm(H1FESpace_);
+  grad_p_ = new mfem::ParGridFunction(HCurlFESpace_);
+  variables.Register(src_gf_name, grad_p_, false);
+}
+
+void ScalarPotentialSource::buildM1(mfem::Coefficient *Sigma) {
+  if (m1 != NULL) {
+    delete m1;
+  }
+
+  m1 = new mfem::ParBilinearForm(HCurlFESpace_);
+  m1->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*Sigma));
+  m1->Assemble();
+
+  // Don't finalize or parallel assemble this is done in FormLinearSystem.
+}
+
+void ScalarPotentialSource::buildGrad() {
+  if (grad != NULL) {
+    delete grad;
+  }
+
+  grad = new mfem::ParDiscreteLinearOperator(H1FESpace_, HCurlFESpace_);
+  grad->AddDomainInterpolator(new mfem::GradientInterpolator());
+  grad->Assemble();
+
+  // no ParallelAssemble since this will be applied to GridFunctions
+}
+
+void ScalarPotentialSource::ApplySource(mfem::ParLinearForm *lf) {
+
+  mfem::ParGridFunction Phi_gf(H1FESpace_);
+  mfem::Array<int> poisson_ess_tdof_list;
+  Phi_gf = 0.0;
+  *b0 = 0.0;
+  _bc_map->applyEssentialBCs(potential_gf_name, poisson_ess_tdof_list, Phi_gf,
+                             (H1FESpace_->GetParMesh()));
+  _bc_map->applyIntegratedBCs(potential_gf_name, *b0,
+                              (H1FESpace_->GetParMesh()));
+  b0->Assemble();
+  a0->FormLinearSystem(poisson_ess_tdof_list, Phi_gf, *b0, *A0, *X0, *B0);
+
+  if (a0_solver == NULL) {
+    hephaestus::InputParameters h1_solver_options;
+    h1_solver_options.SetParam("Tolerance", float(1.0e-9));
+    h1_solver_options.SetParam("MaxIter", (unsigned int)1000);
+    h1_solver_options.SetParam("PrintLevel", -1);
+    a0_solver = new hephaestus::DefaultH1PCGSolver(h1_solver_options, *A0);
+  }
+  // Solve
+  a0_solver->Mult(*B0, *X0);
+
+  // "undo" the static condensation saving result in grid function dP
+  a0->RecoverFEMSolution(*X0, *b0, *p_);
+
+  grad->Mult(*p_, *grad_p_);
+  m1->AddMult(*grad_p_, *lf, 1.0);
+}
+
 DivFreeVolumetricSource::DivFreeVolumetricSource(
     const hephaestus::InputParameters &params)
     : src_coef_name(params.GetParam<std::string>("SourceName")),
@@ -27,6 +119,7 @@ DivFreeVolumetricSource::DivFreeVolumetricSource(
 void DivFreeVolumetricSource::Init(
     mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
     const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
+    hephaestus::BCMap &bc_map,
     hephaestus::DomainProperties &domain_properties) {
   H1FESpace_ = fespaces.Get(h1_fespace_name);
   HCurlFESpace_ = fespaces.Get(hcurl_fespace_name);

--- a/src/hephaestus_lib/sources.cpp
+++ b/src/hephaestus_lib/sources.cpp
@@ -38,7 +38,11 @@ void ScalarPotentialSource::Init(
     hephaestus::DomainProperties &domain_properties) {
   H1FESpace_ = fespaces.Get(h1_fespace_name);
   HCurlFESpace_ = fespaces.Get(hcurl_fespace_name);
+
+  p_ = new mfem::ParGridFunction(H1FESpace_);
+  variables.Register(potential_gf_name, p_, false);
   p_ = variables.Get(potential_gf_name);
+
   _bc_map = &bc_map;
 
   betaCoef = domain_properties.scalar_property_map[beta_coef_name];

--- a/src/hephaestus_lib/sources.cpp
+++ b/src/hephaestus_lib/sources.cpp
@@ -189,6 +189,7 @@ void DivFreeVolumetricSource::ApplyKernel(mfem::ParLinearForm *lf) {
 
     h_curl_mass->RecoverFEMSolution(X, J, j);
   }
+  h_curl_mass->Update();
   h_curl_mass->Assemble();
   h_curl_mass->Finalize();
   *div_free_src_gf = 0.0;

--- a/src/hephaestus_lib/sources.hpp
+++ b/src/hephaestus_lib/sources.hpp
@@ -14,7 +14,8 @@ public:
        const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
        hephaestus::BCMap &bc_map,
        hephaestus::DomainProperties &domain_properties){};
-  virtual void ApplySource(mfem::ParLinearForm *lf){};
+  virtual void ApplyKernel(mfem::ParLinearForm *lf){};
+  virtual void SubtractSource(mfem::ParGridFunction *gf){};
 };
 
 class Sources : public mfem::NamedFieldsMap<hephaestus::Source> {
@@ -23,7 +24,8 @@ public:
             const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
             hephaestus::BCMap &bc_map,
             hephaestus::DomainProperties &domain_properties);
-  void ApplySources(mfem::ParLinearForm *lf);
+  void ApplyKernels(mfem::ParLinearForm *lf);
+  void SubtractSources(mfem::ParGridFunction *gf);
 };
 
 class ScalarPotentialSource : public hephaestus::Source {
@@ -33,7 +35,8 @@ public:
             const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
             hephaestus::BCMap &bc_map,
             hephaestus::DomainProperties &domain_properties) override;
-  void ApplySource(mfem::ParLinearForm *lf) override;
+  void ApplyKernel(mfem::ParLinearForm *lf) override;
+  void SubtractSource(mfem::ParGridFunction *gf) override;
   void buildM1(mfem::Coefficient *Sigma);
   void buildGrad();
 
@@ -76,7 +79,8 @@ public:
             const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
             hephaestus::BCMap &bc_map,
             hephaestus::DomainProperties &domain_properties) override;
-  void ApplySource(mfem::ParLinearForm *lf) override;
+  void ApplyKernel(mfem::ParLinearForm *lf) override;
+  void SubtractSource(mfem::ParGridFunction *gf) override;
 
   std::string src_gf_name;
   std::string src_coef_name;
@@ -86,6 +90,9 @@ public:
   mfem::VectorCoefficient *sourceVecCoef;
   mfem::ParGridFunction *div_free_src_gf; // Source field
   mfem::common::DivergenceFreeProjector *divFreeProj;
+  mfem::VectorFEMassIntegrator *h_curl_mass_integ;
+  mfem::ParBilinearForm *h_curl_mass;
+
   mfem::ParFiniteElementSpace *H1FESpace_;
   mfem::ParFiniteElementSpace *HCurlFESpace_;
   mfem::Solver *solver;

--- a/src/hephaestus_lib/sources.hpp
+++ b/src/hephaestus_lib/sources.hpp
@@ -12,6 +12,7 @@ public:
   virtual void
   Init(mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
        const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
+       hephaestus::BCMap &bc_map,
        hephaestus::DomainProperties &domain_properties){};
   virtual void ApplySource(mfem::ParLinearForm *lf){};
 };
@@ -20,8 +21,52 @@ class Sources : public mfem::NamedFieldsMap<hephaestus::Source> {
 public:
   void Init(mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
             const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
+            hephaestus::BCMap &bc_map,
             hephaestus::DomainProperties &domain_properties);
   void ApplySources(mfem::ParLinearForm *lf);
+};
+
+class ScalarPotentialSource : public hephaestus::Source {
+public:
+  ScalarPotentialSource(const hephaestus::InputParameters &params);
+  void Init(mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
+            const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
+            hephaestus::BCMap &bc_map,
+            hephaestus::DomainProperties &domain_properties) override;
+  void ApplySource(mfem::ParLinearForm *lf) override;
+  void buildM1(mfem::Coefficient *Sigma);
+  void buildGrad();
+
+  std::string src_gf_name;
+  std::string potential_gf_name;
+  std::string hcurl_fespace_name;
+  std::string h1_fespace_name;
+  std::string beta_coef_name;
+  const hephaestus::InputParameters solver_options;
+
+  mfem::ParFiniteElementSpace *H1FESpace_;
+  mfem::ParFiniteElementSpace *HCurlFESpace_;
+  mfem::ParGridFunction *p_; // Potential
+  hephaestus::BCMap *_bc_map;
+  mfem::Coefficient *betaCoef;
+
+  mfem::ParBilinearForm *a0;
+  mfem::ParBilinearForm *m1;
+  mfem::HypreParMatrix *A0;
+  mfem::Vector *X0, *B0;
+  mutable mfem::HypreSolver *amg_a0;
+  mutable hephaestus::DefaultH1PCGSolver *a0_solver;
+
+  mfem::ParDiscreteLinearOperator *grad;
+
+  mfem::ParLinearForm *b0;
+  mfem::ParGridFunction *grad_p_;
+
+  mfem::VectorCoefficient *sourceVecCoef;
+  mfem::ParGridFunction *div_free_src_gf; // Source field
+  mfem::common::DivergenceFreeProjector *divFreeProj;
+
+  mfem::Solver *solver;
 };
 
 class DivFreeVolumetricSource : public hephaestus::Source {
@@ -29,6 +74,7 @@ public:
   DivFreeVolumetricSource(const hephaestus::InputParameters &params);
   void Init(mfem::NamedFieldsMap<mfem::ParGridFunction> &variables,
             const mfem::NamedFieldsMap<mfem::ParFiniteElementSpace> &fespaces,
+            hephaestus::BCMap &bc_map,
             hephaestus::DomainProperties &domain_properties) override;
   void ApplySource(mfem::ParLinearForm *lf) override;
 

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -146,7 +146,7 @@ protected:
     exec_params.SetParam("StartTime", float(0.0));
     exec_params.SetParam("EndTime", float(2.5));
     exec_params.SetParam("VisualisationSteps", int(1));
-    exec_params.SetParam("UseGLVis", false);
+    exec_params.SetParam("UseGLVis", true);
     hephaestus::TransientExecutioner *executioner =
         new hephaestus::TransientExecutioner(exec_params);
 
@@ -172,6 +172,27 @@ protected:
 
     hephaestus::Postprocessors postprocessors;
     hephaestus::Sources sources;
+    hephaestus::InputParameters scalar_potential_source_params;
+    scalar_potential_source_params.SetParam("SourceName",
+                                            std::string("source"));
+    scalar_potential_source_params.SetParam("PotentialName",
+                                            std::string("electric_potential"));
+    scalar_potential_source_params.SetParam("HCurlFESpaceName",
+                                            std::string("_HCurlFESpace"));
+    scalar_potential_source_params.SetParam("H1FESpaceName",
+                                            std::string("_H1FESpace"));
+    scalar_potential_source_params.SetParam(
+        "ConductivityCoefName", std::string("electrical_conductivity"));
+    hephaestus::InputParameters current_solver_options;
+    current_solver_options.SetParam("Tolerance", float(1.0e-9));
+    current_solver_options.SetParam("MaxIter", (unsigned int)1000);
+    current_solver_options.SetParam("PrintLevel", -1);
+    scalar_potential_source_params.SetParam("SolverOptions",
+                                            current_solver_options);
+    sources.Register(
+        "source",
+        new hephaestus::ScalarPotentialSource(scalar_potential_source_params),
+        true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-9));

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -72,7 +72,7 @@ protected:
     exec_params.SetParam("StartTime", float(0.0));
     exec_params.SetParam("EndTime", float(2.5));
     exec_params.SetParam("VisualisationSteps", int(1));
-    exec_params.SetParam("UseGLVis", false);
+    exec_params.SetParam("UseGLVis", true);
     hephaestus::TransientExecutioner *executioner =
         new hephaestus::TransientExecutioner(exec_params);
 
@@ -91,6 +91,27 @@ protected:
     hephaestus::AuxKernels auxkernels;
     hephaestus::Postprocessors postprocessors;
     hephaestus::Sources sources;
+    hephaestus::InputParameters scalar_potential_source_params;
+    scalar_potential_source_params.SetParam("SourceName",
+                                            std::string("source"));
+    scalar_potential_source_params.SetParam("PotentialName",
+                                            std::string("electric_potential"));
+    scalar_potential_source_params.SetParam("HCurlFESpaceName",
+                                            std::string("_HCurlFESpace"));
+    scalar_potential_source_params.SetParam("H1FESpaceName",
+                                            std::string("_H1FESpace"));
+    scalar_potential_source_params.SetParam(
+        "ConductivityCoefName", std::string("electrical_conductivity"));
+    hephaestus::InputParameters current_solver_options;
+    current_solver_options.SetParam("Tolerance", float(1.0e-9));
+    current_solver_options.SetParam("MaxIter", (unsigned int)1000);
+    current_solver_options.SetParam("PrintLevel", -1);
+    scalar_potential_source_params.SetParam("SolverOptions",
+                                            current_solver_options);
+    sources.Register(
+        "source",
+        new hephaestus::ScalarPotentialSource(scalar_potential_source_params),
+        true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-9));

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -70,7 +70,7 @@ protected:
     exec_params.SetParam("StartTime", float(0.0));
     exec_params.SetParam("EndTime", float(2.5));
     exec_params.SetParam("VisualisationSteps", int(1));
-    exec_params.SetParam("UseGLVis", false);
+    exec_params.SetParam("UseGLVis", true);
     hephaestus::TransientExecutioner *executioner =
         new hephaestus::TransientExecutioner(exec_params);
 

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -94,6 +94,27 @@ protected:
     hephaestus::AuxKernels auxkernels;
     hephaestus::Postprocessors postprocessors;
     hephaestus::Sources sources;
+    hephaestus::InputParameters scalar_potential_source_params;
+    scalar_potential_source_params.SetParam("SourceName",
+                                            std::string("source"));
+    scalar_potential_source_params.SetParam("PotentialName",
+                                            std::string("magnetic_potential"));
+    scalar_potential_source_params.SetParam("HCurlFESpaceName",
+                                            std::string("_HCurlFESpace"));
+    scalar_potential_source_params.SetParam("H1FESpaceName",
+                                            std::string("_H1FESpace"));
+    scalar_potential_source_params.SetParam(
+        "ConductivityCoefName", std::string("magnetic_permeability"));
+    hephaestus::InputParameters current_solver_options;
+    current_solver_options.SetParam("Tolerance", float(1.0e-12));
+    current_solver_options.SetParam("MaxIter", (unsigned int)200);
+    current_solver_options.SetParam("PrintLevel", 0);
+    scalar_potential_source_params.SetParam("SolverOptions",
+                                            current_solver_options);
+    sources.Register(
+        "source",
+        new hephaestus::ScalarPotentialSource(scalar_potential_source_params),
+        true);
 
     hephaestus::InputParameters params;
     params.SetParam("Mesh", mfem::ParMesh(MPI_COMM_WORLD, mesh));

--- a/test/integration/test_hjform_rod.cpp
+++ b/test/integration/test_hjform_rod.cpp
@@ -72,7 +72,7 @@ protected:
     exec_params.SetParam("StartTime", float(0.0));
     exec_params.SetParam("EndTime", float(2.5));
     exec_params.SetParam("VisualisationSteps", int(1));
-    exec_params.SetParam("UseGLVis", false);
+    exec_params.SetParam("UseGLVis", true);
     hephaestus::TransientExecutioner *executioner =
         new hephaestus::TransientExecutioner(exec_params);
 
@@ -91,6 +91,27 @@ protected:
     hephaestus::AuxKernels auxkernels;
     hephaestus::Postprocessors postprocessors;
     hephaestus::Sources sources;
+    hephaestus::InputParameters scalar_potential_source_params;
+    scalar_potential_source_params.SetParam("SourceName",
+                                            std::string("source"));
+    scalar_potential_source_params.SetParam("PotentialName",
+                                            std::string("magnetic_potential"));
+    scalar_potential_source_params.SetParam("HCurlFESpaceName",
+                                            std::string("_HCurlFESpace"));
+    scalar_potential_source_params.SetParam("H1FESpaceName",
+                                            std::string("_H1FESpace"));
+    scalar_potential_source_params.SetParam(
+        "ConductivityCoefName", std::string("magnetic_permeability"));
+    hephaestus::InputParameters current_solver_options;
+    current_solver_options.SetParam("Tolerance", float(1.0e-9));
+    current_solver_options.SetParam("MaxIter", (unsigned int)1000);
+    current_solver_options.SetParam("PrintLevel", -1);
+    scalar_potential_source_params.SetParam("SolverOptions",
+                                            current_solver_options);
+    sources.Register(
+        "source",
+        new hephaestus::ScalarPotentialSource(scalar_potential_source_params),
+        true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-9));


### PR DESCRIPTION
Adds the `ScalarPotentialSource` to replace the potential calculation in `dual_solver` and `hcurl_solver` used to provide a source term for linear forms.

Calculation of the potential in these formulations will now only be performed as necessary, if a `ScalarPotentialSource` is used.