### PR TITLE
Update base image for hephaestus Docker build

### DIFF
--- a/docker/hephaestus/Dockerfile
+++ b/docker/hephaestus/Dockerfile
@@ -1,6 +1,6 @@
 # Build Hephaestus image
 # Get base image
-FROM alexanderianblair/hephaestus-deps:latest
+FROM alexanderianblair/hephaestus-deps:master
 
 # By default checkout master branch
 ARG WORKDIR="opt"


### PR DESCRIPTION
Base image for the Docker build of hephaestus was pointing to an outdated build of hephaestus-deps, rather than the copy rebuilt weekly in the CI. This PR fixes that.