### PR TITLE
Add variable names to formulation inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,45 @@
 # Hephaestus
+Hephaestus is an MFEM-based library, created to provide access to a range of finite element electromagnetics formulations and scalable solvers for large-scale engineering analysis on complex geometries.
 
-This project is intended to provide an interface to a selection of MFEM based electromagnetics
-solvers. Hephaestus is still under active development and is being updated frequently.
-# How to use this repository
+Hephaestus depends on the [MFEM](https://mfem.org/) finite element library, and is used in the [MOOSE](https://github.com/idaholab/moose) application [Apollo](https://github.com/aurora-multiphysics/apollo) to enable coupling between MOOSE-based multiphysics simulations and MFEM-based electromagnetic solves, with flexibility in the choice of electromagnetic formulation.
 
-1. Fork this repository using the `fork` button on the front page
-2. Remove the fork relationship: `Settings > General > Advanced > Remove fork relationship`
-3. Rename your repository to align with your project: `Settings > General > Advanced > Rename repository`
-4. Clone the repository with `git clone --recursive <your-project-url-here>.git`
-5. Run `bash rename.sh <your-project-name>`
-6. (Optionally open the project in VS Code)
-7. Start writing your software!
+Hephaestus is still under active development and is being updated frequently.
+# Getting started
+Docker images of Hephaestus for Ubuntu with all dependencies are built weekly and uploaded to DockerHub, and
+can be downloaded via
+```
+docker pull alexanderianblair/hephaestus:master
+```
+Once downloaded, the image can be run in interactive mode with the command
+```
+docker run -it alexanderianblair/hephaestus:master
+```
+Additional information and options for using Docker can be found at this [tutorial](https://docs.docker.com/get-started/) on the Docker website.
 
+Alternatively, up-to-date images of only the current dependencies for Hephaestus can be downloaded from
+```
+docker pull alexanderianblair/hephaestus-deps:master
+```
+for those who with to build Hephaestus themselves.
+
+Dockerfiles used to build these images can be found in the `hephaestus/docker` directory.
 # Building software and tests
-Hephaestus can be built with the following commands from the top level project directory:
+Hephaestus can be built with the following commands from the top level `hephaestus` directory in either of the above containers:
 
     mkdir build
     cd build
-    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/opt/mfem/build/directory -DMFEM_COMMON_INCLUDES=/opt/mfem/miniapps/common ..
     make
     make test
 
-(Or equivalently, you can use `cmake --build .` instead of `make`, and `ctest` instead of `make test`.)
-
+Running `make test` after `hephaestus` is built will run the entire set of tests found in `hephaestus/test`. Running a specific test is possible by providing the `--gtest_filter` flag when running the corresponding test executable; for example:
+```
+/opt/hephaestus/bin/integration_tests --gtest_filter=TestAFormSource
+```
+# Examples
+In addition to the set of tests in `hephaestus/test`, longer running examples of Hephaestus being used can be found in `hephaestus/examples`, with associated executables found in `hephaestus/examples/bin`.
+```
+ mpirun -n 4 -genv OMP_NUM_THREADS=1 /opt/hephaestus/examples/bin/team7
+```
+# Related Projects
+Hephaestus is used extensively by the MOOSE application [Apollo](https://github.com/aurora-multiphysics/apollo). More information can be found on the Apollo GitHub pages.

--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -122,7 +122,9 @@ int main(int argc, char *argv[]) {
 
   // Create Formulation
   hephaestus::FrequencyDomainProblemBuilder *problem_builder =
-      new hephaestus::ComplexAFormulation();
+      new hephaestus::ComplexAFormulation(
+          "magnetic_reluctivity", "electrical_conductivity",
+          "dielectric_permittivity", "frequency", "magnetic_vector_potential");
   // Set Mesh
   mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./team7.g")).c_str(), 1,
                   1);

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -120,7 +120,9 @@ int main(int argc, char *argv[]) {
 
   // Create Formulation
   hephaestus::TimeDomainProblemBuilder *problem_builder =
-      new hephaestus::AFormulation();
+      new hephaestus::AFormulation(
+          "magnetic_reluctivity", "magnetic_permeability",
+          "electrical_conductivity", "magnetic_vector_potential");
   // Set Mesh
   mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./team7.g")).c_str(), 1,
                   1);

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -5,21 +5,38 @@ namespace hephaestus {
 hephaestus::ProblemBuilder *
 Factory::createProblemBuilder(std::string &formulation_name) {
   if (formulation_name == "EBForm") {
-    return new hephaestus::EBDualFormulation();
+    return new hephaestus::EBDualFormulation(
+        "magnetic_reluctivity", "magnetic_permeability",
+        "electrical_conductivity", "electric_field", "magnetic_flux_density");
   } else if (formulation_name == "HJForm") {
-    return new hephaestus::HJDualFormulation();
+    return new hephaestus::HJDualFormulation(
+        "electrical_resistivity", "electrical_conductivity",
+        "magnetic_permeability", "magnetic_field", "current_density");
   } else if (formulation_name == "HForm") {
-    return new hephaestus::HFormulation();
+    return new hephaestus::HFormulation(
+        "electrical_resistivity", "electrical_conductivity",
+        "magnetic_permeability", "magnetic_field");
   } else if (formulation_name == "AForm") {
-    return new hephaestus::AFormulation();
+    return new hephaestus::AFormulation(
+        "magnetic_reluctivity", "magnetic_permeability",
+        "electrical_conductivity", "magnetic_vector_potential");
   } else if (formulation_name == "EForm") {
-    return new hephaestus::EFormulation();
+    return new hephaestus::EFormulation(
+        "magnetic_reluctivity", "magnetic_permeability",
+        "electrical_conductivity", "electric_field");
   } else if (formulation_name == "AVForm") {
-    return new hephaestus::AVFormulation();
+    return new hephaestus::AVFormulation(
+        "magnetic_reluctivity", "magnetic_permeability",
+        "electrical_conductivity", "magnetic_vector_potential",
+        "electric_potential");
   } else if (formulation_name == "ComplexEForm") {
-    return new hephaestus::ComplexEFormulation();
+    return new hephaestus::ComplexEFormulation(
+        "magnetic_reluctivity", "electrical_conductivity",
+        "dielectric_permittivity", "frequency", "electric_field");
   } else if (formulation_name == "ComplexAForm") {
-    return new hephaestus::ComplexAFormulation();
+    return new hephaestus::ComplexAFormulation(
+        "magnetic_reluctivity", "electrical_conductivity",
+        "dielectric_permittivity", "frequency", "magnetic_vector_potential");
   } else if (formulation_name == "Custom") {
     return new hephaestus::TimeDomainFormulation();
   } else {
@@ -31,9 +48,13 @@ Factory::createProblemBuilder(std::string &formulation_name) {
 hephaestus::FrequencyDomainFormulation *
 Factory::createFrequencyDomainFormulation(std::string &formulation) {
   if (formulation == "ComplexEForm") {
-    return new hephaestus::ComplexEFormulation();
+    return new hephaestus::ComplexEFormulation(
+        "magnetic_reluctivity", "electrical_conductivity",
+        "dielectric_permittivity", "frequency", "electric_field");
   } else if (formulation == "ComplexAForm") {
-    return new hephaestus::ComplexAFormulation();
+    return new hephaestus::ComplexAFormulation(
+        "magnetic_reluctivity", "electrical_conductivity",
+        "dielectric_permittivity", "frequency", "magnetic_vector_potential");
   } else {
     MFEM_WARNING("Steady formulation name " << formulation
                                             << " not recognised.");
@@ -44,17 +65,30 @@ Factory::createFrequencyDomainFormulation(std::string &formulation) {
 hephaestus::TimeDomainFormulation *
 Factory::createTimeDomainFormulation(std::string &formulation) {
   if (formulation == "EBForm") {
-    return new hephaestus::EBDualFormulation();
+    return new hephaestus::EBDualFormulation(
+        "magnetic_reluctivity", "magnetic_permeability",
+        "electrical_conductivity", "electric_field", "magnetic_flux_density");
   } else if (formulation == "HJForm") {
-    return new hephaestus::HJDualFormulation();
+    return new hephaestus::HJDualFormulation(
+        "electrical_resistivity", "electrical_conductivity",
+        "magnetic_permeability", "magnetic_field", "current_density");
   } else if (formulation == "HForm") {
-    return new hephaestus::HFormulation();
+    return new hephaestus::HFormulation(
+        "electrical_resistivity", "electrical_conductivity",
+        "magnetic_permeability", "magnetic_field");
   } else if (formulation == "AForm") {
-    return new hephaestus::AFormulation();
+    return new hephaestus::AFormulation(
+        "magnetic_reluctivity", "magnetic_permeability",
+        "electrical_conductivity", "magnetic_vector_potential");
   } else if (formulation == "EForm") {
-    return new hephaestus::EFormulation();
+    return new hephaestus::EFormulation(
+        "magnetic_reluctivity", "magnetic_permeability",
+        "electrical_conductivity", "electric_field");
   } else if (formulation == "AVForm") {
-    return new hephaestus::AVFormulation();
+    return new hephaestus::AVFormulation(
+        "magnetic_reluctivity", "magnetic_permeability",
+        "electrical_conductivity", "magnetic_vector_potential",
+        "electric_potential");
   } else if (formulation == "Custom") {
     return new hephaestus::TimeDomainFormulation();
   } else {

--- a/src/formulations/AV/av_formulation.hpp
+++ b/src/formulations/AV/av_formulation.hpp
@@ -7,11 +7,12 @@
 namespace hephaestus {
 
 class AVFormulation : public TimeDomainFormulation {
-  std::string vector_potential_name, scalar_potential_name, alpha_coef_name,
-      beta_coef_name;
-
 public:
-  AVFormulation();
+  AVFormulation(const std::string &alpha_coef_name,
+                const std::string &inv_alpha_coef_name,
+                const std::string &beta_coef_name,
+                const std::string &vector_potential_name,
+                const std::string &scalar_potential_name);
 
   virtual void ConstructEquationSystem() override;
 
@@ -20,6 +21,13 @@ public:
   virtual void RegisterGridFunctions() override;
 
   virtual void RegisterCoefficients() override;
+
+protected:
+  const std::string _alpha_coef_name;
+  const std::string _inv_alpha_coef_name;
+  const std::string _beta_coef_name;
+  const std::string _vector_potential_name;
+  const std::string _scalar_potential_name;
 };
 
 class AVEquationSystem : public TimeDependentEquationSystem {

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
@@ -2,14 +2,16 @@
 
 namespace hephaestus {
 
-ComplexAFormulation::ComplexAFormulation() : ComplexMaxwellFormulation() {
-  frequency_coef_name = std::string("frequency");
-  h_curl_var_name = std::string("magnetic_vector_potential");
-
-  alpha_coef_name = std::string("magnetic_reluctivity");
-  beta_coef_name = std::string("electrical_conductivity");
-  zeta_coef_name = std::string("dielectric_permittivity");
-};
+ComplexAFormulation::ComplexAFormulation(
+    const std::string &magnetic_reluctivity_name,
+    const std::string &electric_conductivity_name,
+    const std::string &dielectric_permittivity_name,
+    const std::string &frequency_coef_name,
+    const std::string &magnetic_vector_potential_name)
+    : ComplexMaxwellFormulation(
+          magnetic_reluctivity_name, electric_conductivity_name,
+          dielectric_permittivity_name, frequency_coef_name,
+          magnetic_vector_potential_name){};
 
 void ComplexAFormulation::RegisterAuxSolvers() {
   hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
@@ -23,13 +25,13 @@ void ComplexAFormulation::RegisterAuxSolvers() {
               << " found in gridfunctions: building auxvar " << std::endl;
     // }
     hephaestus::InputParameters b_field_aux_params;
-    b_field_aux_params.SetParam("VariableName", h_curl_var_name + "_real");
+    b_field_aux_params.SetParam("VariableName", _h_curl_var_name + "_real");
     b_field_aux_params.SetParam("CurlVariableName", b_field_name + "_real");
     auxsolvers.Register("_magnetic_flux_density_re_aux",
                         new hephaestus::CurlAuxSolver(b_field_aux_params),
                         true);
 
-    b_field_aux_params.SetParam("VariableName", h_curl_var_name + "_imag");
+    b_field_aux_params.SetParam("VariableName", _h_curl_var_name + "_imag");
     b_field_aux_params.SetParam("CurlVariableName", b_field_name + "_imag");
     auxsolvers.Register("_magnetic_flux_density_im_aux",
                         new hephaestus::CurlAuxSolver(b_field_aux_params),
@@ -46,14 +48,16 @@ void ComplexAFormulation::RegisterAuxSolvers() {
     hephaestus::InputParameters e_field_aux_params;
     e_field_aux_params.SetParam("CoefficientName",
                                 std::string("_neg_angular_frequency"));
-    e_field_aux_params.SetParam("InputVariableName", h_curl_var_name + "_real");
+    e_field_aux_params.SetParam("InputVariableName",
+                                _h_curl_var_name + "_real");
     e_field_aux_params.SetParam("ScaledVariableName", e_field_name + "_imag");
     auxsolvers.Register(
         "_electric_field_re_aux",
         new hephaestus::ScaledGridFunctionAuxSolver(e_field_aux_params), true);
     e_field_aux_params.SetParam("CoefficientName",
                                 std::string("_angular_frequency"));
-    e_field_aux_params.SetParam("InputVariableName", h_curl_var_name + "_imag");
+    e_field_aux_params.SetParam("InputVariableName",
+                                _h_curl_var_name + "_imag");
     e_field_aux_params.SetParam("ScaledVariableName", e_field_name + "_real");
     auxsolvers.Register(
         "_electric_field_im_aux",

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
@@ -27,7 +27,11 @@ should be performed on J before use in this operator.
 class ComplexAFormulation : public hephaestus::ComplexMaxwellFormulation {
 
 public:
-  ComplexAFormulation();
+  ComplexAFormulation(const std::string &magnetic_reluctivity_name,
+                      const std::string &electric_conductivity_name,
+                      const std::string &dielectric_permittivity_name,
+                      const std::string &frequency_coef_name,
+                      const std::string &magnetic_vector_potential_name);
 
   virtual void RegisterAuxSolvers() override;
 };

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -2,13 +2,13 @@
 
 namespace hephaestus {
 
-ComplexEFormulation::ComplexEFormulation()
-    : hephaestus::ComplexMaxwellFormulation() {
-  h_curl_var_name = std::string("electric_field");
-
-  alpha_coef_name = std::string("magnetic_reluctivity");
-  beta_coef_name = std::string("electrical_conductivity");
-  zeta_coef_name = std::string("dielectric_permittivity");
-};
+ComplexEFormulation::ComplexEFormulation(
+    const std::string &magnetic_reluctivity_name,
+    const std::string &electric_conductivity_name,
+    const std::string &dielectric_permittivity_name,
+    const std::string &frequency_coef_name, const std::string &e_field_name)
+    : hephaestus::ComplexMaxwellFormulation(
+          magnetic_reluctivity_name, electric_conductivity_name,
+          dielectric_permittivity_name, frequency_coef_name, e_field_name){};
 
 } // namespace hephaestus

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
@@ -26,6 +26,10 @@ should be performed on J꜀ᵉ before use in this operator.
 */
 class ComplexEFormulation : public hephaestus::ComplexMaxwellFormulation {
 public:
-  ComplexEFormulation();
+  ComplexEFormulation(const std::string &magnetic_reluctivity_name,
+                      const std::string &electric_conductivity_name,
+                      const std::string &dielectric_permittivity_name,
+                      const std::string &frequency_coef_name,
+                      const std::string &e_field_name);
 };
 } // namespace hephaestus

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
@@ -62,11 +62,20 @@ class ComplexMaxwellFormulation
     : public hephaestus::FrequencyDomainFormulation {
   // std::vector<mfem::ParGridFunction *> local_trial_vars, local_test_vars;
 protected:
-  std::string frequency_coef_name, h_curl_var_name, alpha_coef_name,
-      beta_coef_name, zeta_coef_name, mass_coef_name, loss_coef_name;
+  const std::string _alpha_coef_name;
+  const std::string _beta_coef_name;
+  const std::string _zeta_coef_name;
+  const std::string _frequency_coef_name;
+  const std::string _h_curl_var_name;
+  const std::string _mass_coef_name;
+  const std::string _loss_coef_name;
 
 public:
-  ComplexMaxwellFormulation();
+  ComplexMaxwellFormulation(const std::string &frequency_coef_name,
+                            const std::string &alpha_coef_name,
+                            const std::string &beta_coef_name,
+                            const std::string &zeta_coef_name,
+                            const std::string &h_curl_var_name);
 
   virtual void ConstructOperator() override;
 

--- a/src/formulations/Dual/dual_formulation.hpp
+++ b/src/formulations/Dual/dual_formulation.hpp
@@ -7,7 +7,10 @@ namespace hephaestus {
 
 class DualFormulation : public TimeDomainFormulation {
 public:
-  DualFormulation();
+  DualFormulation(const std::string &alpha_coef_name,
+                  const std::string &beta_coef_name,
+                  const std::string &h_curl_var_name,
+                  const std::string &h_div_var_name);
 
   virtual void ConstructEquationSystem() override;
 
@@ -18,7 +21,10 @@ public:
   virtual void RegisterCoefficients() override;
 
 protected:
-  std::string h_curl_var_name, h_div_var_name, alpha_coef_name, beta_coef_name;
+  const std::string _alpha_coef_name;
+  const std::string _beta_coef_name;
+  const std::string _h_curl_var_name;
+  const std::string _h_div_var_name;
 };
 
 class WeakCurlEquationSystem : public TimeDependentEquationSystem {
@@ -31,8 +37,8 @@ public:
                     hephaestus::Coefficients &coefficients) override;
   virtual void addKernels() override;
 
-  std::string h_curl_var_name, h_div_var_name, alpha_coef_name, beta_coef_name,
-      dtalpha_coef_name;
+  std::string _h_curl_var_name, _h_div_var_name, _alpha_coef_name,
+      _beta_coef_name, _dtalpha_coef_name;
 };
 
 class DualOperator : public TimeDomainEquationSystemOperator {
@@ -54,7 +60,7 @@ public:
   mfem::ParFiniteElementSpace *HCurlFESpace_;
   mfem::ParFiniteElementSpace *HDivFESpace_;
 
-  std::string h_curl_var_name, h_div_var_name;
+  std::string _h_curl_var_name, _h_div_var_name;
 
   mfem::ParGridFunction *u_;  // HCurl vector field
   mfem::ParGridFunction *dv_; // HDiv vector field

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -2,29 +2,27 @@
 
 namespace hephaestus {
 
-EBDualFormulation::EBDualFormulation() : DualFormulation() {
-  alpha_coef_name = std::string("magnetic_reluctivity");
-  beta_coef_name = std::string("electrical_conductivity");
-  h_curl_var_name = std::string("electric_field");
-  h_div_var_name = std::string("magnetic_flux_density");
-}
+EBDualFormulation::EBDualFormulation(
+    const std::string &magnetic_reluctivity_name,
+    const std::string &magnetic_permeability_name,
+    const std::string &electric_conductivity_name,
+    const std::string &e_field_name, const std::string &b_field_name)
+    : DualFormulation(magnetic_reluctivity_name, electric_conductivity_name,
+                      e_field_name, b_field_name),
+      _magnetic_permeability_name(magnetic_permeability_name) {}
 
 void EBDualFormulation::RegisterCoefficients() {
   hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
-
-  if (!coefficients.scalars.Has("magnetic_permeability")) {
-    MFEM_ABORT("magnetic_permeability coefficient not found.");
+  if (!coefficients.scalars.Has(_magnetic_permeability_name)) {
+    MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has(beta_coef_name)) {
-    MFEM_ABORT(beta_coef_name + " coefficient not found.");
-  }
-
   coefficients.scalars.Register(
-      alpha_coef_name,
+      _magnetic_reluctivity_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get("magnetic_permeability"),
+          &oneCoef, coefficients.scalars.Get(_magnetic_permeability_name),
           fracFunc),
       true);
+  DualFormulation::RegisterCoefficients();
 }
 
 } // namespace hephaestus

--- a/src/formulations/Dual/eb_dual_formulation.hpp
+++ b/src/formulations/Dual/eb_dual_formulation.hpp
@@ -7,11 +7,22 @@ namespace hephaestus {
 
 class EBDualFormulation : public hephaestus::DualFormulation {
 public:
-  EBDualFormulation();
+  EBDualFormulation(const std::string &magnetic_reluctivity_name,
+                    const std::string &magnetic_permeability_name,
+                    const std::string &electric_conductivity_name,
+                    const std::string &e_field_name,
+                    const std::string &b_field_name);
 
   ~EBDualFormulation(){};
 
   virtual void RegisterCoefficients() override;
+
+protected:
+  const std::string _magnetic_permeability_name;
+  const std::string &_magnetic_reluctivity_name =
+      hephaestus::DualFormulation::_alpha_coef_name;
+  const std::string &_electric_conductivity_name =
+      hephaestus::DualFormulation::_beta_coef_name;
 };
 
 } // namespace hephaestus

--- a/src/formulations/Dual/hj_dual_formulation.cpp
+++ b/src/formulations/Dual/hj_dual_formulation.cpp
@@ -2,27 +2,27 @@
 
 namespace hephaestus {
 
-HJDualFormulation::HJDualFormulation() : DualFormulation() {
-  alpha_coef_name = std::string("electrical_resistivity");
-  beta_coef_name = std::string("magnetic_permeability");
-  h_curl_var_name = std::string("magnetic_field");
-  h_div_var_name = std::string("current_density");
-}
+HJDualFormulation::HJDualFormulation(
+    const std::string &electric_resistivity_name,
+    const std::string &electric_conductivity_name,
+    const std::string &magnetic_permeability_name,
+    const std::string &h_field_name, const std::string &j_field_name)
+    : DualFormulation(electric_resistivity_name, magnetic_permeability_name,
+                      h_field_name, j_field_name),
+      _electric_conductivity_name(electric_conductivity_name) {}
 
 void HJDualFormulation::RegisterCoefficients() {
   hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
-  if (!coefficients.scalars.Has("magnetic_permeability")) {
-    MFEM_ABORT("magnetic_permeability coefficient not found.");
-  }
-  if (!coefficients.scalars.Has("electrical_conductivity")) {
-    MFEM_ABORT("electrical_conductivity coefficient not found.");
+  if (!coefficients.scalars.Has(_electric_conductivity_name)) {
+    MFEM_ABORT(_electric_conductivity_name + " coefficient not found.");
   }
   coefficients.scalars.Register(
-      alpha_coef_name,
+      _electric_resistivity_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get("electrical_conductivity"),
+          &oneCoef, coefficients.scalars.Get(_electric_conductivity_name),
           fracFunc),
       true);
+  DualFormulation::RegisterCoefficients();
 }
 
 } // namespace hephaestus

--- a/src/formulations/Dual/hj_dual_formulation.hpp
+++ b/src/formulations/Dual/hj_dual_formulation.hpp
@@ -7,11 +7,22 @@ namespace hephaestus {
 
 class HJDualFormulation : public hephaestus::DualFormulation {
 public:
-  HJDualFormulation();
+  HJDualFormulation(const std::string &electric_resistivity_name,
+                    const std::string &electric_conductivity_name,
+                    const std::string &magnetic_permeability_name,
+                    const std::string &h_field_name,
+                    const std::string &j_field_name);
 
   ~HJDualFormulation(){};
 
   virtual void RegisterCoefficients() override;
+
+protected:
+  const std::string _electric_conductivity_name;
+  const std::string &_electric_resistivity_name =
+      hephaestus::DualFormulation::_alpha_coef_name;
+  const std::string &_magnetic_permeability_name =
+      hephaestus::DualFormulation::_beta_coef_name;
 };
 
 } // namespace hephaestus

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -17,11 +17,13 @@
 
 namespace hephaestus {
 
-AFormulation::AFormulation() : HCurlFormulation() {
-  alpha_coef_name = std::string("magnetic_reluctivity");
-  beta_coef_name = std::string("electrical_conductivity");
-  h_curl_var_name = std::string("magnetic_vector_potential");
-}
+AFormulation::AFormulation(const std::string &magnetic_reluctivity_name,
+                           const std::string &magnetic_permeability_name,
+                           const std::string &electric_conductivity_name,
+                           const std::string &magnetic_vector_potential_name)
+    : HCurlFormulation(magnetic_reluctivity_name, electric_conductivity_name,
+                       magnetic_vector_potential_name),
+      _magnetic_permeability_name(magnetic_permeability_name) {}
 
 void AFormulation::RegisterAuxSolvers() {
   hephaestus::GridFunctions &gridfunctions = this->GetProblem()->gridfunctions;
@@ -30,7 +32,7 @@ void AFormulation::RegisterAuxSolvers() {
   std::string b_field_name = "magnetic_flux_density";
   if (gridfunctions.Get(b_field_name) != NULL) {
     hephaestus::InputParameters b_field_aux_params;
-    b_field_aux_params.SetParam("VariableName", h_curl_var_name);
+    b_field_aux_params.SetParam("VariableName", _h_curl_var_name);
     b_field_aux_params.SetParam("CurlVariableName", b_field_name);
     auxsolvers.Register("_magnetic_flux_density_aux",
                         new hephaestus::CurlAuxSolver(b_field_aux_params),
@@ -40,16 +42,16 @@ void AFormulation::RegisterAuxSolvers() {
 
 void AFormulation::RegisterCoefficients() {
   hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
-  if (!coefficients.scalars.Has("magnetic_permeability")) {
-    MFEM_ABORT("magnetic_permeability coefficient not found.");
+  if (!coefficients.scalars.Has(_magnetic_permeability_name)) {
+    MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has("electrical_conductivity")) {
-    MFEM_ABORT("electrical_conductivity coefficient not found.");
+  if (!coefficients.scalars.Has(_electric_conductivity_name)) {
+    MFEM_ABORT(_electric_conductivity_name + " coefficient not found.");
   }
   coefficients.scalars.Register(
-      alpha_coef_name,
+      _magnetic_reluctivity_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get("magnetic_permeability"),
+          &oneCoef, coefficients.scalars.Get(_magnetic_permeability_name),
           fracFunc),
       true);
 }

--- a/src/formulations/HCurl/a_formulation.hpp
+++ b/src/formulations/HCurl/a_formulation.hpp
@@ -7,12 +7,22 @@ namespace hephaestus {
 
 class AFormulation : public hephaestus::HCurlFormulation {
 public:
-  AFormulation();
+  AFormulation(const std::string &magnetic_reluctivity_name,
+               const std::string &magnetic_permeability_name,
+               const std::string &electric_conductivity_name,
+               const std::string &magnetic_vector_potential_name);
 
   ~AFormulation(){};
 
   virtual void RegisterAuxSolvers() override;
 
   virtual void RegisterCoefficients() override;
+
+protected:
+  const std::string _magnetic_permeability_name;
+  const std::string &_magnetic_reluctivity_name =
+      hephaestus::HCurlFormulation::_alpha_coef_name;
+  const std::string &_electric_conductivity_name =
+      hephaestus::HCurlFormulation::_beta_coef_name;
 };
 } // namespace hephaestus

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -16,26 +16,27 @@
 
 namespace hephaestus {
 
-EFormulation::EFormulation() : HCurlFormulation() {
-  alpha_coef_name = std::string("magnetic_reluctivity");
-  beta_coef_name = std::string("electrical_conductivity");
-  h_curl_var_name = std::string("electric_field");
-}
+EFormulation::EFormulation(const std::string &magnetic_reluctivity_name,
+                           const std::string &magnetic_permeability_name,
+                           const std::string &electric_conductivity_name,
+                           const std::string &e_field_name)
+    : HCurlFormulation(magnetic_reluctivity_name, electric_conductivity_name,
+                       e_field_name),
+      _magnetic_permeability_name(magnetic_permeability_name) {}
 
 void EFormulation::RegisterCoefficients() {
   hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
-  if (!coefficients.scalars.Has("magnetic_permeability")) {
-    MFEM_ABORT("magnetic_permeability coefficient not found.");
+  if (!coefficients.scalars.Has(_magnetic_permeability_name)) {
+    MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has("electrical_conductivity")) {
-    MFEM_ABORT("electrical_conductivity coefficient not found.");
+  if (!coefficients.scalars.Has(_electric_conductivity_name)) {
+    MFEM_ABORT(_electric_conductivity_name + " coefficient not found.");
   }
   coefficients.scalars.Register(
-      alpha_coef_name,
+      _magnetic_reluctivity_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get("magnetic_permeability"),
+          &oneCoef, coefficients.scalars.Get(_magnetic_permeability_name),
           fracFunc),
       true);
 }
-
 } // namespace hephaestus

--- a/src/formulations/HCurl/e_formulation.hpp
+++ b/src/formulations/HCurl/e_formulation.hpp
@@ -7,11 +7,21 @@ namespace hephaestus {
 
 class EFormulation : public hephaestus::HCurlFormulation {
 public:
-  EFormulation();
+  EFormulation(const std::string &magnetic_reluctivity_name,
+               const std::string &magnetic_permeability_name,
+               const std::string &electric_conductivity_name,
+               const std::string &e_field_name);
 
   ~EFormulation(){};
 
   virtual void RegisterCoefficients() override;
+
+protected:
+  const std::string _magnetic_permeability_name;
+  const std::string &_magnetic_reluctivity_name =
+      hephaestus::HCurlFormulation::_alpha_coef_name;
+  const std::string &_electric_conductivity_name =
+      hephaestus::HCurlFormulation::_beta_coef_name;
 };
 
 } // namespace hephaestus

--- a/src/formulations/HCurl/h_formulation.hpp
+++ b/src/formulations/HCurl/h_formulation.hpp
@@ -7,12 +7,22 @@ namespace hephaestus {
 
 class HFormulation : public hephaestus::HCurlFormulation {
 public:
-  HFormulation();
+  HFormulation(const std::string &electric_resistivity_name,
+               const std::string &electric_conductivity_name,
+               const std::string &magnetic_permeability_name,
+               const std::string &h_field_name);
 
   ~HFormulation(){};
 
   virtual void RegisterAuxSolvers() override;
 
   virtual void RegisterCoefficients() override;
+
+protected:
+  const std::string _electric_conductivity_name;
+  const std::string &_electric_resistivity_name =
+      hephaestus::HCurlFormulation::_alpha_coef_name;
+  const std::string &_magnetic_permeability_name =
+      hephaestus::HCurlFormulation::_beta_coef_name;
 };
 } // namespace hephaestus

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -40,17 +40,17 @@
 
 namespace hephaestus {
 
-HCurlFormulation::HCurlFormulation() : TimeDomainFormulation() {
-  alpha_coef_name = std::string("alpha");
-  beta_coef_name = std::string("beta");
-  h_curl_var_name = std::string("h_curl_var");
-}
+HCurlFormulation::HCurlFormulation(const std::string &alpha_coef_name,
+                                   const std::string &beta_coef_name,
+                                   const std::string &h_curl_var_name)
+    : TimeDomainFormulation(), _alpha_coef_name(alpha_coef_name),
+      _beta_coef_name(beta_coef_name), _h_curl_var_name(h_curl_var_name) {}
 
 void HCurlFormulation::ConstructEquationSystem() {
   hephaestus::InputParameters weak_form_params;
-  weak_form_params.SetParam("HCurlVarName", h_curl_var_name);
-  weak_form_params.SetParam("AlphaCoefName", alpha_coef_name);
-  weak_form_params.SetParam("BetaCoefName", beta_coef_name);
+  weak_form_params.SetParam("HCurlVarName", _h_curl_var_name);
+  weak_form_params.SetParam("AlphaCoefName", _alpha_coef_name);
+  weak_form_params.SetParam("BetaCoefName", _beta_coef_name);
   this->GetProblem()->td_equation_system =
       std::make_unique<hephaestus::CurlCurlEquationSystem>(weak_form_params);
 }
@@ -72,13 +72,13 @@ void HCurlFormulation::RegisterGridFunctions() {
   hephaestus::FESpaces &fespaces = this->GetProblem()->fespaces;
 
   // Register default ParGridFunctions of state gridfunctions if not provided
-  if (!gridfunctions.Has(h_curl_var_name)) {
+  if (!gridfunctions.Has(_h_curl_var_name)) {
     if (myid == 0) {
-      MFEM_WARNING(h_curl_var_name << " not found in gridfunctions: building "
-                                      "gridfunction from defaults");
+      MFEM_WARNING(_h_curl_var_name << " not found in gridfunctions: building "
+                                       "gridfunction from defaults");
     }
     AddFESpace(std::string("_HCurlFESpace"), std::string("ND_3D_P2"));
-    AddGridFunction(h_curl_var_name, std::string("_HCurlFESpace"));
+    AddGridFunction(_h_curl_var_name, std::string("_HCurlFESpace"));
   };
   // Register time derivatives
   TimeDomainProblemBuilder::RegisterGridFunctions();
@@ -130,11 +130,11 @@ void CurlCurlEquationSystem::addKernels() {
 
 void HCurlFormulation::RegisterCoefficients() {
   hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
-  if (!coefficients.scalars.Has(alpha_coef_name)) {
-    MFEM_ABORT(alpha_coef_name + " coefficient not found.");
+  if (!coefficients.scalars.Has(_alpha_coef_name)) {
+    MFEM_ABORT(_alpha_coef_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has(beta_coef_name)) {
-    MFEM_ABORT(beta_coef_name + " coefficient not found.");
+  if (!coefficients.scalars.Has(_beta_coef_name)) {
+    MFEM_ABORT(_beta_coef_name + " coefficient not found.");
   }
 }
 

--- a/src/formulations/HCurl/hcurl_formulation.hpp
+++ b/src/formulations/HCurl/hcurl_formulation.hpp
@@ -8,7 +8,9 @@ namespace hephaestus {
 
 class HCurlFormulation : public TimeDomainFormulation {
 public:
-  HCurlFormulation();
+  HCurlFormulation(const std::string &alpha_coef_name,
+                   const std::string &beta_coef_name,
+                   const std::string &h_curl_var_name);
 
   virtual void ConstructEquationSystem() override;
 
@@ -19,7 +21,9 @@ public:
   virtual void RegisterCoefficients() override;
 
 protected:
-  std::string h_curl_var_name, alpha_coef_name, beta_coef_name;
+  const std::string _alpha_coef_name;
+  const std::string _beta_coef_name;
+  const std::string _h_curl_var_name;
 };
 
 class CurlCurlEquationSystem : public TimeDependentEquationSystem {

--- a/src/formulations/frequency_domain_formulation.hpp
+++ b/src/formulations/frequency_domain_formulation.hpp
@@ -6,9 +6,6 @@ namespace hephaestus {
 // Specifies output interfaces of a frequency-domain EM formulation.
 class FrequencyDomainFormulation
     : public hephaestus::FrequencyDomainProblemBuilder {
-  // std::vector<mfem::ParGridFunction *> local_trial_vars, local_test_vars;
-  std::string frequency_coef_name, permittivity_coef_name,
-      reluctivity_coef_name, conductivity_coef_name, h_curl_var_name;
 
 public:
   FrequencyDomainFormulation();

--- a/src/formulations/time_domain_formulation.cpp
+++ b/src/formulations/time_domain_formulation.cpp
@@ -2,6 +2,55 @@
 
 namespace hephaestus {
 
+// enum EMField {
+//   ElectricField,
+//   MagneticField,
+//   MagneticFluxDensity,
+//   CurrentDensity,
+//   LorentzForceDensity,
+//   JouleHeatingPower
+// };
+
+// enum EMPotential {
+//   MagneticVectorPotential,
+//   ElectricScalarPotential,
+//   ElectricVectorPotential,
+//   MagneticScalarPotential
+// };
+
+// enum EMMaterialProperty {
+//   ElectricConductivity,
+//   ElectricResistivity,
+//   MagneticPermeability,
+//   MagneticReluctivity,
+//   ElectricPermittivity
+// };
+
+// // req_coef = blah
+// // check
+
+// Struct: motive: to automate AddAuxSolver
+// and more easily validate fields
+
+// Formulation(EMFieldSet, EMMaterialProperties)
+// struct EMFieldSet:
+// active_fields = std::map<EMField, longname>
+
+// std::string enum_to_longname(EMField field) {
+//   switch (field) {
+//   case ElectricField:
+//     return "electric_field";
+//   case MagneticField:
+//     return "magnetic_field";
+//   case MagneticFluxDensity:
+//     return "magnetic_flux_density";
+//   case CurrentDensity:
+//     return "current_density";
+//   default:
+//     return "";
+//   }
+// }
+
 TimeDomainFormulation::TimeDomainFormulation() : TimeDomainProblemBuilder(){};
 
 } // namespace hephaestus

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -154,7 +154,9 @@ TEST_F(TestAFormSource, CheckRun) {
       pmesh->UniformRefinement();
     }
     hephaestus::TimeDomainProblemBuilder *problem_builder =
-        new hephaestus::AFormulation();
+        new hephaestus::AFormulation(
+            "magnetic_reluctivity", "magnetic_permeability",
+            "electrical_conductivity", "magnetic_vector_potential");
     hephaestus::BCMap bc_map(
         params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
     hephaestus::Coefficients coefficients(

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -89,9 +89,6 @@ protected:
     hephaestus::AuxSolvers preprocessors;
     hephaestus::Sources sources;
 
-    hephaestus::TimeDomainFormulation *formulation =
-        new hephaestus::AVFormulation();
-
     hephaestus::InputParameters params;
     params.SetParam("Mesh", mfem::ParMesh(MPI_COMM_WORLD, mesh));
     params.SetParam("BoundaryConditions", bc_map);
@@ -102,7 +99,6 @@ protected:
     params.SetParam("PostProcessors", postprocessors);
     params.SetParam("Outputs", outputs);
     params.SetParam("Sources", sources);
-    params.SetParam("Formulation", formulation);
 
     return params;
   }
@@ -114,7 +110,10 @@ TEST_F(TestAVFormRod, CheckRun) {
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
   hephaestus::TimeDomainProblemBuilder *problem_builder =
-      new hephaestus::AVFormulation();
+      new hephaestus::AVFormulation(
+          "magnetic_reluctivity", "magnetic_permeability",
+          "electrical_conductivity", "magnetic_vector_potential",
+          "electric_potential");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -162,7 +162,10 @@ TEST_F(TestAVFormSource, CheckRun) {
       pmesh->UniformRefinement();
     }
     hephaestus::TimeDomainProblemBuilder *problem_builder =
-        new hephaestus::AVFormulation();
+        new hephaestus::AVFormulation(
+            "magnetic_reluctivity", "magnetic_permeability",
+            "electrical_conductivity", "magnetic_vector_potential",
+            "electric_potential");
     hephaestus::BCMap bc_map(
         params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
     hephaestus::Coefficients coefficients(

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -139,7 +139,9 @@ TEST_F(TestComplexAFormRod, CheckRun) {
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
   hephaestus::FrequencyDomainProblemBuilder *problem_builder =
-      new hephaestus::ComplexAFormulation();
+      new hephaestus::ComplexAFormulation(
+          "magnetic_reluctivity", "electrical_conductivity",
+          "dielectric_permittivity", "frequency", "magnetic_vector_potential");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -93,7 +93,9 @@ protected:
     hephaestus::Sources sources;
 
     hephaestus::FrequencyDomainFormulation *formulation =
-        new hephaestus::ComplexEFormulation();
+        new hephaestus::ComplexEFormulation(
+            "magnetic_reluctivity", "electrical_conductivity",
+            "dielectric_permittivity", "frequency", "electric_field");
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-16));
@@ -113,7 +115,6 @@ protected:
     params.SetParam("Outputs", outputs);
     params.SetParam("Sources", sources);
     params.SetParam("SolverOptions", solver_options);
-    params.SetParam("Formulation", formulation);
 
     return params;
   }
@@ -125,7 +126,9 @@ TEST_F(TestComplexERMESMouse, CheckRun) {
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
   hephaestus::FrequencyDomainProblemBuilder *problem_builder =
-      new hephaestus::ComplexEFormulation();
+      new hephaestus::ComplexEFormulation(
+          "magnetic_reluctivity", "electrical_conductivity",
+          "dielectric_permittivity", "frequency", "electric_field");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -90,9 +90,6 @@ protected:
     hephaestus::AuxSolvers preprocessors;
     hephaestus::Sources sources;
 
-    hephaestus::FrequencyDomainFormulation *formulation =
-        new hephaestus::ComplexEFormulation();
-
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-16));
     solver_options.SetParam("MaxIter", (unsigned int)1000);
@@ -111,7 +108,6 @@ protected:
     params.SetParam("Outputs", outputs);
     params.SetParam("Sources", sources);
     params.SetParam("SolverOptions", solver_options);
-    params.SetParam("Formulation", formulation);
 
     return params;
   }
@@ -123,7 +119,9 @@ TEST_F(TestComplexIrisWaveguide, CheckRun) {
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
   hephaestus::FrequencyDomainProblemBuilder *problem_builder =
-      new hephaestus::ComplexEFormulation();
+      new hephaestus::ComplexEFormulation(
+          "magnetic_reluctivity", "electrical_conductivity",
+          "dielectric_permittivity", "frequency", "electric_field");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -174,7 +174,9 @@ TEST_F(TestComplexTeam7, CheckRun) {
           "SolverOptions", hephaestus::InputParameters()));
 
   hephaestus::FrequencyDomainProblemBuilder *problem_builder =
-      new hephaestus::ComplexAFormulation();
+      new hephaestus::ComplexAFormulation(
+          "magnetic_reluctivity", "electrical_conductivity",
+          "dielectric_permittivity", "frequency", "magnetic_vector_potential");
   problem_builder->SetMesh(pmesh);
   problem_builder->AddFESpace(std::string("HCurl"), std::string("ND_3D_P1"));
   problem_builder->AddFESpace(std::string("HDiv"), std::string("RT_3D_P0"));

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -173,7 +173,9 @@ protected:
 TEST_F(TestEBFormCoupled, CheckRun) {
   hephaestus::InputParameters params(test_params());
   hephaestus::TimeDomainProblemBuilder *problem_builder =
-      new hephaestus::EBDualFormulation();
+      new hephaestus::EBDualFormulation(
+          "magnetic_reluctivity", "magnetic_permeability",
+          "electrical_conductivity", "electric_field", "magnetic_flux_density");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -135,7 +135,9 @@ protected:
 TEST_F(TestEBFormRod, CheckRun) {
   hephaestus::InputParameters params(test_params());
   hephaestus::TimeDomainProblemBuilder *problem_builder =
-      new hephaestus::EBDualFormulation();
+      new hephaestus::EBDualFormulation(
+          "magnetic_reluctivity", "magnetic_permeability",
+          "electrical_conductivity", "electric_field", "magnetic_flux_density");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -135,7 +135,9 @@ TEST_F(TestHFormRod, CheckRun) {
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
   hephaestus::TimeDomainProblemBuilder *problem_builder =
-      new hephaestus::HFormulation();
+      new hephaestus::HFormulation("electrical_resistivity",
+                                   "electrical_conductivity",
+                                   "magnetic_permeability", "magnetic_field");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -170,7 +170,9 @@ TEST_F(TestHFormSource, CheckRun) {
       pmesh->UniformRefinement();
     }
     hephaestus::TimeDomainProblemBuilder *problem_builder =
-        new hephaestus::HFormulation();
+        new hephaestus::HFormulation("electrical_resistivity",
+                                     "electrical_conductivity",
+                                     "magnetic_permeability", "magnetic_field");
     hephaestus::BCMap bc_map(
         params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
     hephaestus::Coefficients coefficients(

--- a/test/integration/test_hjform_rod.cpp
+++ b/test/integration/test_hjform_rod.cpp
@@ -135,7 +135,9 @@ protected:
 TEST_F(TestHJFormRod, CheckRun) {
   hephaestus::InputParameters params(test_params());
   hephaestus::TimeDomainProblemBuilder *problem_builder =
-      new hephaestus::HJDualFormulation();
+      new hephaestus::HJDualFormulation(
+          "electrical_resistivity", "electrical_conductivity",
+          "magnetic_permeability", "magnetic_field", "current_density");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(


### PR DESCRIPTION
Pass in names of required variables to Formulation constructors. Reduces hard-coding of variable names used in formulations.