### PR TITLE
Add a magnetostatic formulation for calculation of steady state field distributions

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/examples/bin)
 add_subdirectory(team7)
 add_subdirectory(complex_team7)
+add_subdirectory(magnetostatic)

--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
   MPI_Init(&argc, &argv);
 
   // Create Formulation
-  hephaestus::FrequencyDomainProblemBuilder *problem_builder =
+  hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexAFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
           "dielectric_permittivity", "frequency", "magnetic_vector_potential");
@@ -181,7 +181,7 @@ int main(int argc, char *argv[]) {
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder);
   sequencer.ConstructOperatorProblem();
-  std::unique_ptr<hephaestus::FrequencyDomainProblem> problem =
+  std::unique_ptr<hephaestus::SteadyStateProblem> problem =
       problem_builder->ReturnProblem();
 
   hephaestus::InputParameters exec_params;

--- a/examples/magnetostatic/CMakeLists.txt
+++ b/examples/magnetostatic/CMakeLists.txt
@@ -1,0 +1,23 @@
+file(GLOB_RECURSE example_src "*.cpp")
+
+file(GLOB_RECURSE test_src_files "${PROJECT_SOURCE_DIR}/src/*.h" "${PROJECT_SOURCE_DIR}/src/*.hpp" "${PROJECT_SOURCE_DIR}/src/*.cpp")
+
+set (${PROJECT_NAME}_INCLUDE_DIRS "")
+foreach (_srcFile ${test_src_files})
+    get_filename_component(_dir ${_srcFile} PATH)
+    list (APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${_dir})
+endforeach()
+list (REMOVE_DUPLICATES ${PROJECT_NAME}_INCLUDE_DIRS)
+
+
+add_executable(team7 ${example_src})
+add_compile_options(team7 ${BUILD_TYPE_COMPILER_FLAGS})
+target_include_directories(team7 PUBLIC ${MFEM_COMMON_INCLUDES} ${MFEM_INCLUDE_DIRS})
+target_include_directories(team7 PUBLIC ${${PROJECT_NAME}_INCLUDE_DIRS})
+target_include_directories(team7 PUBLIC ${PROJECT_SOURCE_DIR}/data/)
+
+set_property(TARGET team7 PROPERTY CXX_STANDARD 17)
+
+target_link_libraries(team7 ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} pthread)
+target_link_libraries(team7 ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PROJECT_NAME}.so)
+target_link_libraries(team7 ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY} -lrt)

--- a/examples/magnetostatic/CMakeLists.txt
+++ b/examples/magnetostatic/CMakeLists.txt
@@ -10,14 +10,14 @@ endforeach()
 list (REMOVE_DUPLICATES ${PROJECT_NAME}_INCLUDE_DIRS)
 
 
-add_executable(team7 ${example_src})
-add_compile_options(team7 ${BUILD_TYPE_COMPILER_FLAGS})
-target_include_directories(team7 PUBLIC ${MFEM_COMMON_INCLUDES} ${MFEM_INCLUDE_DIRS})
-target_include_directories(team7 PUBLIC ${${PROJECT_NAME}_INCLUDE_DIRS})
-target_include_directories(team7 PUBLIC ${PROJECT_SOURCE_DIR}/data/)
+add_executable(magnetostatic ${example_src})
+add_compile_options(magnetostatic ${BUILD_TYPE_COMPILER_FLAGS})
+target_include_directories(magnetostatic PUBLIC ${MFEM_COMMON_INCLUDES} ${MFEM_INCLUDE_DIRS})
+target_include_directories(magnetostatic PUBLIC ${${PROJECT_NAME}_INCLUDE_DIRS})
+target_include_directories(magnetostatic PUBLIC ${PROJECT_SOURCE_DIR}/data/)
 
-set_property(TARGET team7 PROPERTY CXX_STANDARD 17)
+set_property(TARGET magnetostatic PROPERTY CXX_STANDARD 17)
 
-target_link_libraries(team7 ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} pthread)
-target_link_libraries(team7 ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PROJECT_NAME}.so)
-target_link_libraries(team7 ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY} -lrt)
+target_link_libraries(magnetostatic ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} pthread)
+target_link_libraries(magnetostatic ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PROJECT_NAME}.so)
+target_link_libraries(magnetostatic ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY} -lrt)

--- a/examples/magnetostatic/Main.cpp
+++ b/examples/magnetostatic/Main.cpp
@@ -1,0 +1,168 @@
+#include "hephaestus.hpp"
+
+const char *DATA_DIR = "../../data/";
+
+static void source_current(const mfem::Vector &xv, double t, mfem::Vector &J) {
+  double x0(194e-3);  // Coil centre x coordinate
+  double y0(100e-3);  // Coil centre y coordinate
+  double a(50e-3);    // Coil thickness
+  double I0(2742);    // Coil current in Ampere-turns
+  double S(2.5e-3);   // Coil cross sectional area
+
+  double x = xv(0);
+  double y = xv(1);
+
+  // Current density magnitude
+  double Jmag = (I0 / S);
+
+  // Calculate x component of current density unit vector
+  if (abs(x - x0) < a) {
+    J(0) = -(y - y0) / abs(y - y0);
+  } else if (abs(y - y0) < a) {
+    J(0) = 0.0;
+  } else {
+    J(0) = -(y - (y0 + a * ((y - y0) / abs(y - y0)))) /
+           hypot(x - (x0 + a * ((x - x0) / abs(x - x0))),
+                 y - (y0 + a * ((y - y0) / abs(y - y0))));
+  }
+
+  // Calculate y component of current density unit vector
+  if (abs(y - y0) < a) {
+    J(1) = (x - x0) / abs(x - x0);
+  } else if (abs(x - x0) < a) {
+    J(1) = 0.0;
+  } else {
+    J(1) = (x - (x0 + a * ((x - x0) / abs(x - x0)))) /
+           hypot(x - (x0 + a * ((x - x0) / abs(x - x0))),
+                 y - (y0 + a * ((y - y0) / abs(y - y0))));
+  }
+
+  // Calculate z component of current density unit vector
+  J(2) = 0.0;
+
+  // Scale by current density magnitude
+  J *= Jmag;
+}
+
+hephaestus::Coefficients defineCoefficients() {
+  hephaestus::Subdomain air("air", 1);
+  air.scalar_coefficients.Register("electrical_conductivity",
+                                   new mfem::ConstantCoefficient(1.0), true);
+  hephaestus::Subdomain plate("plate", 2);
+  plate.scalar_coefficients.Register(
+      "electrical_conductivity", new mfem::ConstantCoefficient(3.526e7), true);
+  hephaestus::Subdomain coil1("coil1", 3);
+  coil1.scalar_coefficients.Register("electrical_conductivity",
+                                     new mfem::ConstantCoefficient(1.0), true);
+  hephaestus::Subdomain coil2("coil2", 4);
+  coil2.scalar_coefficients.Register("electrical_conductivity",
+                                     new mfem::ConstantCoefficient(1.0), true);
+  hephaestus::Subdomain coil3("coil3", 5);
+  coil3.scalar_coefficients.Register("electrical_conductivity",
+                                     new mfem::ConstantCoefficient(1.0), true);
+  hephaestus::Subdomain coil4("coil4", 6);
+  coil4.scalar_coefficients.Register("electrical_conductivity",
+                                     new mfem::ConstantCoefficient(1.0), true);
+  hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>(
+      {air, plate, coil1, coil2, coil3, coil4}));
+  coefficients.scalars.Register("magnetic_permeability",
+                                new mfem::ConstantCoefficient(M_PI * 4.0e-7),
+                                true);
+
+  mfem::VectorFunctionCoefficient *JSrcCoef =
+      new mfem::VectorFunctionCoefficient(3, source_current);
+  mfem::Array<mfem::VectorCoefficient *> sourcecoefs(4);
+  sourcecoefs[0] = JSrcCoef;
+  sourcecoefs[1] = JSrcCoef;
+  sourcecoefs[2] = JSrcCoef;
+  sourcecoefs[3] = JSrcCoef;
+  mfem::Array<int> coilsegments(4);
+  coilsegments[0] = 3;
+  coilsegments[1] = 4;
+  coilsegments[2] = 5;
+  coilsegments[3] = 6;
+  mfem::PWVectorCoefficient *JSrcRestricted =
+      new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
+  coefficients.vectors.Register("source", JSrcRestricted, true);
+  return coefficients;
+}
+
+hephaestus::Sources defineSources() {
+  hephaestus::InputParameters div_free_source_params;
+  div_free_source_params.SetParam("SourceName", std::string("source"));
+  div_free_source_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
+  div_free_source_params.SetParam("H1FESpaceName", std::string("H1"));
+  hephaestus::InputParameters current_solver_options;
+  current_solver_options.SetParam("Tolerance", float(1.0e-12));
+  current_solver_options.SetParam("MaxIter", (unsigned int)200);
+  current_solver_options.SetParam("PrintLevel", 0);
+  div_free_source_params.SetParam("SolverOptions", current_solver_options);
+  hephaestus::Sources sources;
+  sources.Register("source",
+                   new hephaestus::DivFreeSource(div_free_source_params), true);
+  return sources;
+}
+hephaestus::Outputs defineOutputs() {
+  std::map<std::string, mfem::DataCollection *> data_collections;
+  data_collections["ParaViewDataCollection"] =
+      new mfem::ParaViewDataCollection("Team7ParaView");
+  hephaestus::Outputs outputs(data_collections);
+  return outputs;
+}
+
+int main(int argc, char *argv[]) {
+  mfem::OptionsParser args(argc, argv);
+  args.AddOption(&DATA_DIR, "-dataDir", "--data_directory",
+                 "Directory storing input data for tests.");
+  args.Parse();
+  MPI_Init(&argc, &argv);
+
+  // Create Formulation
+  hephaestus::SteadyStateProblemBuilder *problem_builder =
+      new hephaestus::MagnetostaticFormulation(
+          "magnetic_reluctivity", "magnetic_permeability", "magnetic_vector_potential");
+  // Set Mesh
+  mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./team7.g")).c_str(), 1,
+                  1);
+  std::shared_ptr<mfem::ParMesh> pmesh =
+      std::make_shared<mfem::ParMesh>(mfem::ParMesh(MPI_COMM_WORLD, mesh));
+  problem_builder->SetMesh(pmesh);
+  problem_builder->AddFESpace(std::string("H1"), std::string("H1_3D_P1"));
+  problem_builder->AddFESpace(std::string("HCurl"), std::string("ND_3D_P1"));
+  problem_builder->AddFESpace(std::string("HDiv"), std::string("RT_3D_P0"));
+  problem_builder->AddGridFunction(std::string("magnetic_vector_potential"),
+                                   std::string("HCurl"));
+  problem_builder->AddGridFunction(std::string("magnetic_flux_density"),
+                                   std::string("HDiv"));
+  hephaestus::Coefficients coefficients = defineCoefficients();
+  problem_builder->SetCoefficients(coefficients);
+
+  hephaestus::Sources sources = defineSources();
+  problem_builder->SetSources(sources);
+
+  hephaestus::Outputs outputs = defineOutputs();
+  problem_builder->SetOutputs(outputs);
+
+  hephaestus::InputParameters solver_options;
+  solver_options.SetParam("Tolerance", float(1.0e-16));
+  solver_options.SetParam("MaxIter", (unsigned int)1000);
+  solver_options.SetParam("PrintLevel", 0);
+  problem_builder->SetSolverOptions(solver_options);
+
+  hephaestus::ProblemBuildSequencer sequencer(problem_builder);
+  sequencer.ConstructEquationSystemProblem();
+  std::unique_ptr<hephaestus::SteadyStateProblem> problem =
+      problem_builder->ReturnProblem();
+  hephaestus::InputParameters exec_params;
+  exec_params.SetParam("VisualisationSteps", int(1));
+  exec_params.SetParam("UseGLVis", true);
+  exec_params.SetParam("Problem", problem.get());
+  hephaestus::SteadyExecutioner *executioner =
+      new hephaestus::SteadyExecutioner(exec_params);
+
+  mfem::out << "Created executioner";
+  executioner->Init();
+  executioner->Execute();
+
+  MPI_Finalize();
+}

--- a/examples/magnetostatic/Main.cpp
+++ b/examples/magnetostatic/Main.cpp
@@ -3,11 +3,11 @@
 const char *DATA_DIR = "../../data/";
 
 static void source_current(const mfem::Vector &xv, double t, mfem::Vector &J) {
-  double x0(194e-3);  // Coil centre x coordinate
-  double y0(100e-3);  // Coil centre y coordinate
-  double a(50e-3);    // Coil thickness
-  double I0(2742);    // Coil current in Ampere-turns
-  double S(2.5e-3);   // Coil cross sectional area
+  double x0(194e-3); // Coil centre x coordinate
+  double y0(100e-3); // Coil centre y coordinate
+  double a(50e-3);   // Coil thickness
+  double I0(2742);   // Coil current in Ampere-turns
+  double S(2.5e-3);  // Coil cross sectional area
 
   double x = xv(0);
   double y = xv(1);
@@ -119,8 +119,9 @@ int main(int argc, char *argv[]) {
 
   // Create Formulation
   hephaestus::SteadyStateProblemBuilder *problem_builder =
-      new hephaestus::MagnetostaticFormulation(
-          "magnetic_reluctivity", "magnetic_permeability", "magnetic_vector_potential");
+      new hephaestus::MagnetostaticFormulation("magnetic_reluctivity",
+                                               "magnetic_permeability",
+                                               "magnetic_vector_potential");
   // Set Mesh
   mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./team7.g")).c_str(), 1,
                   1);

--- a/src/executioners/steady_executioner.cpp
+++ b/src/executioners/steady_executioner.cpp
@@ -5,7 +5,7 @@ namespace hephaestus {
 SteadyExecutioner::SteadyExecutioner(const hephaestus::InputParameters &params)
     : Executioner(params),
       problem(
-          params.GetParam<hephaestus::FrequencyDomainProblem *>("Problem")) {}
+          params.GetParam<hephaestus::SteadyStateProblem *>("Problem")) {}
 
 void SteadyExecutioner::Init() {
   // Set up DataCollections to track fields of interest.
@@ -27,7 +27,7 @@ void SteadyExecutioner::Init() {
 void SteadyExecutioner::Solve() const {
   // Advance time step.
   problem->preprocessors.Solve();
-  problem->fd_operator.get()->Solve(*(problem->F));
+  problem->GetOperator()->Solve(*(problem->F));
   problem->postprocessors.Solve();
 
   // Output data

--- a/src/executioners/steady_executioner.hpp
+++ b/src/executioners/steady_executioner.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "executioner_base.hpp"
-#include "frequency_domain_problem_builder.hpp"
+#include "steady_state_problem_builder.hpp"
 
 namespace hephaestus {
 
@@ -15,7 +15,7 @@ public:
 
   void Execute() const override;
 
-  hephaestus::FrequencyDomainProblem *problem;
+  hephaestus::SteadyStateProblem *problem;
 };
 
 } // namespace hephaestus

--- a/src/factory/factory.hpp
+++ b/src/factory/factory.hpp
@@ -8,6 +8,7 @@
 #include "eb_dual_formulation.hpp"
 #include "h_formulation.hpp"
 #include "hj_dual_formulation.hpp"
+#include "magnetostatic_formulation.hpp"
 #include "inputs.hpp"
 
 namespace hephaestus {

--- a/src/factory/factory.hpp
+++ b/src/factory/factory.hpp
@@ -8,8 +8,8 @@
 #include "eb_dual_formulation.hpp"
 #include "h_formulation.hpp"
 #include "hj_dual_formulation.hpp"
-#include "magnetostatic_formulation.hpp"
 #include "inputs.hpp"
+#include "magnetostatic_formulation.hpp"
 
 namespace hephaestus {
 

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
@@ -7,7 +7,7 @@ ComplexMaxwellOperator::ComplexMaxwellOperator(
     hephaestus::GridFunctions &gridfunctions, hephaestus::BCMap &bc_map,
     hephaestus::Coefficients &coefficients, hephaestus::Sources &sources,
     hephaestus::InputParameters &solver_options)
-    : FrequencyDomainEquationSystemOperator(pmesh, fespaces, gridfunctions,
+    : EquationSystemOperator(pmesh, fespaces, gridfunctions,
                                             bc_map, coefficients, sources,
                                             solver_options),
       h_curl_var_name(solver_options.GetParam<std::string>("HCurlVarName")),
@@ -20,14 +20,14 @@ void ComplexMaxwellOperator::SetGridFunctions() {
   state_var_names.push_back(h_curl_var_name + "_real");
   state_var_names.push_back(h_curl_var_name + "_imag");
 
-  FrequencyDomainEquationSystemOperator::SetGridFunctions();
+  EquationSystemOperator::SetGridFunctions();
 
   u_ = new mfem::ParComplexGridFunction(local_test_vars.at(0)->ParFESpace());
   *u_ = std::complex(0.0, 0.0);
 };
 
 void ComplexMaxwellOperator::Init(mfem::Vector &X) {
-  FrequencyDomainEquationSystemOperator::Init(X);
+  EquationSystemOperator::Init(X);
 
   stiffCoef_ = _coefficients.scalars.Get(stiffness_coef_name);
   massCoef_ = _coefficients.scalars.Get(mass_coef_name);
@@ -115,13 +115,13 @@ void ComplexMaxwellFormulation::ConstructOperator() {
   solver_options.SetParam("StiffnessCoefName", _alpha_coef_name);
   solver_options.SetParam("MassCoefName", _mass_coef_name);
   solver_options.SetParam("LossCoefName", _loss_coef_name);
-  this->problem->fd_operator =
+  this->problem->eq_sys_operator =
       std::make_unique<hephaestus::ComplexMaxwellOperator>(
           *(this->problem->pmesh), this->problem->fespaces,
           this->problem->gridfunctions, this->problem->bc_map,
           this->problem->coefficients, this->problem->sources,
           this->problem->solver_options);
-  this->problem->fd_operator->SetGridFunctions();
+  this->problem->GetOperator()->SetGridFunctions();
 }
 
 void ComplexMaxwellFormulation::RegisterGridFunctions() {

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
@@ -24,7 +24,7 @@ Robin boundaries weakly constrain (α∇×u)×n + γ(n×n×u) = F
 Divergence cleaning (such as via Helmholtz projection)
 should be performed on g before use in this operator.
 */
-class ComplexMaxwellOperator : public FrequencyDomainEquationSystemOperator {
+class ComplexMaxwellOperator : public EquationSystemOperator {
 public:
   ComplexMaxwellOperator(mfem::ParMesh &pmesh, hephaestus::FESpaces &fespaces,
                          hephaestus::GridFunctions &gridfunctions,

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
@@ -16,10 +16,12 @@
 
 namespace hephaestus {
 
-MagnetostaticFormulation::MagnetostaticFormulation(const std::string &magnetic_reluctivity_name,
-                           const std::string &magnetic_permeability_name,
-                           const std::string &magnetic_vector_potential_name)
-    : StaticsFormulation(magnetic_reluctivity_name, magnetic_vector_potential_name),
+MagnetostaticFormulation::MagnetostaticFormulation(
+    const std::string &magnetic_reluctivity_name,
+    const std::string &magnetic_permeability_name,
+    const std::string &magnetic_vector_potential_name)
+    : StaticsFormulation(magnetic_reluctivity_name,
+                         magnetic_vector_potential_name),
       _magnetic_permeability_name(magnetic_permeability_name) {}
 
 void MagnetostaticFormulation::RegisterAuxSolvers() {

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
@@ -1,0 +1,52 @@
+//* Solves:
+//* ∇×(ν∇×A) = Jᵉ
+//*
+//* in weak form
+//* (ν∇×A, ∇×A') - (Jᵉ, A') - <(ν∇×A)×n, A'>  = 0
+
+//* where:
+//* reluctivity ν = 1/μ
+//* Magnetic vector potential A
+//* Electric field, E = ρJᵉ
+//* Magnetic flux density, B = ∇×A
+//* Magnetic field H = ν∇×A
+//* Current density J = Jᵉ
+
+#include "magnetostatic_formulation.hpp"
+
+namespace hephaestus {
+
+MagnetostaticFormulation::MagnetostaticFormulation(const std::string &magnetic_reluctivity_name,
+                           const std::string &magnetic_permeability_name,
+                           const std::string &magnetic_vector_potential_name)
+    : StaticsFormulation(magnetic_reluctivity_name, magnetic_vector_potential_name),
+      _magnetic_permeability_name(magnetic_permeability_name) {}
+
+void MagnetostaticFormulation::RegisterAuxSolvers() {
+  hephaestus::GridFunctions &gridfunctions = this->GetProblem()->gridfunctions;
+  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  std::vector<std::string> aux_var_names;
+  std::string b_field_name = "magnetic_flux_density";
+  if (gridfunctions.Get(b_field_name) != NULL) {
+    hephaestus::InputParameters b_field_aux_params;
+    b_field_aux_params.SetParam("VariableName", _h_curl_var_name);
+    b_field_aux_params.SetParam("CurlVariableName", b_field_name);
+    auxsolvers.Register("_magnetic_flux_density_aux",
+                        new hephaestus::CurlAuxSolver(b_field_aux_params),
+                        true);
+  }
+}
+
+void MagnetostaticFormulation::RegisterCoefficients() {
+  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  if (!coefficients.scalars.Has(_magnetic_permeability_name)) {
+    MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
+  }
+  coefficients.scalars.Register(
+      _magnetic_reluctivity_name,
+      new mfem::TransformedCoefficient(
+          &oneCoef, coefficients.scalars.Get(_magnetic_permeability_name),
+          fracFunc),
+      true);
+}
+} // namespace hephaestus

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include "../common/pfem_extras.hpp"
+#include "statics_formulation.hpp"
+#include "inputs.hpp"
+
+namespace hephaestus {
+
+class MagnetostaticFormulation : public hephaestus::StaticsFormulation {
+public:
+  MagnetostaticFormulation(const std::string &magnetic_reluctivity_name,
+               const std::string &magnetic_permeability_name,
+               const std::string &magnetic_vector_potential_name);
+
+  ~MagnetostaticFormulation(){};
+
+  virtual void RegisterAuxSolvers() override;
+
+  virtual void RegisterCoefficients() override;
+
+protected:
+  const std::string _magnetic_permeability_name;
+  const std::string &_magnetic_reluctivity_name =
+      hephaestus::StaticsFormulation::_alpha_coef_name;
+};
+} // namespace hephaestus

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
@@ -1,15 +1,15 @@
 #pragma once
 #include "../common/pfem_extras.hpp"
-#include "statics_formulation.hpp"
 #include "inputs.hpp"
+#include "statics_formulation.hpp"
 
 namespace hephaestus {
 
 class MagnetostaticFormulation : public hephaestus::StaticsFormulation {
 public:
   MagnetostaticFormulation(const std::string &magnetic_reluctivity_name,
-               const std::string &magnetic_permeability_name,
-               const std::string &magnetic_vector_potential_name);
+                           const std::string &magnetic_permeability_name,
+                           const std::string &magnetic_vector_potential_name);
 
   ~MagnetostaticFormulation(){};
 

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -30,7 +30,7 @@
 namespace hephaestus {
 
 StaticsFormulation::StaticsFormulation(const std::string &alpha_coef_name,
-                                   const std::string &h_curl_var_name)
+                                       const std::string &h_curl_var_name)
     : SteadyStateFormulation(), _alpha_coef_name(alpha_coef_name),
       _h_curl_var_name(h_curl_var_name) {}
 
@@ -39,11 +39,12 @@ void StaticsFormulation::ConstructOperator() {
       this->GetProblem()->solver_options;
   solver_options.SetParam("HCurlVarName", _h_curl_var_name);
   solver_options.SetParam("StiffnessCoefName", _alpha_coef_name);
-  this->problem->eq_sys_operator = std::make_unique<hephaestus::StaticsOperator>(
-      *(this->problem->pmesh), this->problem->fespaces,
-      this->problem->gridfunctions, this->problem->bc_map,
-      this->problem->coefficients, this->problem->sources,
-      this->problem->solver_options);
+  this->problem->eq_sys_operator =
+      std::make_unique<hephaestus::StaticsOperator>(
+          *(this->problem->pmesh), this->problem->fespaces,
+          this->problem->gridfunctions, this->problem->bc_map,
+          this->problem->coefficients, this->problem->sources,
+          this->problem->solver_options);
   this->problem->GetOperator()->SetGridFunctions();
 };
 
@@ -71,15 +72,15 @@ void StaticsFormulation::RegisterCoefficients() {
 }
 
 StaticsOperator::StaticsOperator(mfem::ParMesh &pmesh,
-                             hephaestus::FESpaces &fespaces,
-                             hephaestus::GridFunctions &gridfunctions,
-                             hephaestus::BCMap &bc_map,
-                             hephaestus::Coefficients &coefficients,
-                             hephaestus::Sources &sources,
-                             hephaestus::InputParameters &solver_options)
+                                 hephaestus::FESpaces &fespaces,
+                                 hephaestus::GridFunctions &gridfunctions,
+                                 hephaestus::BCMap &bc_map,
+                                 hephaestus::Coefficients &coefficients,
+                                 hephaestus::Sources &sources,
+                                 hephaestus::InputParameters &solver_options)
     : EquationSystemOperator(pmesh, fespaces, gridfunctions, bc_map,
-                                       coefficients, sources, solver_options),      
-                                       h_curl_var_name(solver_options.GetParam<std::string>("HCurlVarName")),
+                             coefficients, sources, solver_options),
+      h_curl_var_name(solver_options.GetParam<std::string>("HCurlVarName")),
       stiffness_coef_name(
           solver_options.GetParam<std::string>("StiffnessCoefName")) {}
 
@@ -104,7 +105,7 @@ Fully discretised equations
 (α∇×u, ∇×u') - (s0, u') - <(α∇×u) × n, u'> = 0
 */
 void StaticsOperator::Solve(mfem::Vector &X) {
-  mfem::ParGridFunction a_ (local_test_vars.at(0)->ParFESpace());
+  mfem::ParGridFunction a_(local_test_vars.at(0)->ParFESpace());
   a_ = 0.0;
   mfem::ParLinearForm b1_(a_.ParFESpace());
   b1_ = 0.0;
@@ -123,7 +124,8 @@ void StaticsOperator::Solve(mfem::Vector &X) {
   mfem::HypreParVector RHS(a_.ParFESpace());
   a1_.FormLinearSystem(ess_bdr_tdofs_, a_, b1_, CurlMuInvCurl, A, RHS);
 
-  hephaestus::DefaultHCurlPCGSolver a1_solver(_solver_options, CurlMuInvCurl, a_.ParFESpace());
+  hephaestus::DefaultHCurlPCGSolver a1_solver(_solver_options, CurlMuInvCurl,
+                                              a_.ParFESpace());
   a1_solver.Mult(RHS, A);
   a1_.RecoverFEMSolution(A, b1_, *_gridfunctions.Get(state_var_names.at(0)));
 }

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -1,0 +1,131 @@
+// Solves the equations
+// ∇⋅s0 = 0
+// ∇×(α∇×u) = s0
+
+// where
+// s0 ∈ H(div) source field
+// u ∈ H(curl)
+
+// Dirichlet boundaries constrain u
+// Integrated boundaries constrain (α∇×u) × n
+
+// Weak form (Space discretisation)
+// (α∇×u, ∇×u') - (s0, u') - <(α∇×u) × n, u'> = 0
+
+// Time discretisation using implicit scheme:
+// Unknowns
+// u ∈ H(curl)
+
+// Fully discretised equations
+// (α∇×u, ∇×u') - (s0, u') - <(α∇×u) × n, u'> = 0
+
+// Rewritten as
+// a1(u, u') = b1(u')
+
+// where
+// a1(u, u') = (α∇×u, ∇×u')
+// b1(u') = (s0, u') + <(α∇×u) × n, u'>
+#include "statics_formulation.hpp"
+
+namespace hephaestus {
+
+StaticsFormulation::StaticsFormulation(const std::string &alpha_coef_name,
+                                   const std::string &h_curl_var_name)
+    : SteadyStateFormulation(), _alpha_coef_name(alpha_coef_name),
+      _h_curl_var_name(h_curl_var_name) {}
+
+void StaticsFormulation::ConstructOperator() {
+  hephaestus::InputParameters &solver_options =
+      this->GetProblem()->solver_options;
+  solver_options.SetParam("HCurlVarName", _h_curl_var_name);
+  solver_options.SetParam("StiffnessCoefName", _alpha_coef_name);
+  this->problem->eq_sys_operator = std::make_unique<hephaestus::StaticsOperator>(
+      *(this->problem->pmesh), this->problem->fespaces,
+      this->problem->gridfunctions, this->problem->bc_map,
+      this->problem->coefficients, this->problem->sources,
+      this->problem->solver_options);
+  this->problem->GetOperator()->SetGridFunctions();
+};
+
+void StaticsFormulation::RegisterGridFunctions() {
+  int &myid = this->GetProblem()->myid_;
+  hephaestus::GridFunctions &gridfunctions = this->GetProblem()->gridfunctions;
+  hephaestus::FESpaces &fespaces = this->GetProblem()->fespaces;
+
+  // Register default ParGridFunctions of state gridfunctions if not provided
+  if (!gridfunctions.Has(_h_curl_var_name)) {
+    if (myid == 0) {
+      MFEM_WARNING(_h_curl_var_name << " not found in gridfunctions: building "
+                                       "gridfunction from defaults");
+    }
+    AddFESpace(std::string("_HCurlFESpace"), std::string("ND_3D_P2"));
+    AddGridFunction(_h_curl_var_name, std::string("_HCurlFESpace"));
+  };
+};
+
+void StaticsFormulation::RegisterCoefficients() {
+  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  if (!coefficients.scalars.Has(_alpha_coef_name)) {
+    MFEM_ABORT(_alpha_coef_name + " coefficient not found.");
+  }
+}
+
+StaticsOperator::StaticsOperator(mfem::ParMesh &pmesh,
+                             hephaestus::FESpaces &fespaces,
+                             hephaestus::GridFunctions &gridfunctions,
+                             hephaestus::BCMap &bc_map,
+                             hephaestus::Coefficients &coefficients,
+                             hephaestus::Sources &sources,
+                             hephaestus::InputParameters &solver_options)
+    : EquationSystemOperator(pmesh, fespaces, gridfunctions, bc_map,
+                                       coefficients, sources, solver_options),      
+                                       h_curl_var_name(solver_options.GetParam<std::string>("HCurlVarName")),
+      stiffness_coef_name(
+          solver_options.GetParam<std::string>("StiffnessCoefName")) {}
+
+void StaticsOperator::SetGridFunctions() {
+  state_var_names.push_back(h_curl_var_name);
+  EquationSystemOperator::SetGridFunctions();
+};
+
+void StaticsOperator::Init(mfem::Vector &X) {
+  EquationSystemOperator::Init(X);
+  stiffCoef_ = _coefficients.scalars.Get(stiffness_coef_name);
+}
+
+/*
+This is the main method that solves for u.
+
+Unknowns
+s0 ∈ H(div) divergence-free source field
+u ∈ H(curl)
+
+Fully discretised equations
+(α∇×u, ∇×u') - (s0, u') - <(α∇×u) × n, u'> = 0
+*/
+void StaticsOperator::Solve(mfem::Vector &X) {
+  mfem::ParGridFunction a_ (local_test_vars.at(0)->ParFESpace());
+  a_ = 0.0;
+  mfem::ParLinearForm b1_(a_.ParFESpace());
+  b1_ = 0.0;
+  mfem::Array<int> ess_bdr_tdofs_;
+  _bc_map.applyEssentialBCs(h_curl_var_name, ess_bdr_tdofs_, a_, pmesh_);
+  _bc_map.applyIntegratedBCs(h_curl_var_name, b1_, pmesh_);
+  b1_.Assemble();
+  _sources.Apply(&b1_);
+
+  mfem::ParBilinearForm a1_(a_.ParFESpace());
+  a1_.AddDomainIntegrator(new mfem::CurlCurlIntegrator(*stiffCoef_));
+  a1_.Assemble();
+
+  mfem::HypreParMatrix CurlMuInvCurl;
+  mfem::HypreParVector A(a_.ParFESpace());
+  mfem::HypreParVector RHS(a_.ParFESpace());
+  a1_.FormLinearSystem(ess_bdr_tdofs_, a_, b1_, CurlMuInvCurl, A, RHS);
+
+  hephaestus::DefaultHCurlPCGSolver a1_solver(_solver_options, CurlMuInvCurl, a_.ParFESpace());
+  a1_solver.Mult(RHS, A);
+  a1_.RecoverFEMSolution(A, b1_, *_gridfunctions.Get(state_var_names.at(0)));
+}
+
+} // namespace hephaestus

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -105,7 +105,7 @@ Fully discretised equations
 (α∇×u, ∇×u') - (s0, u') - <(α∇×u) × n, u'> = 0
 */
 void StaticsOperator::Solve(mfem::Vector &X) {
-  mfem::ParGridFunction a_(local_test_vars.at(0)->ParFESpace());
+  mfem::ParGridFunction &a_(*local_test_vars.at(0));
   a_ = 0.0;
   mfem::ParLinearForm b1_(a_.ParFESpace());
   b1_ = 0.0;
@@ -120,14 +120,14 @@ void StaticsOperator::Solve(mfem::Vector &X) {
   a1_.Assemble();
 
   mfem::HypreParMatrix CurlMuInvCurl;
-  mfem::HypreParVector A(a_.ParFESpace());
-  mfem::HypreParVector RHS(a_.ParFESpace());
+  mfem::Vector &A(trueX.GetBlock(0));
+  mfem::Vector &RHS(trueRhs.GetBlock(0));
   a1_.FormLinearSystem(ess_bdr_tdofs_, a_, b1_, CurlMuInvCurl, A, RHS);
 
   hephaestus::DefaultHCurlPCGSolver a1_solver(_solver_options, CurlMuInvCurl,
                                               a_.ParFESpace());
   a1_solver.Mult(RHS, A);
-  a1_.RecoverFEMSolution(A, b1_, *_gridfunctions.Get(state_var_names.at(0)));
+  a1_.RecoverFEMSolution(A, b1_, a_);
 }
 
 } // namespace hephaestus

--- a/src/formulations/Magnetostatic/statics_formulation.hpp
+++ b/src/formulations/Magnetostatic/statics_formulation.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include "../common/pfem_extras.hpp"
+#include "formulation.hpp"
+#include "inputs.hpp"
+#include "sources.hpp"
+
+namespace hephaestus {
+
+class StaticsFormulation : public SteadyStateFormulation {
+public:
+  StaticsFormulation(const std::string &alpha_coef_name,
+                   const std::string &h_curl_var_name);
+
+  virtual void ConstructOperator() override;
+
+  virtual void RegisterGridFunctions() override;
+
+  virtual void RegisterCoefficients() override;
+
+protected:
+  const std::string _alpha_coef_name;
+  const std::string _h_curl_var_name;
+};
+
+class StaticsOperator : public EquationSystemOperator {
+public:
+  StaticsOperator(mfem::ParMesh &pmesh, hephaestus::FESpaces &fespaces,
+                hephaestus::GridFunctions &gridfunctions,
+                hephaestus::BCMap &bc_map,
+                hephaestus::Coefficients &coefficients,
+                hephaestus::Sources &sources,
+                hephaestus::InputParameters &solver_options);
+
+  ~StaticsOperator(){};
+
+  virtual void SetGridFunctions() override;
+  virtual void Init(mfem::Vector &X) override;
+  virtual void Solve(mfem::Vector &X) override;
+
+private:
+  std::string h_curl_var_name, stiffness_coef_name;
+
+  mfem::Coefficient *stiffCoef_; // Stiffness Material Coefficient
+};
+
+} // namespace hephaestus

--- a/src/formulations/Magnetostatic/statics_formulation.hpp
+++ b/src/formulations/Magnetostatic/statics_formulation.hpp
@@ -9,7 +9,7 @@ namespace hephaestus {
 class StaticsFormulation : public SteadyStateFormulation {
 public:
   StaticsFormulation(const std::string &alpha_coef_name,
-                   const std::string &h_curl_var_name);
+                     const std::string &h_curl_var_name);
 
   virtual void ConstructOperator() override;
 
@@ -25,11 +25,11 @@ protected:
 class StaticsOperator : public EquationSystemOperator {
 public:
   StaticsOperator(mfem::ParMesh &pmesh, hephaestus::FESpaces &fespaces,
-                hephaestus::GridFunctions &gridfunctions,
-                hephaestus::BCMap &bc_map,
-                hephaestus::Coefficients &coefficients,
-                hephaestus::Sources &sources,
-                hephaestus::InputParameters &solver_options);
+                  hephaestus::GridFunctions &gridfunctions,
+                  hephaestus::BCMap &bc_map,
+                  hephaestus::Coefficients &coefficients,
+                  hephaestus::Sources &sources,
+                  hephaestus::InputParameters &solver_options);
 
   ~StaticsOperator(){};
 

--- a/src/formulations/equation_system_operator.cpp
+++ b/src/formulations/equation_system_operator.cpp
@@ -1,8 +1,8 @@
-#include "frequency_domain_equation_system_operator.hpp"
+#include "equation_system_operator.hpp"
 
 namespace hephaestus {
 
-void FrequencyDomainEquationSystemOperator::SetGridFunctions() {
+void EquationSystemOperator::SetGridFunctions() {
   local_test_vars = populateVectorFromNamedFieldsMap<mfem::ParGridFunction>(
       _gridfunctions, state_var_names);
 
@@ -36,7 +36,7 @@ void FrequencyDomainEquationSystemOperator::SetGridFunctions() {
   }
 };
 
-void FrequencyDomainEquationSystemOperator::Init(mfem::Vector &X) {
+void EquationSystemOperator::Init(mfem::Vector &X) {
   // Define material property coefficients
   for (unsigned int ind = 0; ind < local_test_vars.size(); ++ind) {
     local_test_vars.at(ind)->MakeRef(local_test_vars.at(ind)->ParFESpace(),
@@ -45,6 +45,6 @@ void FrequencyDomainEquationSystemOperator::Init(mfem::Vector &X) {
   }
 }
 
-void FrequencyDomainEquationSystemOperator::Solve(mfem::Vector &X) {}
+void EquationSystemOperator::Solve(mfem::Vector &X) {}
 
 } // namespace hephaestus

--- a/src/formulations/equation_system_operator.hpp
+++ b/src/formulations/equation_system_operator.hpp
@@ -7,9 +7,9 @@
 #include "sources.hpp"
 
 namespace hephaestus {
-class FrequencyDomainEquationSystemOperator : public mfem::Operator {
+class EquationSystemOperator : public mfem::Operator {
 public:
-  FrequencyDomainEquationSystemOperator(
+  EquationSystemOperator(
       mfem::ParMesh &pmesh, hephaestus::FESpaces &fespaces,
       hephaestus::GridFunctions &gridfunctions, hephaestus::BCMap &bc_map,
       hephaestus::Coefficients &coefficients, hephaestus::Sources &sources,
@@ -18,7 +18,7 @@ public:
         _gridfunctions(gridfunctions), _bc_map(bc_map), _sources(sources),
         _coefficients(coefficients), _solver_options(solver_options){};
 
-  ~FrequencyDomainEquationSystemOperator(){};
+  ~EquationSystemOperator(){};
 
   virtual void SetGridFunctions();
   virtual void Init(mfem::Vector &X);

--- a/src/formulations/equation_system_operator.hpp
+++ b/src/formulations/equation_system_operator.hpp
@@ -9,11 +9,12 @@
 namespace hephaestus {
 class EquationSystemOperator : public mfem::Operator {
 public:
-  EquationSystemOperator(
-      mfem::ParMesh &pmesh, hephaestus::FESpaces &fespaces,
-      hephaestus::GridFunctions &gridfunctions, hephaestus::BCMap &bc_map,
-      hephaestus::Coefficients &coefficients, hephaestus::Sources &sources,
-      hephaestus::InputParameters &solver_options)
+  EquationSystemOperator(mfem::ParMesh &pmesh, hephaestus::FESpaces &fespaces,
+                         hephaestus::GridFunctions &gridfunctions,
+                         hephaestus::BCMap &bc_map,
+                         hephaestus::Coefficients &coefficients,
+                         hephaestus::Sources &sources,
+                         hephaestus::InputParameters &solver_options)
       : myid_(0), num_procs_(1), pmesh_(&pmesh), _fespaces(fespaces),
         _gridfunctions(gridfunctions), _bc_map(bc_map), _sources(sources),
         _coefficients(coefficients), _solver_options(solver_options){};
@@ -36,7 +37,7 @@ public:
   // in formulation,
   std::vector<std::string> active_aux_var_names;
 
-  std::vector<mfem::ParGridFunction *> local_trial_vars, local_test_vars;
+  std::vector<mfem::ParGridFunction *> local_test_vars;
 
   int myid_;
   int num_procs_;

--- a/src/formulations/formulation.hpp
+++ b/src/formulations/formulation.hpp
@@ -1,3 +1,4 @@
 #pragma once
+#include "steady_state_formulation.hpp"
 #include "frequency_domain_formulation.hpp"
 #include "time_domain_formulation.hpp"

--- a/src/formulations/frequency_domain_formulation.hpp
+++ b/src/formulations/frequency_domain_formulation.hpp
@@ -1,12 +1,13 @@
 #pragma once
-#include "frequency_domain_problem_builder.hpp"
+#include "steady_state_problem_builder.hpp"
 
 namespace hephaestus {
 
 // Specifies output interfaces of a frequency-domain EM formulation.
 class FrequencyDomainFormulation
-    : public hephaestus::FrequencyDomainProblemBuilder {
-
+    : public hephaestus::SteadyStateProblemBuilder {
+protected:
+  mfem::ConstantCoefficient *freqCoef;
 public:
   FrequencyDomainFormulation();
 };

--- a/src/formulations/steady_state_formulation.cpp
+++ b/src/formulations/steady_state_formulation.cpp
@@ -1,0 +1,7 @@
+#include "steady_state_formulation.hpp"
+
+namespace hephaestus {
+
+SteadyStateFormulation::SteadyStateFormulation(){};
+
+} // namespace hephaestus

--- a/src/formulations/steady_state_formulation.hpp
+++ b/src/formulations/steady_state_formulation.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "steady_state_problem_builder.hpp"
+
+namespace hephaestus {
+
+// Specifies output interfaces of a time-independent problem formulation.
+class SteadyStateFormulation
+    : public hephaestus::SteadyStateProblemBuilder {
+public:
+  SteadyStateFormulation();
+};
+} // namespace hephaestus

--- a/src/formulations/steady_state_formulation.hpp
+++ b/src/formulations/steady_state_formulation.hpp
@@ -4,8 +4,7 @@
 namespace hephaestus {
 
 // Specifies output interfaces of a time-independent problem formulation.
-class SteadyStateFormulation
-    : public hephaestus::SteadyStateProblemBuilder {
+class SteadyStateFormulation : public hephaestus::SteadyStateProblemBuilder {
 public:
   SteadyStateFormulation();
 };

--- a/src/problem_builders/problem_builder.hpp
+++ b/src/problem_builders/problem_builder.hpp
@@ -1,4 +1,4 @@
 #pragma once
 #include "factory.hpp"
-#include "frequency_domain_problem_builder.hpp"
+#include "steady_state_problem_builder.hpp"
 #include "time_domain_problem_builder.hpp"

--- a/src/problem_builders/steady_state_problem_builder.cpp
+++ b/src/problem_builders/steady_state_problem_builder.cpp
@@ -1,28 +1,28 @@
-#include "frequency_domain_problem_builder.hpp"
+#include "steady_state_problem_builder.hpp"
 
 namespace hephaestus {
 
-void FrequencyDomainProblemBuilder::InitializeKernels() {
+void SteadyStateProblemBuilder::InitializeKernels() {
   this->problem->preprocessors.Init(this->problem->gridfunctions,
                                     this->problem->coefficients);
   this->problem->sources.Init(this->problem->gridfunctions,
                               this->problem->fespaces, this->problem->bc_map,
                               this->problem->coefficients);
 }
-void FrequencyDomainProblemBuilder::ConstructOperator() {
-  this->problem->fd_operator =
-      std::make_unique<hephaestus::FrequencyDomainEquationSystemOperator>(
+void SteadyStateProblemBuilder::ConstructOperator() {
+  this->problem->eq_sys_operator =
+      std::make_unique<hephaestus::EquationSystemOperator>(
           *(this->problem->pmesh), this->problem->fespaces,
           this->problem->gridfunctions, this->problem->bc_map,
           this->problem->coefficients, this->problem->sources,
           this->problem->solver_options);
-  this->problem->fd_operator->SetGridFunctions();
+  this->problem->eq_sys_operator->SetGridFunctions();
 }
 
-void FrequencyDomainProblemBuilder::ConstructState() {
+void SteadyStateProblemBuilder::ConstructState() {
   this->problem->F = new mfem::BlockVector(
-      this->problem->fd_operator->true_offsets); // Vector of dofs
-  this->problem->fd_operator->Init(
+      this->problem->eq_sys_operator->true_offsets); // Vector of dofs
+  this->problem->eq_sys_operator->Init(
       *(this->problem->F)); // Set up initial conditions
 }
 } // namespace hephaestus

--- a/src/problem_builders/steady_state_problem_builder.hpp
+++ b/src/problem_builders/steady_state_problem_builder.hpp
@@ -1,40 +1,39 @@
 #pragma once
-#include "frequency_domain_equation_system_operator.hpp"
+#include "equation_system_operator.hpp"
 #include "problem_builder_base.hpp"
 namespace hephaestus {
 
-class FrequencyDomainProblem : public hephaestus::Problem {
+class SteadyStateProblem : public hephaestus::Problem {
 public:
   std::unique_ptr<hephaestus::EquationSystem> eq_sys;
-  std::unique_ptr<hephaestus::FrequencyDomainEquationSystemOperator>
-      fd_operator;
+  std::unique_ptr<hephaestus::EquationSystemOperator>
+      eq_sys_operator;
 
-  FrequencyDomainProblem() = default;
+  SteadyStateProblem() = default;
 
   virtual hephaestus::EquationSystem *GetEquationSystem() {
     return eq_sys.get();
   };
-  virtual hephaestus::FrequencyDomainEquationSystemOperator *GetOperator() {
-    return fd_operator.get();
+  virtual hephaestus::EquationSystemOperator *GetOperator() {
+    return eq_sys_operator.get();
   };
 };
 
 // Builder class of a frequency-domain problem.
-class FrequencyDomainProblemBuilder : public hephaestus::ProblemBuilder {
+class SteadyStateProblemBuilder : public hephaestus::ProblemBuilder {
 protected:
-  std::unique_ptr<hephaestus::FrequencyDomainProblem> problem;
+  std::unique_ptr<hephaestus::SteadyStateProblem> problem;
   mfem::ConstantCoefficient oneCoef{1.0};
-  mfem::ConstantCoefficient *freqCoef;
 
-  virtual hephaestus::FrequencyDomainProblem *GetProblem() override {
+  virtual hephaestus::SteadyStateProblem *GetProblem() override {
     return this->problem.get();
   };
 
 public:
-  FrequencyDomainProblemBuilder()
-      : problem(std::make_unique<hephaestus::FrequencyDomainProblem>()){};
+  SteadyStateProblemBuilder()
+      : problem(std::make_unique<hephaestus::SteadyStateProblem>()){};
 
-  virtual std::unique_ptr<hephaestus::FrequencyDomainProblem> ReturnProblem() {
+  virtual std::unique_ptr<hephaestus::SteadyStateProblem> ReturnProblem() {
     return std::move(this->problem);
   };
 

--- a/src/problem_builders/steady_state_problem_builder.hpp
+++ b/src/problem_builders/steady_state_problem_builder.hpp
@@ -6,8 +6,7 @@ namespace hephaestus {
 class SteadyStateProblem : public hephaestus::Problem {
 public:
   std::unique_ptr<hephaestus::EquationSystem> eq_sys;
-  std::unique_ptr<hephaestus::EquationSystemOperator>
-      eq_sys_operator;
+  std::unique_ptr<hephaestus::EquationSystemOperator> eq_sys_operator;
 
   SteadyStateProblem() = default;
 

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -23,4 +23,4 @@ target_link_libraries(integration_tests ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${P
 target_link_libraries(integration_tests ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY} -lrt)
 
 include(GoogleTest)
-gtest_discover_tests(integration_tests EXTRA_ARGS --data_directory ${PROJECT_SOURCE_DIR}/data/)
+gtest_discover_tests(integration_tests PROPERTIES DISCOVERY_TIMEOUT 30 EXTRA_ARGS --data_directory ${PROJECT_SOURCE_DIR}/data/)

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -138,7 +138,7 @@ TEST_F(TestComplexAFormRod, CheckRun) {
   hephaestus::InputParameters params(test_params());
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
-  hephaestus::FrequencyDomainProblemBuilder *problem_builder =
+  hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexAFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
           "dielectric_permittivity", "frequency", "magnetic_vector_potential");
@@ -169,7 +169,7 @@ TEST_F(TestComplexAFormRod, CheckRun) {
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder);
   sequencer.ConstructOperatorProblem();
-  std::unique_ptr<hephaestus::FrequencyDomainProblem> problem =
+  std::unique_ptr<hephaestus::SteadyStateProblem> problem =
       problem_builder->ReturnProblem();
 
   hephaestus::InputParameters exec_params;

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -125,7 +125,7 @@ TEST_F(TestComplexERMESMouse, CheckRun) {
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
-  hephaestus::FrequencyDomainProblemBuilder *problem_builder =
+  hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexEFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
           "dielectric_permittivity", "frequency", "electric_field");
@@ -154,7 +154,7 @@ TEST_F(TestComplexERMESMouse, CheckRun) {
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder);
   sequencer.ConstructOperatorProblem();
-  std::unique_ptr<hephaestus::FrequencyDomainProblem> problem =
+  std::unique_ptr<hephaestus::SteadyStateProblem> problem =
       problem_builder->ReturnProblem();
 
   hephaestus::InputParameters exec_params;

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -118,7 +118,7 @@ TEST_F(TestComplexIrisWaveguide, CheckRun) {
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
-  hephaestus::FrequencyDomainProblemBuilder *problem_builder =
+  hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexEFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
           "dielectric_permittivity", "frequency", "electric_field");
@@ -147,7 +147,7 @@ TEST_F(TestComplexIrisWaveguide, CheckRun) {
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder);
   sequencer.ConstructOperatorProblem();
-  std::unique_ptr<hephaestus::FrequencyDomainProblem> problem =
+  std::unique_ptr<hephaestus::SteadyStateProblem> problem =
       problem_builder->ReturnProblem();
 
   hephaestus::InputParameters exec_params;

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -173,7 +173,7 @@ TEST_F(TestComplexTeam7, CheckRun) {
       params.GetOptionalParam<hephaestus::InputParameters>(
           "SolverOptions", hephaestus::InputParameters()));
 
-  hephaestus::FrequencyDomainProblemBuilder *problem_builder =
+  hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexAFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
           "dielectric_permittivity", "frequency", "magnetic_vector_potential");
@@ -199,7 +199,7 @@ TEST_F(TestComplexTeam7, CheckRun) {
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder);
   sequencer.ConstructOperatorProblem();
-  std::unique_ptr<hephaestus::FrequencyDomainProblem> problem =
+  std::unique_ptr<hephaestus::SteadyStateProblem> problem =
       problem_builder->ReturnProblem();
 
   hephaestus::InputParameters exec_params;

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(regression_tests ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PR
 target_link_libraries(regression_tests ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY} -lrt)
 
 include(GoogleTest)
-gtest_discover_tests(regression_tests)
+gtest_discover_tests(regression_tests PROPERTIES DISCOVERY_TIMEOUT 30)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(unit_tests ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PROJECT_
 target_link_libraries(unit_tests ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY} -lrt)
 
 include(GoogleTest)
-gtest_discover_tests(unit_tests EXTRA_ARGS --data_directory ${PROJECT_SOURCE_DIR}/data/)
+gtest_discover_tests(unit_tests PROPERTIES DISCOVERY_TIMEOUT 30 EXTRA_ARGS --data_directory ${PROJECT_SOURCE_DIR}/data/)


### PR DESCRIPTION
Adds a magnetostatic solver (similar to MFEM's Tesla miniapp) to complement the existing magnetodynamic formulations in Hephaestus, and provide a template for future contributed steady state problems.