### PR TITLE
Changed VectorFunctionDirichletBC to VectorDirichletBC

### DIFF
--- a/src/boundary_conditions/Essential/essential_bcs.hpp
+++ b/src/boundary_conditions/Essential/essential_bcs.hpp
@@ -1,3 +1,3 @@
 #pragma once
 #include "function_dirichlet_bc.hpp"
-#include "vector_function_dirichlet_bc.hpp"
+#include "vector_dirichlet_bc.hpp"

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
@@ -1,19 +1,19 @@
-#include "vector_function_dirichlet_bc.hpp"
+#include "vector_dirichlet_bc.hpp"
 
 namespace hephaestus {
 
-VectorFunctionDirichletBC::VectorFunctionDirichletBC(
+VectorDirichletBC::VectorDirichletBC(
     const std::string &name_, mfem::Array<int> bdr_attributes_)
     : EssentialBC(name_, bdr_attributes_) {}
 
-VectorFunctionDirichletBC::VectorFunctionDirichletBC(
+VectorDirichletBC::VectorDirichletBC(
     const std::string &name_, mfem::Array<int> bdr_attributes_,
-    mfem::VectorFunctionCoefficient *vec_coeff_,
-    mfem::VectorFunctionCoefficient *vec_coeff_im_)
+    mfem::VectorCoefficient *vec_coeff_,
+    mfem::VectorCoefficient *vec_coeff_im_)
     : EssentialBC(name_, bdr_attributes_), vec_coeff(vec_coeff_),
       vec_coeff_im(vec_coeff_im_) {}
 
-void VectorFunctionDirichletBC::applyBC(mfem::GridFunction &gridfunc,
+void VectorDirichletBC::applyBC(mfem::GridFunction &gridfunc,
                                         mfem::Mesh *mesh_) {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
   ess_bdrs = this->getMarkers(*mesh_);
@@ -25,7 +25,7 @@ void VectorFunctionDirichletBC::applyBC(mfem::GridFunction &gridfunc,
   gridfunc.ProjectBdrCoefficientTangent(*(this->vec_coeff), ess_bdrs);
 }
 
-void VectorFunctionDirichletBC::applyBC(mfem::ParComplexGridFunction &gridfunc,
+void VectorDirichletBC::applyBC(mfem::ParComplexGridFunction &gridfunc,
                                         mfem::Mesh *mesh_) {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
   ess_bdrs = this->getMarkers(*mesh_);

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
@@ -3,14 +3,14 @@
 
 namespace hephaestus {
 
-class VectorFunctionDirichletBC : public EssentialBC {
+class VectorDirichletBC : public EssentialBC {
 public:
-  VectorFunctionDirichletBC(const std::string &name_,
+  VectorDirichletBC(const std::string &name_,
                             mfem::Array<int> bdr_attributes_);
-  VectorFunctionDirichletBC(
+  VectorDirichletBC(
       const std::string &name_, mfem::Array<int> bdr_attributes_,
-      mfem::VectorFunctionCoefficient *vec_coeff_,
-      mfem::VectorFunctionCoefficient *vec_coeff_im_ = nullptr);
+      mfem::VectorCoefficient *vec_coeff_,
+      mfem::VectorCoefficient *vec_coeff_im_ = nullptr);
 
   virtual void applyBC(mfem::GridFunction &gridfunc,
                        mfem::Mesh *mesh_) override;

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -64,7 +64,7 @@ protected:
     mfem::VectorFunctionCoefficient *adotVecCoef =
         new mfem::VectorFunctionCoefficient(3, adot_bc);
     bc_map.Register("tangential_dAdt",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("dmagnetic_vector_potential_dt"),
                         mfem::Array<int>({1, 2, 3}), adotVecCoef),
                     true);

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -47,7 +47,7 @@ protected:
     mfem::VectorFunctionCoefficient *adotVecCoef =
         new mfem::VectorFunctionCoefficient(3, adot_bc);
     bc_map.Register("tangential_dAdt",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("dmagnetic_vector_potential_dt"),
                         mfem::Array<int>({1, 2, 3}), adotVecCoef),
                     true);

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -61,7 +61,7 @@ protected:
     mfem::VectorFunctionCoefficient *adotVecCoef =
         new mfem::VectorFunctionCoefficient(3, adot_bc);
     bc_map.Register("tangential_dAdt",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("dmagnetic_vector_potential_dt"),
                         mfem::Array<int>({1, 2, 3}), adotVecCoef),
                     true);

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -51,7 +51,7 @@ protected:
     hephaestus::BCMap bc_map;
 
     bc_map.Register("tangential_A",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("magnetic_vector_potential"),
                         mfem::Array<int>({1, 2, 3}),
                         new mfem::VectorFunctionCoefficient(3, a_bc_r),

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -55,7 +55,7 @@ protected:
     hephaestus::BCMap bc_map;
     mfem::Array<int> dirichlet_attr({2, 3, 4});
     bc_map.Register("tangential_E",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("electric_field"), dirichlet_attr,
                         new mfem::VectorFunctionCoefficient(3, e_bc_r),
                         new mfem::VectorFunctionCoefficient(3, e_bc_i)),

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -54,7 +54,7 @@ protected:
     mfem::Array<int> dirichlet_attr(1);
     dirichlet_attr[0] = 1;
     bc_map.Register("tangential_E",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("electric_field"), dirichlet_attr,
                         new mfem::VectorFunctionCoefficient(3, e_bc_r),
                         new mfem::VectorFunctionCoefficient(3, e_bc_i)),

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -74,7 +74,7 @@ protected:
     mfem::VectorFunctionCoefficient *edotVecCoef =
         new mfem::VectorFunctionCoefficient(3, edot_bc);
     bc_map.Register("tangential_dEdt",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("electric_field"),
                         mfem::Array<int>({1, 2, 3}), edotVecCoef),
                     true);

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -49,7 +49,7 @@ protected:
     mfem::VectorFunctionCoefficient *edotVecCoef =
         new mfem::VectorFunctionCoefficient(3, edot_bc);
     bc_map.Register("tangential_dEdt",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("electric_field"),
                         mfem::Array<int>({1, 2, 3}), edotVecCoef),
                     true);

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -49,7 +49,7 @@ protected:
     mfem::VectorFunctionCoefficient *hdotVecCoef =
         new mfem::VectorFunctionCoefficient(3, hdot_bc);
     bc_map.Register("tangential_dHdt",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("dmagnetic_field_dt"),
                         mfem::Array<int>({1, 2, 3}), hdotVecCoef),
                     true);

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -67,7 +67,7 @@ protected:
     mfem::VectorFunctionCoefficient *hdotVecCoef =
         new mfem::VectorFunctionCoefficient(3, hdot_bc);
     bc_map.Register("tangential_dHdt",
-                    new hephaestus::VectorFunctionDirichletBC(
+                    new hephaestus::VectorDirichletBC(
                         std::string("dmagnetic_field_dt"),
                         mfem::Array<int>({1, 2, 3}), hdotVecCoef),
                     true);


### PR DESCRIPTION
Renamed the `VectorFunctionDirichletBC` class to `VectorDirichletBC`, and made it so that its constructor takes in a `VectorCoefficient` instead of a `VectorFunctionCoefficient`.

The reason for this is that  `VectorCoefficent` is a parent class for both `VectorFunctionCoefficient` and also `VectorGridFunctionCoefficient`, and therefore both of these can be cast into a `VectorCoefficent`. Thus, now `VectorDirichletBC` extends its functionality to accept either an analytic vector function as a vector Dirichlet BC, or the vectors present on a `GridFunction` boundary. This will be particularly important for applying results from a submesh as boundary conditions for integrators on an adjacent or intersecting submesh. 