### PR TITLE
Added projection option option to VectorDirichletBC.

### DIFF
--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
@@ -9,9 +9,10 @@ VectorDirichletBC::VectorDirichletBC(
 VectorDirichletBC::VectorDirichletBC(
     const std::string &name_, mfem::Array<int> bdr_attributes_,
     mfem::VectorCoefficient *vec_coeff_,
-    mfem::VectorCoefficient *vec_coeff_im_)
+    mfem::VectorCoefficient *vec_coeff_im_,
+    APPLY_TYPE boundary_apply_type_)
     : EssentialBC(name_, bdr_attributes_), vec_coeff(vec_coeff_),
-      vec_coeff_im(vec_coeff_im_) {}
+      vec_coeff_im(vec_coeff_im_), boundary_apply_type(boundary_apply_type_) {}
 
 void VectorDirichletBC::applyBC(mfem::GridFunction &gridfunc,
                                         mfem::Mesh *mesh_) {
@@ -22,7 +23,21 @@ void VectorDirichletBC::applyBC(mfem::GridFunction &gridfunc,
         "Boundary condition does not store valid coefficients to specify the "
         "components of the vector at the Dirichlet boundary.");
   }
-  gridfunc.ProjectBdrCoefficientTangent(*(this->vec_coeff), ess_bdrs);
+
+  if(boundary_apply_type == STANDARD)
+  {
+    gridfunc.ProjectBdrCoefficient(*(this->vec_coeff), ess_bdrs);
+  }
+
+  if(boundary_apply_type == TANGENTIAL)
+  {
+    gridfunc.ProjectBdrCoefficientTangent(*(this->vec_coeff), ess_bdrs);
+  }
+
+  if(boundary_apply_type == NORMAL)
+  {
+    gridfunc.ProjectBdrCoefficientNormal(*(this->vec_coeff), ess_bdrs);
+  }
 }
 
 void VectorDirichletBC::applyBC(mfem::ParComplexGridFunction &gridfunc,

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
@@ -24,19 +24,16 @@ void VectorDirichletBC::applyBC(mfem::GridFunction &gridfunc,
         "components of the vector at the Dirichlet boundary.");
   }
 
-  if(boundary_apply_type == STANDARD)
+  switch (boundary_apply_type)
   {
+  case STANDARD:
     gridfunc.ProjectBdrCoefficient(*(this->vec_coeff), ess_bdrs);
-  }
-
-  if(boundary_apply_type == TANGENTIAL)
-  {
-    gridfunc.ProjectBdrCoefficientTangent(*(this->vec_coeff), ess_bdrs);
-  }
-
-  if(boundary_apply_type == NORMAL)
-  {
+    break;
+  case NORMAL:
     gridfunc.ProjectBdrCoefficientNormal(*(this->vec_coeff), ess_bdrs);
+    break;
+  case TANGENTIAL:
+    gridfunc.ProjectBdrCoefficientTangent(*(this->vec_coeff), ess_bdrs);
   }
 }
 

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
@@ -4,13 +4,24 @@
 namespace hephaestus {
 
 class VectorDirichletBC : public EssentialBC {
+
+protected:
+  enum APPLY_TYPE
+  {
+    STANDARD,
+    TANGENTIAL,
+    NORMAL
+  };
+
 public:
   VectorDirichletBC(const std::string &name_,
                             mfem::Array<int> bdr_attributes_);
   VectorDirichletBC(
       const std::string &name_, mfem::Array<int> bdr_attributes_,
       mfem::VectorCoefficient *vec_coeff_,
-      mfem::VectorCoefficient *vec_coeff_im_ = nullptr);
+      mfem::VectorCoefficient *vec_coeff_im_ = nullptr,
+      APPLY_TYPE boundary_apply_type = TANGENTIAL
+      );
 
   virtual void applyBC(mfem::GridFunction &gridfunc,
                        mfem::Mesh *mesh_) override;
@@ -20,6 +31,7 @@ public:
 
   mfem::VectorCoefficient *vec_coeff;
   mfem::VectorCoefficient *vec_coeff_im;
+  APPLY_TYPE boundary_apply_type;  
 };
 
 } // namespace hephaestus


### PR DESCRIPTION
Previously when a VectorDirichletBC was applied, it was assumed that the user wanted to use `ProjectBdrCoefficientTangent`. I've added an enum in VectorDirichletBC and an option to the constructor so that the user can specify how they want the coefficient projected.