### PR TITLE
Initialise preprocessed AuxSolvers during problem setup

### DIFF
--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -107,7 +107,9 @@ void ProblemBuilder::AddSource(std::string source_name,
   this->GetProblem()->sources.Register(source_name, source, own_data);
 }
 
-void ProblemBuilder::InitializePostprocessors() {
+void ProblemBuilder::InitializeAuxSolvers() {
+  this->GetProblem()->preprocessors.Init(this->GetProblem()->gridfunctions,
+                                         this->GetProblem()->coefficients);
   this->GetProblem()->postprocessors.Init(this->GetProblem()->gridfunctions,
                                           this->GetProblem()->coefficients);
 }

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -82,7 +82,7 @@ public:
   virtual void ConstructState() = 0;
   virtual void ConstructSolver() = 0;
 
-  void InitializePostprocessors();
+  void InitializeAuxSolvers();
 };
 
 class ProblemBuildSequencer {
@@ -114,7 +114,7 @@ public:
     this->problem_builder->InitializeKernels();
     this->problem_builder->ConstructOperator();
     this->problem_builder->ConstructState();
-    this->problem_builder->InitializePostprocessors();
+    this->problem_builder->InitializeAuxSolvers();
   }
   void ConstructEquationSystemProblem() {
     this->problem_builder->RegisterFESpaces();
@@ -126,7 +126,7 @@ public:
     this->problem_builder->ConstructOperator();
     this->problem_builder->ConstructState();
     this->problem_builder->ConstructSolver();
-    this->problem_builder->InitializePostprocessors();
+    this->problem_builder->InitializeAuxSolvers();
   }
 };
 


### PR DESCRIPTION
Initialises both pre- and post- processed auxsolvers in mfem_problem_builder. Previously only postprocessed auxsolvers were initialised.