### PR TITLE
Changes FunctionDirichletBC to ScalarDirichletBC

### DIFF
--- a/src/boundary_conditions/Essential/function_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/function_dirichlet_bc.cpp
@@ -2,18 +2,18 @@
 
 namespace hephaestus {
 
-FunctionDirichletBC::FunctionDirichletBC(const std::string &name_,
-                                         mfem::Array<int> bdr_attributes_)
+ScalarDirichletBC::ScalarDirichletBC(const std::string &name_,
+                                     mfem::Array<int> bdr_attributes_)
     : EssentialBC(name_, bdr_attributes_) {}
 
-FunctionDirichletBC::FunctionDirichletBC(const std::string &name_,
-                                         mfem::Array<int> bdr_attributes_,
-                                         mfem::FunctionCoefficient *coeff_,
-                                         mfem::FunctionCoefficient *coeff_im_)
+ScalarDirichletBC::ScalarDirichletBC(const std::string &name_,
+                                     mfem::Array<int> bdr_attributes_,
+                                     mfem::Coefficient *coeff_,
+                                     mfem::Coefficient *coeff_im_)
     : EssentialBC(name_, bdr_attributes_), coeff(coeff_), coeff_im(coeff_im_) {}
 
-void FunctionDirichletBC::applyBC(mfem::GridFunction &gridfunc,
-                                  mfem::Mesh *mesh_) {
+void ScalarDirichletBC::applyBC(mfem::GridFunction &gridfunc,
+                                mfem::Mesh *mesh_) {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
   ess_bdrs = this->getMarkers(*mesh_);
   gridfunc.ProjectBdrCoefficient(*(this->coeff), ess_bdrs);

--- a/src/boundary_conditions/Essential/function_dirichlet_bc.hpp
+++ b/src/boundary_conditions/Essential/function_dirichlet_bc.hpp
@@ -3,20 +3,18 @@
 
 namespace hephaestus {
 
-class FunctionDirichletBC : public EssentialBC {
+class ScalarDirichletBC : public EssentialBC {
 public:
-  FunctionDirichletBC(const std::string &name_,
-                      mfem::Array<int> bdr_attributes_);
-  FunctionDirichletBC(const std::string &name_,
-                      mfem::Array<int> bdr_attributes_,
-                      mfem::FunctionCoefficient *coeff_,
-                      mfem::FunctionCoefficient *coeff_im_ = nullptr);
+  ScalarDirichletBC(const std::string &name_, mfem::Array<int> bdr_attributes_);
+  ScalarDirichletBC(const std::string &name_, mfem::Array<int> bdr_attributes_,
+                    mfem::Coefficient *coeff_,
+                    mfem::Coefficient *coeff_im_ = nullptr);
 
   virtual void applyBC(mfem::GridFunction &gridfunc,
                        mfem::Mesh *mesh_) override;
 
-  mfem::FunctionCoefficient *coeff;
-  mfem::FunctionCoefficient *coeff_im;
+  mfem::Coefficient *coeff;
+  mfem::Coefficient *coeff_im;
 };
 
 } // namespace hephaestus

--- a/src/sources/closed_coil.cpp
+++ b/src/sources/closed_coil.cpp
@@ -345,9 +345,9 @@ void ClosedCoilSolver::SetBCs() {
 
   for (int i = 0; i < 2; ++i) {
 
-    high_DBC_[i] = new hephaestus::FunctionDirichletBC(
+    high_DBC_[i] = new hephaestus::ScalarDirichletBC(
         std::string("V_" + std::to_string(i)), high_terminal_, high_src_);
-    low_DBC_[i] = new hephaestus::FunctionDirichletBC(
+    low_DBC_[i] = new hephaestus::ScalarDirichletBC(
         std::string("V_" + std::to_string(i)), low_terminal_, low_src_);
     bc_maps_[i] = new hephaestus::BCMap;
     bc_maps_[i]->Register("high_potential", high_DBC_[i], true);

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "helmholtz_projector.hpp"
 #include "div_free_source.hpp"
+#include "helmholtz_projector.hpp"
 #include "scalar_potential_source.hpp"
 #include "source_base.hpp"
 
@@ -79,8 +79,11 @@ public:
   // Resets the domain attributes on the parent mesh to what they were initially
   void restoreAttributes();
 
-  // Applies the HelmholtzProjector onto the J GridFunction to clean it of any divergences 
-  void cleanDivergence(hephaestus::GridFunctions* gridfunctions, std::string J_name, std::string V_name, hephaestus::BCMap* bc_map);
+  // Applies the HelmholtzProjector onto the J GridFunction to clean it of any
+  // divergences
+  void cleanDivergence(hephaestus::GridFunctions *gridfunctions,
+                       std::string J_name, std::string V_name,
+                       hephaestus::BCMap *bc_map);
 
 private:
   // Parameters
@@ -122,8 +125,8 @@ private:
   std::vector<hephaestus::FESpaces *> fespaces_;
   std::vector<hephaestus::BCMap *> bc_maps_;
   std::vector<hephaestus::Coefficients *> coefs_;
-  std::vector<hephaestus::FunctionDirichletBC *> high_DBC_;
-  std::vector<hephaestus::FunctionDirichletBC *> low_DBC_;
+  std::vector<hephaestus::ScalarDirichletBC *> high_DBC_;
+  std::vector<hephaestus::ScalarDirichletBC *> low_DBC_;
 
   // Children boundary condition objects
   mfem::FunctionCoefficient *high_src_;

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -56,7 +56,7 @@ protected:
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
     bc_map.Register("high_potential",
-                    new hephaestus::FunctionDirichletBC(
+                    new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal,
                         new mfem::FunctionCoefficient(potential_high)),
                     true);
@@ -64,7 +64,7 @@ protected:
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;
     bc_map.Register("ground_potential",
-                    new hephaestus::FunctionDirichletBC(
+                    new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), ground_terminal,
                         new mfem::FunctionCoefficient(potential_ground)),
                     true);

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -74,7 +74,7 @@ protected:
     mfem::FunctionCoefficient *ground_coeff =
         new mfem::FunctionCoefficient(potential_ground);
     bc_map.Register("ground_potential",
-                    new hephaestus::FunctionDirichletBC(
+                    new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"),
                         mfem::Array<int>({1, 2, 3}), ground_coeff),
                     true);

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -64,15 +64,15 @@ protected:
         new mfem::FunctionCoefficient(potential_high);
     bc_map.Register(
         "high_potential",
-        new hephaestus::FunctionDirichletBC(std::string("electric_potential"),
-                                            high_terminal, potential_src),
+        new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
+                                          high_terminal, potential_src),
         true);
     coefficients.scalars.Register("source_potential", potential_src, true);
 
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;
     bc_map.Register("ground_potential",
-                    new hephaestus::FunctionDirichletBC(
+                    new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), ground_terminal,
                         new mfem::FunctionCoefficient(potential_ground)),
                     true);

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -88,15 +88,15 @@ protected:
         new mfem::FunctionCoefficient(potential_high);
     bc_map.Register(
         "high_potential",
-        new hephaestus::FunctionDirichletBC(std::string("electric_potential"),
-                                            high_terminal, potential_src),
+        new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
+                                          high_terminal, potential_src),
         true);
     coefficients.scalars.Register("source_potential", potential_src, true);
 
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;
     bc_map.Register("ground_potential",
-                    new hephaestus::FunctionDirichletBC(
+                    new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), ground_terminal,
                         new mfem::FunctionCoefficient(potential_ground)),
                     true);

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -63,15 +63,15 @@ protected:
         new mfem::FunctionCoefficient(potential_high);
     bc_map.Register(
         "high_potential",
-        new hephaestus::FunctionDirichletBC(std::string("electric_potential"),
-                                            high_terminal, potential_src),
+        new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
+                                          high_terminal, potential_src),
         true);
     coefficients.scalars.Register("source_potential", potential_src, true);
 
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;
     bc_map.Register("ground_potential",
-                    new hephaestus::FunctionDirichletBC(
+                    new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), ground_terminal,
                         new mfem::FunctionCoefficient(potential_ground)),
                     true);

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -60,7 +60,7 @@ protected:
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
     bc_map.Register("high_potential",
-                    new hephaestus::FunctionDirichletBC(
+                    new hephaestus::ScalarDirichletBC(
                         std::string("magnetic_potential"), high_terminal,
                         new mfem::FunctionCoefficient(potential_high)),
                     true);
@@ -68,7 +68,7 @@ protected:
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;
     bc_map.Register("ground_potential",
-                    new hephaestus::FunctionDirichletBC(
+                    new hephaestus::ScalarDirichletBC(
                         std::string("magnetic_potential"), ground_terminal,
                         new mfem::FunctionCoefficient(potential_ground)),
                     true);


### PR DESCRIPTION
Renames the `FunctionDirichletBC` class to `ScalarDirichletBC` and allows it to be constructed using `mfem::Coefficient`s rather than specifically `mfem::FunctionCoefficient`s, in analogy to `VectorDirichletBC` introduced in #25 