### PR TITLE
Adds methods to set up auxsolvers for EM-relevant fields to frequency domain EM formulations

### DIFF
--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -124,7 +124,8 @@ int main(int argc, char *argv[]) {
   hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexAFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
-          "dielectric_permittivity", "frequency", "magnetic_vector_potential");
+          "dielectric_permittivity", "frequency", "magnetic_vector_potential",
+          "magnetic_vector_potential_real", "magnetic_vector_potential_imag");
   // Set Mesh
   mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./team7.g")).c_str(), 1,
                   1);

--- a/src/auxsolvers/scaled_curl_vector_gridfunction_aux.cpp
+++ b/src/auxsolvers/scaled_curl_vector_gridfunction_aux.cpp
@@ -13,6 +13,7 @@ void ScaledCurlVectorGridFunctionAux::buildMixedBilinearForm() {
   a_mixed = new mfem::ParMixedBilinearForm(trial_fes, test_fes);
   a_mixed->AddDomainIntegrator(new mfem::MixedVectorCurlIntegrator(*coef));
   a_mixed->Assemble();
+  a_mixed->Finalize();
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
+++ b/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
@@ -25,11 +25,13 @@ double VectorGridFunctionDotProductCoefficient::Eval(
 
 VectorGridFunctionDotProductAux::VectorGridFunctionDotProductAux(
     const std::string &dot_product_gf_name,
-    const std::string &dot_product_coef_name, const std::string &u_gf_name,
-    const std::string &v_gf_name, const std::string &scaling_coef_name,
-    const bool complex_average)
+    const std::string &dot_product_coef_name,
+    const std::string &scaling_coef_name, const std::string &u_gf_real_name,
+    const std::string &v_gf_real_name, const std::string &u_gf_imag_name,
+    const std::string &v_gf_imag_name, const bool complex_average)
     : CoefficientAux(dot_product_gf_name, dot_product_coef_name),
-      _u_gf_name(u_gf_name), _v_gf_name(v_gf_name),
+      _u_gf_real_name(u_gf_real_name), _v_gf_real_name(v_gf_real_name),
+      _u_gf_imag_name(u_gf_imag_name), _v_gf_imag_name(v_gf_imag_name),
       _scaling_coef_name(scaling_coef_name), _complex_average(complex_average),
       _scaling_coef(nullptr), _u_gf_re(nullptr), _u_gf_im(nullptr),
       _v_gf_re(nullptr), _v_gf_im(nullptr) {}
@@ -44,48 +46,48 @@ void VectorGridFunctionDotProductAux::Init(
   }
 
   if (_complex_average) {
-    _u_gf_re = gridfunctions.Get(_u_gf_name + "_real");
+    _u_gf_re = gridfunctions.Get(_u_gf_real_name);
     if (_u_gf_re == NULL) {
       MFEM_ABORT(
           "GridFunction "
-          << _u_gf_name + "_real"
+          << _u_gf_real_name
           << " not found when initializing VectorGridFunctionDotProductAux");
     }
-    _v_gf_re = gridfunctions.Get(_v_gf_name + "_real");
+    _v_gf_re = gridfunctions.Get(_v_gf_real_name);
     if (_v_gf_re == NULL) {
       MFEM_ABORT(
           "GridFunction "
-          << _v_gf_name + "_real"
+          << _v_gf_real_name
           << " not found when initializing VectorGridFunctionDotProductAux");
     }
-    _u_gf_im = gridfunctions.Get(_u_gf_name + "_imag");
+    _u_gf_im = gridfunctions.Get(_u_gf_imag_name);
     if (_u_gf_im == NULL) {
       MFEM_ABORT(
           "GridFunction "
-          << _u_gf_name + "_imag"
+          << _u_gf_imag_name
           << " not found when initializing VectorGridFunctionDotProductAux");
     }
-    _v_gf_im = gridfunctions.Get(_v_gf_name + "_imag");
+    _v_gf_im = gridfunctions.Get(_v_gf_imag_name);
     if (_v_gf_im == NULL) {
       MFEM_ABORT(
           "GridFunction "
-          << _v_gf_name + "_imag"
+          << _v_gf_imag_name
           << " not found when initializing VectorGridFunctionDotProductAux");
     }
 
   } else {
-    _u_gf_re = gridfunctions.Get(_u_gf_name);
+    _u_gf_re = gridfunctions.Get(_u_gf_real_name);
     if (_u_gf_re == NULL) {
       MFEM_ABORT(
           "GridFunction "
-          << _u_gf_name
+          << _u_gf_real_name
           << " not found when initializing VectorGridFunctionDotProductAux");
     }
-    _v_gf_re = gridfunctions.Get(_v_gf_name);
+    _v_gf_re = gridfunctions.Get(_v_gf_real_name);
     if (_v_gf_re == NULL) {
       MFEM_ABORT(
           "GridFunction "
-          << _v_gf_name
+          << _v_gf_real_name
           << " not found when initializing VectorGridFunctionDotProductAux");
     }
   }

--- a/src/auxsolvers/vector_gridfunction_dot_product_aux.hpp
+++ b/src/auxsolvers/vector_gridfunction_dot_product_aux.hpp
@@ -37,17 +37,21 @@ private:
   mfem::ParGridFunction *_v_gf_re;
   mfem::ParGridFunction *_v_gf_im;
 
-  const std::string _u_gf_name;
-  const std::string _v_gf_name;
+  const std::string _u_gf_real_name;
+  const std::string _v_gf_real_name;
+  const std::string _u_gf_imag_name;
+  const std::string _v_gf_imag_name;
   const std::string _scaling_coef_name;
   bool _complex_average;
 
 public:
   VectorGridFunctionDotProductAux(const std::string &dot_product_gf_name,
                                   const std::string &dot_product_coef_name,
-                                  const std::string &u_gf_name,
-                                  const std::string &v_gf_name,
                                   const std::string &scaling_coef_name,
+                                  const std::string &u_gf_real_name,
+                                  const std::string &v_gf_real_name,
+                                  const std::string &u_gf_imag_name = "",
+                                  const std::string &v_gf_imag_name = "",
                                   const bool complex_average = false);
 
   void Init(const hephaestus::GridFunctions &gridfunctions,

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -28,11 +28,13 @@ Factory::createProblemBuilder(std::string &formulation_name) {
   } else if (formulation_name == "ComplexEForm") {
     return new hephaestus::ComplexEFormulation(
         "magnetic_reluctivity", "electrical_conductivity",
-        "dielectric_permittivity", "frequency", "electric_field");
+        "dielectric_permittivity", "frequency", "electric_field",
+        "electric_field_real", "electric_field_imag");
   } else if (formulation_name == "ComplexAForm") {
     return new hephaestus::ComplexAFormulation(
         "magnetic_reluctivity", "electrical_conductivity",
-        "dielectric_permittivity", "frequency", "magnetic_vector_potential");
+        "dielectric_permittivity", "frequency", "magnetic_vector_potential",
+        "magnetic_vector_potential_real", "magnetic_vector_potential_imag");
   } else if (formulation_name == "Custom") {
     return new hephaestus::TimeDomainEMFormulation();
   } else {
@@ -46,11 +48,13 @@ Factory::createFrequencyDomainEMFormulation(std::string &formulation) {
   if (formulation == "ComplexEForm") {
     return new hephaestus::ComplexEFormulation(
         "magnetic_reluctivity", "electrical_conductivity",
-        "dielectric_permittivity", "frequency", "electric_field");
+        "dielectric_permittivity", "frequency", "electric_field",
+        "electric_field_real", "electric_field_imag");
   } else if (formulation == "ComplexAForm") {
     return new hephaestus::ComplexAFormulation(
         "magnetic_reluctivity", "electrical_conductivity",
-        "dielectric_permittivity", "frequency", "magnetic_vector_potential");
+        "dielectric_permittivity", "frequency", "magnetic_vector_potential",
+        "magnetic_vector_potential_real", "magnetic_vector_potential_imag");
   } else {
     MFEM_WARNING("Steady formulation name " << formulation
                                             << " not recognised.");

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
@@ -7,11 +7,15 @@ ComplexAFormulation::ComplexAFormulation(
     const std::string &electric_conductivity_name,
     const std::string &dielectric_permittivity_name,
     const std::string &frequency_coef_name,
-    const std::string &magnetic_vector_potential_name)
+    const std::string &magnetic_vector_potential_complex_name,
+    const std::string &magnetic_vector_potential_real_name,
+    const std::string &magnetic_vector_potential_imag_name)
     : ComplexMaxwellFormulation(
           magnetic_reluctivity_name, electric_conductivity_name,
           dielectric_permittivity_name, frequency_coef_name,
-          magnetic_vector_potential_name){};
+          magnetic_vector_potential_complex_name,
+          magnetic_vector_potential_real_name,
+          magnetic_vector_potential_imag_name){};
 
 void ComplexAFormulation::RegisterAuxSolvers() {
   hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
@@ -25,12 +29,12 @@ void ComplexAFormulation::RegisterAuxSolvers() {
               << " found in gridfunctions: building auxvar " << std::endl;
     // }
     auxsolvers.Register("_magnetic_flux_density_re_aux",
-                        new hephaestus::CurlAuxSolver(
-                            _h_curl_var_name + "_real", b_field_name + "_real"),
+                        new hephaestus::CurlAuxSolver(_h_curl_var_real_name,
+                                                      b_field_name + "_real"),
                         true);
     auxsolvers.Register("_magnetic_flux_density_im_aux",
-                        new hephaestus::CurlAuxSolver(
-                            _h_curl_var_name + "_imag", b_field_name + "_imag"),
+                        new hephaestus::CurlAuxSolver(_h_curl_var_imag_name,
+                                                      b_field_name + "_imag"),
                         true);
   }
 

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
@@ -31,7 +31,9 @@ public:
                       const std::string &electric_conductivity_name,
                       const std::string &dielectric_permittivity_name,
                       const std::string &frequency_coef_name,
-                      const std::string &magnetic_vector_potential_name);
+                      const std::string &magnetic_vector_potential_complex_name,
+                      const std::string &magnetic_vector_potential_real_name,
+                      const std::string &magnetic_vector_potential_imag_name);
 
   virtual void RegisterAuxSolvers() override;
 };

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
@@ -35,6 +35,41 @@ public:
                       const std::string &magnetic_vector_potential_real_name,
                       const std::string &magnetic_vector_potential_imag_name);
 
-  virtual void RegisterAuxSolvers() override;
+  // Enable auxiliary calculation of J ∈ H(div)
+  //* Induced electric current, Jind = σE = -iωσA
+  virtual void
+  registerCurrentDensityAux(const std::string &j_field_real_name,
+                            const std::string &j_field_imag_name) override;
+
+  //* Magnetic flux density B = curl A
+  virtual void
+  registerMagneticFluxDensityAux(const std::string &b_field_real_name,
+                                 const std::string &b_field_imag_name) override;
+
+  //* Electric field E =-dA/dt=-iωA
+  virtual void
+  registerElectricFieldAux(const std::string &e_field_real_name,
+                           const std::string &e_field_imag_name) override;
+
+  // Enable auxiliary calculation of P ∈ L2
+  // Time averaged Joule heating density E.J
+  virtual void registerJouleHeatingDensityAux(
+      const std::string &p_field_name, const std::string &e_field_real_name,
+      const std::string &e_field_imag_name,
+      const std::string &conductivity_coef_name) override;
+
+protected:
+  const std::string &_magnetic_reluctivity_name =
+      hephaestus::ComplexMaxwellFormulation::_alpha_coef_name;
+  const std::string &_electric_conductivity_name =
+      hephaestus::ComplexMaxwellFormulation::_beta_coef_name;
+  const std::string &_electric_permittivity_name =
+      hephaestus::ComplexMaxwellFormulation::_zeta_coef_name;
+  const std::string &_magnetic_vector_potential_complex_name =
+      hephaestus::ComplexMaxwellFormulation::_h_curl_var_complex_name;
+  const std::string &_magnetic_vector_potential_real_name =
+      hephaestus::ComplexMaxwellFormulation::_h_curl_var_real_name;
+  const std::string &_magnetic_vector_potential_imag_name =
+      hephaestus::ComplexMaxwellFormulation::_h_curl_var_imag_name;
 };
 } // namespace hephaestus

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -14,4 +14,58 @@ ComplexEFormulation::ComplexEFormulation(
           dielectric_permittivity_name, frequency_coef_name,
           e_field_complex_name, e_field_real_name, e_field_imag_name){};
 
+// Enable auxiliary calculation of J ∈ H(div)
+void ComplexEFormulation::registerCurrentDensityAux(
+    const std::string &j_field_real_name,
+    const std::string &j_field_imag_name) {
+  //* Current density J = Jᵉ + σE
+  //* Induced electric current, Jind = σE
+  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  auxsolvers.Register(j_field_real_name,
+                      new hephaestus::ScaledVectorGridFunctionAux(
+                          _electric_field_real_name, j_field_real_name,
+                          _electric_conductivity_name),
+                      true);
+  auxsolvers.Register(j_field_imag_name,
+                      new hephaestus::ScaledVectorGridFunctionAux(
+                          _electric_field_imag_name, j_field_imag_name,
+                          _electric_conductivity_name),
+                      true);
+};
+
+void ComplexEFormulation::registerMagneticFluxDensityAux(
+    const std::string &b_field_real_name,
+    const std::string &b_field_imag_name) {
+  //* Magnetic flux density B = (i/ω) curl E
+  //* (∇×E = -dB/dt = -iωB)
+  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  auxsolvers.Register(b_field_imag_name,
+                      new hephaestus::ScaledCurlVectorGridFunctionAux(
+                          _electric_field_real_name, b_field_imag_name,
+                          "_inv_angular_frequency", 1.0),
+                      true);
+  auxsolvers.Register(b_field_real_name,
+                      new hephaestus::ScaledCurlVectorGridFunctionAux(
+                          _electric_field_imag_name, b_field_real_name,
+                          "_inv_angular_frequency", -1.0),
+                      true);
+}
+
+// Enable auxiliary calculation of P ∈ L2
+void ComplexEFormulation::registerJouleHeatingDensityAux(
+    const std::string &p_field_name, const std::string &e_field_real_name,
+    const std::string &e_field_imag_name,
+    const std::string &conductivity_coef_name) {
+  //* Time averaged Joule heating density = E.J
+  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  auxsolvers.Register(
+      p_field_name,
+      new hephaestus::VectorGridFunctionDotProductAux(
+          p_field_name, p_field_name, _electric_conductivity_name,
+          _electric_field_real_name, _electric_field_real_name,
+          _electric_field_imag_name, _electric_field_imag_name, true),
+      true);
+  auxsolvers.Get(p_field_name)->SetPriority(2);
+}
+
 } // namespace hephaestus

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -6,9 +6,12 @@ ComplexEFormulation::ComplexEFormulation(
     const std::string &magnetic_reluctivity_name,
     const std::string &electric_conductivity_name,
     const std::string &dielectric_permittivity_name,
-    const std::string &frequency_coef_name, const std::string &e_field_name)
+    const std::string &frequency_coef_name,
+    const std::string &e_field_complex_name,
+    const std::string &e_field_real_name, const std::string &e_field_imag_name)
     : hephaestus::ComplexMaxwellFormulation(
           magnetic_reluctivity_name, electric_conductivity_name,
-          dielectric_permittivity_name, frequency_coef_name, e_field_name){};
+          dielectric_permittivity_name, frequency_coef_name,
+          e_field_complex_name, e_field_real_name, e_field_imag_name){};
 
 } // namespace hephaestus

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
@@ -30,6 +30,44 @@ public:
                       const std::string &electric_conductivity_name,
                       const std::string &dielectric_permittivity_name,
                       const std::string &frequency_coef_name,
-                      const std::string &e_field_name);
+                      const std::string &e_field_complex_name,
+                      const std::string &e_field_real_name,
+                      const std::string &e_field_imag_name);
+
+  // Enable auxiliary calculation of J ∈ H(div)
+  virtual void
+  registerCurrentDensityAux(const std::string &j_field_real_name,
+                            const std::string &j_field_imag_name) override {
+    //* Current density J = Jᵉ + σE
+    //* Induced electric field, Jind = σE
+    hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+    auxsolvers.Register(j_field_real_name,
+                        new hephaestus::ScaledVectorGridFunctionAux(
+                            _electric_field_real_name, j_field_real_name,
+                            _electric_conductivity_name),
+                        true);
+  };
+
+  // Enable auxiliary calculation of P ∈ L2
+  virtual void registerJouleHeatingDensityAux(
+      const std::string &p_field_name, const std::string &e_field_real_name,
+      const std::string &e_field_imag_name,
+      const std::string &conductivity_coef_name) override{
+
+  };
+
+protected:
+  const std::string &_magnetic_reluctivity_name =
+      hephaestus::ComplexMaxwellFormulation::_alpha_coef_name;
+  const std::string &_electric_conductivity_name =
+      hephaestus::ComplexMaxwellFormulation::_beta_coef_name;
+  const std::string &_electric_permittivity_name =
+      hephaestus::ComplexMaxwellFormulation::_zeta_coef_name;
+  const std::string &_electric_field_complex_name =
+      hephaestus::ComplexMaxwellFormulation::_h_curl_var_complex_name;
+  const std::string &_electric_field_real_name =
+      hephaestus::ComplexMaxwellFormulation::_h_curl_var_real_name;
+  const std::string &_electric_field_imag_name =
+      hephaestus::ComplexMaxwellFormulation::_h_curl_var_imag_name;
 };
 } // namespace hephaestus

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
@@ -35,26 +35,28 @@ public:
                       const std::string &e_field_imag_name);
 
   // Enable auxiliary calculation of J ∈ H(div)
+  //* Induced electric current, Jind = σE
   virtual void
   registerCurrentDensityAux(const std::string &j_field_real_name,
-                            const std::string &j_field_imag_name) override {
-    //* Current density J = Jᵉ + σE
-    //* Induced electric field, Jind = σE
-    hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
-    auxsolvers.Register(j_field_real_name,
-                        new hephaestus::ScaledVectorGridFunctionAux(
-                            _electric_field_real_name, j_field_real_name,
-                            _electric_conductivity_name),
-                        true);
-  };
+                            const std::string &j_field_imag_name) override;
+
+  //* Magnetic flux density B = (i/ω) curl E
+  //* (∇×E = -dB/dt = -iωB)
+  virtual void
+  registerMagneticFluxDensityAux(const std::string &b_field_real_name,
+                                 const std::string &b_field_imag_name) override;
+
+  //* Electric field is already a state variable solved for
+  virtual void
+  registerElectricFieldAux(const std::string &e_field_real_name,
+                           const std::string &e_field_imag_name) override{};
 
   // Enable auxiliary calculation of P ∈ L2
+  // Time averaged Joule heating density E.J
   virtual void registerJouleHeatingDensityAux(
       const std::string &p_field_name, const std::string &e_field_real_name,
       const std::string &e_field_imag_name,
-      const std::string &conductivity_coef_name) override{
-
-  };
+      const std::string &conductivity_coef_name) override;
 
 protected:
   const std::string &_magnetic_reluctivity_name =

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
@@ -185,6 +185,12 @@ void ComplexMaxwellFormulation::RegisterCoefficients() {
       true);
 
   coefficients.scalars.Register(
+      "_inv_angular_frequency",
+      new mfem::RatioCoefficient(
+          1.0, *coefficients.scalars.Get("_angular_frequency")),
+      true);
+
+  coefficients.scalars.Register(
       _mass_coef_name,
       new mfem::TransformedCoefficient(
           coefficients.scalars.Get("_neg_angular_frequency_sq"),

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
@@ -56,12 +56,6 @@ void ComplexMaxwellOperator::Solve(mfem::Vector &X) {
     a1_.AddDomainIntegrator(NULL, new mfem::VectorFEMassIntegrator(*lossCoef_));
   }
 
-  // Volume Current Density
-  mfem::Vector j(3);
-  j = 0.0;
-  mfem::VectorConstantCoefficient jrCoef_(j);
-  mfem::VectorConstantCoefficient jiCoef_(j);
-
   mfem::ParLinearForm b1_real_(u_->ParFESpace());
   mfem::ParLinearForm b1_imag_(u_->ParFESpace());
   b1_real_ = 0.0;
@@ -79,8 +73,8 @@ void ComplexMaxwellOperator::Solve(mfem::Vector &X) {
   a1_.Finalize();
 
   b1_.Assemble();
-  b1_.real() += *b1_real_;
-  b1_.imag() += *b1_imag_;
+  b1_.real() += b1_real_;
+  b1_.imag() += b1_imag_;
 
   a1_.FormLinearSystem(ess_bdr_tdofs_, *u_, b1_, A1, U, RHS);
 

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
@@ -42,16 +42,11 @@ public:
   std::string h_curl_var_complex_name, h_curl_var_real_name,
       h_curl_var_imag_name, stiffness_coef_name, mass_coef_name, loss_coef_name;
   mfem::ParComplexGridFunction *u_;
-  mfem::ParComplexLinearForm *b1_;
-  mfem::ParSesquilinearForm *a1_;
   mfem::ComplexOperator::Convention conv_ = mfem::ComplexOperator::HERMITIAN;
 
   mfem::Coefficient *stiffCoef_; // Dia/Paramagnetic Material Coefficient
   mfem::Coefficient *massCoef_;  // -omega^2 epsilon
   mfem::Coefficient *lossCoef_;  // omega sigma
-
-  mfem::VectorCoefficient *jrCoef_; // Volume Current Density Function
-  mfem::VectorCoefficient *jiCoef_; // Volume Current Density Function
 
   mfem::Array<int> ess_bdr_tdofs_;
 };

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
@@ -39,8 +39,8 @@ public:
   virtual void Init(mfem::Vector &X) override;
   virtual void Solve(mfem::Vector &X) override;
 
-  std::string h_curl_var_name, stiffness_coef_name, mass_coef_name,
-      loss_coef_name;
+  std::string h_curl_var_complex_name, h_curl_var_real_name,
+      h_curl_var_imag_name, stiffness_coef_name, mass_coef_name, loss_coef_name;
   mfem::ParComplexGridFunction *u_;
   mfem::ParComplexLinearForm *b1_;
   mfem::ParSesquilinearForm *a1_;
@@ -66,7 +66,9 @@ protected:
   const std::string _beta_coef_name;
   const std::string _zeta_coef_name;
   const std::string _frequency_coef_name;
-  const std::string _h_curl_var_name;
+  const std::string _h_curl_var_complex_name;
+  const std::string _h_curl_var_real_name;
+  const std::string _h_curl_var_imag_name;
   const std::string _mass_coef_name;
   const std::string _loss_coef_name;
 
@@ -75,7 +77,9 @@ public:
                             const std::string &alpha_coef_name,
                             const std::string &beta_coef_name,
                             const std::string &zeta_coef_name,
-                            const std::string &h_curl_var_name);
+                            const std::string &h_curl_var_complex_name,
+                            const std::string &h_curl_var_real_name,
+                            const std::string &h_curl_var_imag_name);
 
   virtual void ConstructOperator() override;
 

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -43,8 +43,9 @@ void EBDualFormulation::registerJouleHeatingDensityAux(
   hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(
-                          p_field_name, p_field_name, e_field_name,
-                          e_field_name, _electric_conductivity_name),
+                          p_field_name, p_field_name,
+                          _electric_conductivity_name, e_field_name,
+                          e_field_name),
                       true);
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -86,8 +86,9 @@ void AFormulation::registerJouleHeatingDensityAux(
   hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(
-                          p_field_name, p_field_name, e_field_name,
-                          e_field_name, _electric_conductivity_name),
+                          p_field_name, p_field_name,
+                          _electric_conductivity_name, e_field_name,
+                          e_field_name),
                       true);
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -58,8 +58,9 @@ void EFormulation::registerJouleHeatingDensityAux(
   hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(
-                          p_field_name, p_field_name, e_field_name,
-                          e_field_name, _electric_conductivity_name),
+                          p_field_name, p_field_name,
+                          _electric_conductivity_name, e_field_name,
+                          e_field_name),
                       true);
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }

--- a/src/formulations/HCurl/h_formulation.cpp
+++ b/src/formulations/HCurl/h_formulation.cpp
@@ -77,8 +77,9 @@ void HFormulation::registerJouleHeatingDensityAux(
   hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(
-                          p_field_name, p_field_name, e_field_name,
-                          e_field_name, _electric_conductivity_name),
+                          p_field_name, p_field_name,
+                          _electric_conductivity_name, e_field_name,
+                          e_field_name),
                       true);
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }

--- a/src/formulations/complex_em_formulation_interface.hpp
+++ b/src/formulations/complex_em_formulation_interface.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include "mfem.hpp"
+
+namespace hephaestus {
+
+// Specifies interface specific to EM formulations.
+class ComplexEMFormulationInterface {
+public:
+  ComplexEMFormulationInterface(){};
+
+  // Enable auxiliary calculation of J ∈ H(div)
+  virtual void registerCurrentDensityAux(const std::string &j_field_real_name,
+                                         const std::string &j_field_imag_name) {
+    MFEM_ABORT("Current density auxsolver not available for this formulation");
+  };
+
+  // Enable auxiliary calculation of B ∈ H(div)
+  virtual void
+  registerMagneticFluxDensityAux(const std::string &b_field_real_name,
+                                 const std::string &b_field_imag_name) {
+    MFEM_ABORT(
+        "Magnetic flux density auxsolver not available for this formulation");
+  };
+
+  // Enable auxiliary calculation of E ∈ H(curl)
+  virtual void registerElectricFieldAux(const std::string &e_field_real_name,
+                                        const std::string &e_field_imag_name) {
+    MFEM_ABORT("Electric field auxsolver not available for this formulation");
+  };
+
+  // Enable auxiliary calculation of H ∈ H(curl)
+  virtual void registerMagneticFieldAux(const std::string &h_field_real_name,
+                                        const std::string &h_field_imag_name) {
+    MFEM_ABORT("Magnetic field auxsolver not available for this formulation");
+  };
+
+  // Enable auxiliary calculation of P ∈ L2
+  virtual void
+  registerJouleHeatingDensityAux(const std::string &p_field_name,
+                                 const std::string &e_field_real_name,
+                                 const std::string &e_field_imag_name,
+                                 const std::string &conductivity_coef_name) {
+    MFEM_ABORT("Joule heating auxsolver not available for this formulation");
+  };
+};
+} // namespace hephaestus

--- a/src/formulations/frequency_domain_em_formulation.hpp
+++ b/src/formulations/frequency_domain_em_formulation.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "em_formulation_interface.hpp"
+#include "complex_em_formulation_interface.hpp"
 #include "steady_state_problem_builder.hpp"
 
 namespace hephaestus {
@@ -7,7 +7,7 @@ namespace hephaestus {
 // Specifies output interfaces of a frequency-domain EM formulation.
 class FrequencyDomainEMFormulation
     : public hephaestus::SteadyStateProblemBuilder,
-      public hephaestus::EMFormulationInterface {
+      public hephaestus::ComplexEMFormulationInterface {
 protected:
   mfem::ConstantCoefficient *freqCoef;
 

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -141,7 +141,8 @@ TEST_F(TestComplexAFormRod, CheckRun) {
   hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexAFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
-          "dielectric_permittivity", "frequency", "magnetic_vector_potential");
+          "dielectric_permittivity", "frequency", "magnetic_vector_potential",
+          "magnetic_vector_potential_real", "magnetic_vector_potential_imag");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(
@@ -158,6 +159,9 @@ TEST_F(TestComplexAFormRod, CheckRun) {
 
   problem_builder->SetMesh(pmesh);
   problem_builder->AddFESpace(std::string("HCurl"), std::string("ND_3D_P1"));
+  problem_builder->AddFESpace(std::string("H1"), std::string("H1_3D_P1"));
+  problem_builder->AddGridFunction("magnetic_vector_potential_real", "HCurl");
+  problem_builder->AddGridFunction("magnetic_vector_potential_imag", "HCurl");
   problem_builder->AddFESpace(std::string("H1"), std::string("H1_3D_P1"));
   problem_builder->SetBoundaryConditions(bc_map);
   problem_builder->SetAuxSolvers(preprocessors);

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -138,7 +138,7 @@ TEST_F(TestComplexAFormRod, CheckRun) {
   hephaestus::InputParameters params(test_params());
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
-  hephaestus::SteadyStateProblemBuilder *problem_builder =
+  hephaestus::ComplexAFormulation *problem_builder =
       new hephaestus::ComplexAFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
           "dielectric_permittivity", "frequency", "magnetic_vector_potential",
@@ -167,6 +167,30 @@ TEST_F(TestComplexAFormRod, CheckRun) {
   problem_builder->SetAuxSolvers(preprocessors);
   problem_builder->SetCoefficients(coefficients);
   problem_builder->SetPostprocessors(postprocessors);
+
+  problem_builder->AddFESpace("HDiv", "RT_3D_P0");
+  problem_builder->AddFESpace("Scalar_L2", "L2Int_3D_P0");
+
+  problem_builder->AddGridFunction("electric_field_real", "HCurl");
+  problem_builder->AddGridFunction("electric_field_imag", "HCurl");
+  problem_builder->registerElectricFieldAux("electric_field_real",
+                                            "electric_field_imag");
+
+  problem_builder->AddGridFunction("magnetic_flux_density_real", "HDiv");
+  problem_builder->AddGridFunction("magnetic_flux_density_imag", "HDiv");
+  problem_builder->registerMagneticFluxDensityAux("magnetic_flux_density_real",
+                                                  "magnetic_flux_density_imag");
+
+  problem_builder->AddGridFunction("current_density_real", "HDiv");
+  problem_builder->AddGridFunction("current_density_imag", "HDiv");
+  problem_builder->registerCurrentDensityAux("current_density_real",
+                                             "current_density_imag");
+
+  problem_builder->AddGridFunction("joule_heating_density", "Scalar_L2");
+  problem_builder->registerJouleHeatingDensityAux(
+      "joule_heating_density", "electric_field_real", "electric_field_imag",
+      "electrical_conductivity");
+
   problem_builder->SetSources(sources);
   problem_builder->SetOutputs(outputs);
   problem_builder->SetSolverOptions(solver_options);

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -95,7 +95,8 @@ protected:
     hephaestus::FrequencyDomainEMFormulation *formulation =
         new hephaestus::ComplexEFormulation(
             "magnetic_reluctivity", "electrical_conductivity",
-            "dielectric_permittivity", "frequency", "electric_field");
+            "dielectric_permittivity", "frequency", "electric_field",
+            "electric_field_real", "electric_field_imag");
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-16));
@@ -128,7 +129,8 @@ TEST_F(TestComplexERMESMouse, CheckRun) {
   hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexEFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
-          "dielectric_permittivity", "frequency", "electric_field");
+          "dielectric_permittivity", "frequency", "electric_field",
+          "electric_field_real", "electric_field_imag");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -118,7 +118,7 @@ TEST_F(TestComplexIrisWaveguide, CheckRun) {
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
-  hephaestus::SteadyStateProblemBuilder *problem_builder =
+  hephaestus::ComplexEFormulation *problem_builder =
       new hephaestus::ComplexEFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
           "dielectric_permittivity", "frequency", "electric_field",
@@ -140,6 +140,25 @@ TEST_F(TestComplexIrisWaveguide, CheckRun) {
   problem_builder->SetMesh(pmesh);
   problem_builder->SetBoundaryConditions(bc_map);
   problem_builder->SetAuxSolvers(preprocessors);
+
+  problem_builder->AddFESpace("HDiv", "RT_3D_P0");
+  problem_builder->AddFESpace("Scalar_L2", "L2Int_3D_P0");
+
+  problem_builder->AddGridFunction("magnetic_flux_density_real", "HDiv");
+  problem_builder->AddGridFunction("magnetic_flux_density_imag", "HDiv");
+  problem_builder->registerMagneticFluxDensityAux("magnetic_flux_density_real",
+                                                  "magnetic_flux_density_imag");
+
+  problem_builder->AddGridFunction("current_density_real", "HDiv");
+  problem_builder->AddGridFunction("current_density_imag", "HDiv");
+  problem_builder->registerCurrentDensityAux("current_density_real",
+                                             "current_density_imag");
+
+  problem_builder->AddGridFunction("joule_heating_density", "Scalar_L2");
+  problem_builder->registerJouleHeatingDensityAux(
+      "joule_heating_density", "electric_field_real", "electric_field_imag",
+      "electrical_conductivity");
+
   problem_builder->SetCoefficients(coefficients);
   problem_builder->SetPostprocessors(postprocessors);
   problem_builder->SetSources(sources);

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -121,7 +121,8 @@ TEST_F(TestComplexIrisWaveguide, CheckRun) {
   hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexEFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
-          "dielectric_permittivity", "frequency", "electric_field");
+          "dielectric_permittivity", "frequency", "electric_field",
+          "electric_field_real", "electric_field_imag");
   hephaestus::BCMap bc_map(
       params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
   hephaestus::Coefficients coefficients(

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -175,7 +175,8 @@ TEST_F(TestComplexTeam7, CheckRun) {
   hephaestus::SteadyStateProblemBuilder *problem_builder =
       new hephaestus::ComplexAFormulation(
           "magnetic_reluctivity", "electrical_conductivity",
-          "dielectric_permittivity", "frequency", "magnetic_vector_potential");
+          "dielectric_permittivity", "frequency", "magnetic_vector_potential",
+          "magnetic_vector_potential_real", "magnetic_vector_potential_imag");
   problem_builder->SetMesh(pmesh);
   problem_builder->AddFESpace(std::string("HCurl"), std::string("ND_3D_P1"));
   problem_builder->AddFESpace(std::string("HDiv"), std::string("RT_3D_P0"));

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -116,8 +116,8 @@ protected:
     postprocessors.Register("JouleHeatingAux",
                             new hephaestus::VectorGridFunctionDotProductAux(
                                 "joule_heating_load", "JouleHeating",
-                                "electric_field", "electric_field",
-                                "electrical_conductivity"),
+                                "electrical_conductivity", "electric_field",
+                                "electric_field"),
                             true);
 
     hephaestus::Sources sources;


### PR DESCRIPTION
Adds the `ComplexEMFormulationInterface` mixin to provide an interface to set up solvers for common derived EM fields for frequency domain formulations in Hephaestus. Extension of #24.
