### PR TITLE
Update Outputs to inherit from NamedFieldsMap<mfem::DataCollection>

### DIFF
--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -106,10 +106,10 @@ hephaestus::Sources defineSources() {
   return sources;
 }
 hephaestus::Outputs defineOutputs() {
-  std::map<std::string, mfem::DataCollection *> data_collections;
-  data_collections["ParaViewDataCollection"] =
-      new mfem::ParaViewDataCollection("ComplexTeam7ParaView");
-  hephaestus::Outputs outputs(data_collections);
+  hephaestus::Outputs outputs;
+  outputs.Register("ParaViewDataCollection",
+                   new mfem::ParaViewDataCollection("ComplexTeam7ParaView"),
+                   true);
   return outputs;
 }
 

--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -177,7 +177,6 @@ int main(int argc, char *argv[]) {
       new hephaestus::SteadyExecutioner(exec_params);
 
   std::cout << "Created exec ";
-  executioner->Init();
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/magnetostatic/Main.cpp
+++ b/examples/magnetostatic/Main.cpp
@@ -162,7 +162,6 @@ int main(int argc, char *argv[]) {
       new hephaestus::SteadyExecutioner(exec_params);
 
   mfem::out << "Created executioner";
-  executioner->Init();
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/magnetostatic/Main.cpp
+++ b/examples/magnetostatic/Main.cpp
@@ -103,10 +103,10 @@ hephaestus::Sources defineSources() {
   return sources;
 }
 hephaestus::Outputs defineOutputs() {
-  std::map<std::string, mfem::DataCollection *> data_collections;
-  data_collections["ParaViewDataCollection"] =
-      new mfem::ParaViewDataCollection("Team7ParaView");
-  hephaestus::Outputs outputs(data_collections);
+  hephaestus::Outputs outputs;
+  outputs.Register("ParaViewDataCollection",
+                   new mfem::ParaViewDataCollection("MagnetostaticParaView"),
+                   true);
   return outputs;
 }
 

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -104,10 +104,9 @@ hephaestus::Sources defineSources() {
   return sources;
 }
 hephaestus::Outputs defineOutputs() {
-  std::map<std::string, mfem::DataCollection *> data_collections;
-  data_collections["ParaViewDataCollection"] =
-      new mfem::ParaViewDataCollection("Team7ParaView");
-  hephaestus::Outputs outputs(data_collections);
+  hephaestus::Outputs outputs;
+  outputs.Register("ParaViewDataCollection",
+                   new mfem::ParaViewDataCollection("Team7ParaView"), true);
   return outputs;
 }
 

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -181,7 +181,6 @@ int main(int argc, char *argv[]) {
       new hephaestus::TransientExecutioner(exec_params);
 
   mfem::out << "Created executioner";
-  executioner->Init();
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -175,7 +175,6 @@ int main(int argc, char *argv[]) {
   exec_params.SetParam("StartTime", float(0.00));
   exec_params.SetParam("EndTime", float(0.002));
   exec_params.SetParam("VisualisationSteps", int(1));
-  exec_params.SetParam("UseGLVis", false);
   exec_params.SetParam("Problem", problem.get());
   hephaestus::TransientExecutioner *executioner =
       new hephaestus::TransientExecutioner(exec_params);

--- a/src/executioners/executioner_base.cpp
+++ b/src/executioners/executioner_base.cpp
@@ -1,8 +1,0 @@
-#include "executioner.hpp"
-
-namespace hephaestus {
-
-Executioner::Executioner(const hephaestus::InputParameters &params)
-    : visualization(params.GetOptionalParam<bool>("UseGLVis", false)) {}
-
-} // namespace hephaestus

--- a/src/executioners/executioner_base.hpp
+++ b/src/executioners/executioner_base.hpp
@@ -4,24 +4,15 @@
 namespace hephaestus {
 
 class Executioner {
-protected:
-  bool visualization; // Flag to control whether GLVis visualisation is required
-
 public:
   Executioner() = default;
-  explicit Executioner(const hephaestus::InputParameters &params);
-
-  // Initialise owned objects
-  virtual void Init() = 0;
+  explicit Executioner(const hephaestus::InputParameters &params){};
 
   // Solve the current system of equations
   virtual void Solve() const = 0;
 
   // Execute solution strategy including any timestepping
   virtual void Execute() const = 0;
-
-  // Enable output to GLVis
-  void EnableVisualisation() { visualization = true; };
 };
 
 } // namespace hephaestus

--- a/src/executioners/steady_executioner.cpp
+++ b/src/executioners/steady_executioner.cpp
@@ -6,13 +6,6 @@ SteadyExecutioner::SteadyExecutioner(const hephaestus::InputParameters &params)
     : Executioner(params),
       problem(params.GetParam<hephaestus::SteadyStateProblem *>("Problem")) {}
 
-void SteadyExecutioner::Init() {
-  // Set up DataCollections to track fields of interest.
-  problem->outputs.SetGridFunctions(problem->gridfunctions);
-  problem->outputs.Reset();
-  problem->outputs.EnableGLVis(visualization);
-}
-
 void SteadyExecutioner::Solve() const {
   // Advance time step.
   problem->preprocessors.Solve();

--- a/src/executioners/steady_executioner.cpp
+++ b/src/executioners/steady_executioner.cpp
@@ -4,24 +4,13 @@ namespace hephaestus {
 
 SteadyExecutioner::SteadyExecutioner(const hephaestus::InputParameters &params)
     : Executioner(params),
-      problem(
-          params.GetParam<hephaestus::SteadyStateProblem *>("Problem")) {}
+      problem(params.GetParam<hephaestus::SteadyStateProblem *>("Problem")) {}
 
 void SteadyExecutioner::Init() {
   // Set up DataCollections to track fields of interest.
-  for (auto const &[name, dc_] : problem->outputs.data_collections) {
-    problem->outputs.RegisterOutputFields(dc_, problem->pmesh.get(),
-                                          problem->gridfunctions);
-    // Write initial fields to disk
-    problem->outputs.WriteOutputFields(dc_, 0.0, 0);
-  }
-
-  // Initialize GLVis visualization and send the initial condition
-  // by socket to a GLVis server.
-  if (visualization) {
-    problem->outputs.InitializeGLVis(problem->myid_, problem->gridfunctions);
-    problem->outputs.DisplayToGLVis(problem->gridfunctions);
-  }
+  problem->outputs.SetGridFunctions(problem->gridfunctions);
+  problem->outputs.Reset();
+  problem->outputs.EnableGLVis(visualization);
 }
 
 void SteadyExecutioner::Solve() const {
@@ -32,21 +21,7 @@ void SteadyExecutioner::Solve() const {
 
   // Output data
   // Output timestep summary to console
-  problem->outputs.WriteConsoleSummary(problem->myid_, 1.0, 1);
-
-  // Make sure all ranks have sent their 'v' solution before initiating
-  // another set of GLVis connections (one from each rank):
-  MPI_Barrier(problem->pmesh->GetComm());
-
-  // Send output fields to GLVis for visualisation
-  if (visualization) {
-    problem->outputs.DisplayToGLVis(problem->gridfunctions);
-  }
-
-  // Save output fields at timestep to DataCollections
-  for (auto const &[name, dc_] : problem->outputs.data_collections) {
-    problem->outputs.WriteOutputFields(dc_, 1.0, 1);
-  }
+  problem->outputs.Write();
 }
 void SteadyExecutioner::Execute() const { this->Solve(); }
 } // namespace hephaestus

--- a/src/executioners/steady_executioner.hpp
+++ b/src/executioners/steady_executioner.hpp
@@ -9,8 +9,6 @@ public:
   SteadyExecutioner() = default;
   explicit SteadyExecutioner(const hephaestus::InputParameters &params);
 
-  void Init() override;
-
   void Solve() const override;
 
   void Execute() const override;

--- a/src/executioners/transient_executioner.cpp
+++ b/src/executioners/transient_executioner.cpp
@@ -12,13 +12,6 @@ TransientExecutioner::TransientExecutioner(
       vis_steps(params.GetOptionalParam<int>("VisualisationSteps", 1)),
       last_step(false) {}
 
-void TransientExecutioner::Init() {
-  // Set up DataCollections to track fields of interest.
-  problem->outputs.SetGridFunctions(problem->gridfunctions);
-  problem->outputs.Reset();
-  problem->outputs.EnableGLVis(visualization);
-}
-
 void TransientExecutioner::Step(double dt, int it) const {
   // Check if current time step is final
   if (t + dt >= t_final - dt / 2) {

--- a/src/executioners/transient_executioner.hpp
+++ b/src/executioners/transient_executioner.hpp
@@ -19,8 +19,6 @@ public:
   TransientExecutioner() = default;
   explicit TransientExecutioner(const hephaestus::InputParameters &params);
 
-  void Init() override;
-
   void Step(double dt, int it) const;
 
   void Solve() const override;

--- a/src/io/outputs.cpp
+++ b/src/io/outputs.cpp
@@ -4,8 +4,10 @@ namespace hephaestus {
 
 Outputs::Outputs() {}
 
-Outputs::Outputs(
-    std::map<std::string, mfem::DataCollection *> data_collections_)
-    : data_collections(data_collections_) {}
-
+Outputs::Outputs(hephaestus::GridFunctions &gridfunctions)
+    : _gridfunctions(&gridfunctions), _cycle(0), _use_glvis(false),
+      _my_comm(MPI_COMM_WORLD) {
+  MPI_Comm_size(_my_comm, &_n_ranks);
+  MPI_Comm_rank(_my_comm, &_my_rank);
+}
 } // namespace hephaestus

--- a/src/io/outputs.cpp
+++ b/src/io/outputs.cpp
@@ -2,11 +2,13 @@
 
 namespace hephaestus {
 
-Outputs::Outputs() {}
+Outputs::Outputs() {
+  MPI_Comm_size(_my_comm, &_n_ranks);
+  MPI_Comm_rank(_my_comm, &_my_rank);
+}
 
 Outputs::Outputs(hephaestus::GridFunctions &gridfunctions)
-    : _gridfunctions(&gridfunctions), _cycle(0), _use_glvis(false),
-      _my_comm(MPI_COMM_WORLD) {
+    : _gridfunctions(&gridfunctions) {
   MPI_Comm_size(_my_comm, &_n_ranks);
   MPI_Comm_rank(_my_comm, &_my_rank);
 }

--- a/src/io/outputs.hpp
+++ b/src/io/outputs.hpp
@@ -9,57 +9,107 @@
 
 namespace hephaestus {
 
-class Outputs {
+class Outputs : public mfem::NamedFieldsMap<mfem::DataCollection> {
 public:
   Outputs();
-  Outputs(std::map<std::string, mfem::DataCollection *> data_collections_);
+  Outputs(hephaestus::GridFunctions &gridfunctions);
 
-  std::map<std::string, mfem::DataCollection *> data_collections;
+  void SetGridFunctions(hephaestus::GridFunctions &gridfunctions) {
+    _gridfunctions = &gridfunctions;
+  }
+
+  void EnableGLVis(bool &use_glvis) { _use_glvis = use_glvis; }
+
+  void Reset() {
+    // Reset cycle counter
+    _cycle = 0;
+    // Set up DataCollections to track fields of interest.
+    RegisterOutputFields();
+    // Write initial fields to disk
+    WriteOutputFields(0.0);
+
+    // Initialize GLVis _use_glvis and send the initial condition
+    // by socket to a GLVis server.
+    if (_use_glvis) {
+      InitializeGLVis(_my_rank);
+      DisplayToGLVis();
+    }
+  }
+
+  void Write(double t = 1.0) {
+    _cycle++;
+    // Output timestep summary to console
+    WriteConsoleSummary(_my_rank, t);
+    // Make sure all ranks have sent their 'v' solution before initiating
+    // another set of GLVis connections (one from each rank):
+    // Send output fields to GLVis for visualisation
+    MPI_Barrier(_my_comm);
+    if (_use_glvis) {
+      DisplayToGLVis();
+    }
+    // Save output fields at timestep to DataCollections
+    WriteOutputFields(t);
+  }
+
+private:
   std::map<std::string, mfem::socketstream *> socks_;
 
-  void RegisterOutputFields(mfem::DataCollection *dc_, mfem::ParMesh *pmesh_,
-                            hephaestus::GridFunctions &_gridfunctions) {
-    dc_->SetMesh(pmesh_);
-    for (auto var = _gridfunctions.begin(); var != _gridfunctions.end();
-         ++var) {
-      dc_->RegisterField(var->first, var->second);
+  hephaestus::GridFunctions *_gridfunctions;
+  int _cycle;
+  bool _use_glvis;
+  MPI_Comm _my_comm;
+  int _n_ranks, _my_rank;
+
+  void RegisterOutputFields() {
+    for (auto output = begin(); output != end(); ++output) {
+      auto const &dc_(output->second);
+      mfem::ParMesh *pmesh_(
+          _gridfunctions->begin()->second->ParFESpace()->GetParMesh());
+      dc_->SetMesh(pmesh_);
+      for (auto var = _gridfunctions->begin(); var != _gridfunctions->end();
+           ++var) {
+        dc_->RegisterField(var->first, var->second);
+      }
     }
   }
 
-  void WriteConsoleSummary(int id, double t, int it) {
+  void WriteConsoleSummary(int _my_rank, double t) {
     // Write a summary of the timestep to console.
-    if (id == 0) {
+    if (_my_rank == 0) {
       std::cout << std::fixed;
-      std::cout << "step " << std::setw(6) << it << ",\tt = " << std::setw(6)
-                << std::setprecision(3) << t << std::endl;
+      std::cout << "step " << std::setw(6) << _cycle
+                << ",\tt = " << std::setw(6) << std::setprecision(3) << t
+                << std::endl;
     }
   }
 
-  void WriteOutputFields(mfem::DataCollection *dc_, double t, int it) {
-    if (dc_) {
-      dc_->SetCycle(it);
+  void WriteOutputFields(double t) {
+    // Write fields to disk
+    for (auto output = begin(); output != end(); ++output) {
+      auto const &dc_(output->second);
+      dc_->SetCycle(_cycle);
       dc_->SetTime(t);
       dc_->Save();
     }
   }
 
-  void InitializeGLVis(int id, hephaestus::GridFunctions &_gridfunctions) {
-    if (id == 0) {
+  void InitializeGLVis(int _my_rank) {
+    if (_my_rank == 0) {
       std::cout << "Opening GLVis sockets." << std::endl;
     }
 
-    for (auto var = _gridfunctions.begin(); var != _gridfunctions.end();
+    for (auto var = _gridfunctions->begin(); var != _gridfunctions->end();
          ++var) {
       socks_[var->first] = new mfem::socketstream;
       socks_[var->first]->precision(8);
     }
 
-    if (id == 0) {
+    if (_my_rank == 0) {
       std::cout << "GLVis sockets open." << std::endl;
     }
   }
 
-  void DisplayToGLVis(hephaestus::GridFunctions &_gridfunctions) {
+  void DisplayToGLVis() {
     char vishost[] = "localhost";
     int visport = 19916;
 
@@ -67,7 +117,7 @@ public:
     int Ww = 350, Wh = 350;             // window size
     int offx = Ww + 10, offy = Wh + 45; // window offsets
 
-    for (auto var = _gridfunctions.begin(); var != _gridfunctions.end();
+    for (auto var = _gridfunctions->begin(); var != _gridfunctions->end();
          ++var) {
       mfem::common::VisualizeField(*socks_[var->first], vishost, visport,
                                    *(var->second), (var->first).c_str(), Wx, Wy,

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -114,4 +114,8 @@ void ProblemBuilder::InitializeAuxSolvers() {
                                           this->GetProblem()->coefficients);
 }
 
+void ProblemBuilder::InitializeOutputs() {
+  this->GetProblem()->outputs.Init(this->GetProblem()->gridfunctions);
+}
+
 } // namespace hephaestus

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -83,6 +83,7 @@ public:
   virtual void ConstructSolver() = 0;
 
   void InitializeAuxSolvers();
+  void InitializeOutputs();
 };
 
 class ProblemBuildSequencer {
@@ -115,6 +116,7 @@ public:
     this->problem_builder->ConstructOperator();
     this->problem_builder->ConstructState();
     this->problem_builder->InitializeAuxSolvers();
+    this->problem_builder->InitializeOutputs();
   }
   void ConstructEquationSystemProblem() {
     this->problem_builder->RegisterFESpaces();
@@ -127,6 +129,7 @@ public:
     this->problem_builder->ConstructState();
     this->problem_builder->ConstructSolver();
     this->problem_builder->InitializeAuxSolvers();
+    this->problem_builder->InitializeOutputs();
   }
 };
 

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -77,10 +77,9 @@ protected:
     mfem::Mesh mesh(
         (std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("AFormVisIt");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("AFormVisIt"), true);
 
     hephaestus::InputParameters l2errpostprocparams;
     l2errpostprocparams.SetParam("VariableName",

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -191,12 +191,10 @@ TEST_F(TestAFormSource, CheckRun) {
     exec_params.SetParam("StartTime", float(0.00));
     exec_params.SetParam("EndTime", float(0.05));
     exec_params.SetParam("VisualisationSteps", int(1));
-    exec_params.SetParam("UseGLVis", true);
     exec_params.SetParam("Problem", problem.get());
     hephaestus::TransientExecutioner *executioner =
         new hephaestus::TransientExecutioner(exec_params);
 
-    executioner->Init();
     executioner->Execute();
 
     delete executioner;

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -146,10 +146,9 @@ TEST_F(TestAVFormRod, CheckRun) {
   exec_params.SetParam("StartTime", float(0.00));
   exec_params.SetParam("EndTime", float(2.5));
   exec_params.SetParam("VisualisationSteps", int(1));
-  exec_params.SetParam("UseGLVis", true);
   exec_params.SetParam("Problem", problem.get());
   hephaestus::TransientExecutioner *executioner =
       new hephaestus::TransientExecutioner(exec_params);
-  executioner->Init();
+
   executioner->Execute();
 }

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -76,13 +76,12 @@ protected:
         (std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(),
         1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("AVFormVisIt");
-    data_collections["ParaViewDataCollection"] =
-        new mfem::ParaViewDataCollection("AVFormParaView");
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("AVFormVisIt"), true);
+    outputs.Register("ParaViewDataCollection",
+                     new mfem::ParaViewDataCollection("AVFormParaView"), true);
 
-    hephaestus::Outputs outputs(data_collections);
     hephaestus::FESpaces fespaces;
     hephaestus::GridFunctions gridfunctions;
     hephaestus::AuxSolvers postprocessors;

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -87,10 +87,9 @@ protected:
     mfem::Mesh mesh(
         (std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("AVFormVisIt");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("AVFormVisIt"), true);
 
     hephaestus::InputParameters l2errpostprocparams;
     l2errpostprocparams.SetParam("VariableName",

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -203,12 +203,10 @@ TEST_F(TestAVFormSource, CheckRun) {
     exec_params.SetParam("StartTime", float(0.00));
     exec_params.SetParam("EndTime", float(0.05));
     exec_params.SetParam("VisualisationSteps", int(1));
-    exec_params.SetParam("UseGLVis", true);
     exec_params.SetParam("Problem", problem.get());
     hephaestus::TransientExecutioner *executioner =
         new hephaestus::TransientExecutioner(exec_params);
 
-    executioner->Init();
     executioner->Execute();
   }
 

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -200,10 +200,9 @@ TEST_F(TestComplexAFormRod, CheckRun) {
       problem_builder->ReturnProblem();
 
   hephaestus::InputParameters exec_params;
-  exec_params.SetParam("UseGLVis", true);
   exec_params.SetParam("Problem", problem.get());
   hephaestus::SteadyExecutioner *executioner =
       new hephaestus::SteadyExecutioner(exec_params);
-  executioner->Init();
+
   executioner->Execute();
 }

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -81,12 +81,11 @@ protected:
         (std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(),
         1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("EBFormVisIt");
-    data_collections["ParaViewDataCollection"] =
-        new mfem::ParaViewDataCollection("EBFormParaView");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("EBFormVisIt"), true);
+    outputs.Register("ParaViewDataCollection",
+                     new mfem::ParaViewDataCollection("EBFormParaView"), true);
 
     hephaestus::GridFunctions gridfunctions;
     hephaestus::AuxSolvers preprocessors;

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -81,10 +81,10 @@ protected:
         (std::string(DATA_DIR) + std::string("./ermes_mouse_coarse.g")).c_str(),
         1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("ComplexMaxwellERMESMouse");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("ComplexMaxwellERMESMouse"),
+                     true);
 
     hephaestus::FESpaces fespaces;
     hephaestus::GridFunctions gridfunctions;

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -160,11 +160,10 @@ TEST_F(TestComplexERMESMouse, CheckRun) {
       problem_builder->ReturnProblem();
 
   hephaestus::InputParameters exec_params;
-  exec_params.SetParam("UseGLVis", true);
   exec_params.SetParam("Problem", problem.get());
   hephaestus::SteadyExecutioner *executioner =
       new hephaestus::SteadyExecutioner(exec_params);
-  executioner->Init();
+
   executioner->Execute();
 
   mfem::Vector zeroVec(3);

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -79,10 +79,10 @@ protected:
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./irises.g")).c_str(),
                     1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("Hertz-AMR-Parallel-VisIt");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("Hertz-AMR-Parallel-VisIt"),
+                     true);
 
     hephaestus::FESpaces fespaces;
     hephaestus::GridFunctions gridfunctions;

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -171,11 +171,10 @@ TEST_F(TestComplexIrisWaveguide, CheckRun) {
       problem_builder->ReturnProblem();
 
   hephaestus::InputParameters exec_params;
-  exec_params.SetParam("UseGLVis", true);
   exec_params.SetParam("Problem", problem.get());
   hephaestus::SteadyExecutioner *executioner =
       new hephaestus::SteadyExecutioner(exec_params);
-  executioner->Init();
+
   executioner->Execute();
 
   mfem::Vector zeroVec(3);

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -89,12 +89,13 @@ protected:
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./team7.g")).c_str(),
                     1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("ComplexMaxwellTeam7VisIt");
-    data_collections["ParaViewDataCollection"] =
-        new mfem::ParaViewDataCollection("ComplexMaxwellTeam7ParaView");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("ComplexMaxwellTeam7VisIt"),
+                     true);
+    outputs.Register(
+        "ParaViewDataCollection",
+        new mfem::ParaViewDataCollection("ComplexMaxwellTeam7ParaView"), true);
 
     hephaestus::AuxSolvers postprocessors;
     hephaestus::AuxSolvers preprocessors;

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -204,11 +204,10 @@ TEST_F(TestComplexTeam7, CheckRun) {
       problem_builder->ReturnProblem();
 
   hephaestus::InputParameters exec_params;
-  exec_params.SetParam("UseGLVis", true);
   exec_params.SetParam("Problem", problem.get());
   hephaestus::SteadyExecutioner *executioner =
       new hephaestus::SteadyExecutioner(exec_params);
   std::cout << "Created exec ";
-  executioner->Init();
+
   executioner->Execute();
 }

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -105,12 +105,11 @@ protected:
         (std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(),
         1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("EBFormVisIt");
-    data_collections["ParaViewDataCollection"] =
-        new mfem::ParaViewDataCollection("EBFormParaView");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("EBFormVisIt"), true);
+    outputs.Register("ParaViewDataCollection",
+                     new mfem::ParaViewDataCollection("EBFormParaView"), true);
 
     hephaestus::AuxSolvers postprocessors;
     postprocessors.Register("JouleHeatingAux",

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -212,10 +212,9 @@ TEST_F(TestEBFormCoupled, CheckRun) {
   exec_params.SetParam("StartTime", float(0.00));
   exec_params.SetParam("EndTime", float(2.5));
   exec_params.SetParam("VisualisationSteps", int(1));
-  exec_params.SetParam("UseGLVis", true);
   exec_params.SetParam("Problem", problem.get());
   hephaestus::TransientExecutioner *executioner =
       new hephaestus::TransientExecutioner(exec_params);
-  executioner->Init();
+
   executioner->Execute();
 }

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -80,12 +80,11 @@ protected:
         (std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(),
         1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("EBFormVisIt");
-    data_collections["ParaViewDataCollection"] =
-        new mfem::ParaViewDataCollection("EBFormParaView");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("EBFormVisIt"), true);
+    outputs.Register("ParaViewDataCollection",
+                     new mfem::ParaViewDataCollection("EBFormParaView"), true);
 
     hephaestus::GridFunctions gridfunctions;
     hephaestus::AuxSolvers preprocessors;

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -175,11 +175,9 @@ TEST_F(TestEBFormRod, CheckRun) {
   exec_params.SetParam("StartTime", float(0.00));
   exec_params.SetParam("EndTime", float(2.5));
   exec_params.SetParam("VisualisationSteps", int(1));
-  exec_params.SetParam("UseGLVis", true);
   exec_params.SetParam("Problem", problem.get());
   hephaestus::TransientExecutioner *executioner =
       new hephaestus::TransientExecutioner(exec_params);
 
-  executioner->Init();
   executioner->Execute();
 }

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -77,12 +77,11 @@ protected:
         (std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(),
         1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("HFormVisIt");
-    data_collections["ParaViewDataCollection"] =
-        new mfem::ParaViewDataCollection("HFormParaView");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("HFormVisIt"), true);
+    outputs.Register("ParaViewDataCollection",
+                     new mfem::ParaViewDataCollection("HFormParaView"), true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-16));

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -170,11 +170,9 @@ TEST_F(TestHFormRod, CheckRun) {
   exec_params.SetParam("StartTime", float(0.00));
   exec_params.SetParam("EndTime", float(2.5));
   exec_params.SetParam("VisualisationSteps", int(1));
-  exec_params.SetParam("UseGLVis", true);
   exec_params.SetParam("Problem", problem.get());
   hephaestus::TransientExecutioner *executioner =
       new hephaestus::TransientExecutioner(exec_params);
 
-  executioner->Init();
   executioner->Execute();
 }

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -86,10 +86,11 @@ protected:
     mfem::Mesh mesh(
         (std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
 
-    std::map<std::string, mfem::DataCollection *> data_collections;
-    data_collections["VisItDataCollection"] =
-        new mfem::VisItDataCollection("HFormVisIt");
-    hephaestus::Outputs outputs(data_collections);
+    hephaestus::Outputs outputs;
+    outputs.Register("VisItDataCollection",
+                     new mfem::VisItDataCollection("HFormVisIt"), true);
+    outputs.Register("ParaViewDataCollection",
+                     new mfem::ParaViewDataCollection("HFormParaView"), true);
 
     hephaestus::InputParameters l2errpostprocparams;
     l2errpostprocparams.SetParam("VariableName", std::string("magnetic_field"));

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -212,12 +212,10 @@ TEST_F(TestHFormSource, CheckRun) {
     exec_params.SetParam("StartTime", float(0.00));
     exec_params.SetParam("EndTime", float(0.05));
     exec_params.SetParam("VisualisationSteps", int(1));
-    exec_params.SetParam("UseGLVis", false);
     exec_params.SetParam("Problem", problem.get());
     hephaestus::TransientExecutioner *executioner =
         new hephaestus::TransientExecutioner(exec_params);
 
-    executioner->Init();
     executioner->Execute();
   }
 


### PR DESCRIPTION
Updates `hephaestus::Outputs` to inherit from `NamedFieldsMap<mfem::DataCollection>`, making usage consistent with `GridFunctions` and `BoundaryConditions`.

Also moves `Output` initialisation into `ProblemBuilder` from `Executioners`