### PR TITLE
Ensure GLVis visualisation is always initialised when enabled

### DIFF
--- a/src/io/outputs.hpp
+++ b/src/io/outputs.hpp
@@ -23,7 +23,10 @@ public:
   }
 
   // Enable GLVis streams for visualisation
-  void EnableGLVis(const bool &use_glvis) { _use_glvis = use_glvis; }
+  void EnableGLVis(const bool &use_glvis) {
+    _use_glvis = use_glvis;
+    InitializeGLVis(_my_rank);
+  }
 
   // Reset Outputs and re-register output fields from GridFunctions
   void Reset() {
@@ -37,7 +40,6 @@ public:
     // Initialize GLVis _use_glvis and send the initial condition
     // by socket to a GLVis server.
     if (_use_glvis) {
-      InitializeGLVis(_my_rank);
       DisplayToGLVis();
     }
   }


### PR DESCRIPTION
Minor bugfix to avoid cases where output to a GLVis display could be attempted before initialisation. 