### PR TITLE
Update OpenCoilSolver to support coils with inhomogenous conductivity

### DIFF
--- a/src/formulations/AV/av_formulation.cpp
+++ b/src/formulations/AV/av_formulation.cpp
@@ -215,7 +215,6 @@ u_{n+1} = u_{n} + dt du/dt_{n+1}
 */
 void AVOperator::ImplicitSolve(const double dt, const mfem::Vector &X,
                                mfem::Vector &dX_dt) {
-  dX_dt = 0.0;
   for (unsigned int ind = 0; ind < local_test_vars.size(); ++ind) {
     local_test_vars.at(ind)->MakeRef(local_test_vars.at(ind)->ParFESpace(),
                                      const_cast<mfem::Vector &>(X),

--- a/src/formulations/Dual/dual_formulation.cpp
+++ b/src/formulations/Dual/dual_formulation.cpp
@@ -184,7 +184,6 @@ void DualOperator::Init(mfem::Vector &X) {
 
 void DualOperator::ImplicitSolve(const double dt, const mfem::Vector &X,
                                  mfem::Vector &dX_dt) {
-  dX_dt = 0.0;
   for (unsigned int ind = 0; ind < local_test_vars.size(); ++ind) {
     local_test_vars.at(ind)->MakeRef(local_test_vars.at(ind)->ParFESpace(),
                                      const_cast<mfem::Vector &>(X),

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -166,7 +166,6 @@ u_{n+1} = u_{n} + dt du/dt_{n+1}
 */
 void HCurlOperator::ImplicitSolve(const double dt, const mfem::Vector &X,
                                   mfem::Vector &dX_dt) {
-  dX_dt = 0.0;
   for (unsigned int ind = 0; ind < local_test_vars.size(); ++ind) {
     local_test_vars.at(ind)->MakeRef(local_test_vars.at(ind)->ParFESpace(),
                                      const_cast<mfem::Vector &>(X),

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -114,7 +114,6 @@ void StaticsOperator::Solve(mfem::Vector &X) {
   _bc_map.applyIntegratedBCs(h_curl_var_name, b1_, pmesh_);
   b1_.Assemble();
   _sources.Apply(&b1_);
-
   mfem::ParBilinearForm a1_(a_.ParFESpace());
   a1_.AddDomainIntegrator(new mfem::CurlCurlIntegrator(*stiffCoef_));
   a1_.Assemble();

--- a/src/problem_builders/time_domain_problem_builder.cpp
+++ b/src/problem_builders/time_domain_problem_builder.cpp
@@ -62,6 +62,7 @@ void TimeDomainProblemBuilder::ConstructOperator() {
 void TimeDomainProblemBuilder::ConstructState() {
   this->problem->F = new mfem::BlockVector(
       this->problem->td_operator->true_offsets); // Vector of dofs
+  *(problem->F) = 0.0;                           // give initial value
   this->problem->td_operator->Init(
       *(this->problem->F)); // Set up initial conditions
   this->problem->td_operator->SetTime(0.0);

--- a/src/sources/open_coil.cpp
+++ b/src/sources/open_coil.cpp
@@ -169,10 +169,10 @@ OpenCoilSolver::OpenCoilSolver(const hephaestus::InputParameters &params,
       high_terminal_(1), low_terminal_(1) {
 
   hephaestus::InputParameters default_pars;
-  default_pars.SetParam("Tolerance", 0.0);
-  default_pars.SetParam("AbsTolerance", 0.0);
-  default_pars.SetParam("MaxIter", (unsigned int)10000);
-  default_pars.SetParam("PrintLevel", 2);
+  default_pars.SetParam("Tolerance", float(1.0e-20));
+  default_pars.SetParam("AbsTolerance", float(1.0e-20));
+  default_pars.SetParam("MaxIter", (unsigned int)1000);
+  default_pars.SetParam("PrintLevel", 1);
 
   solver_options_ = params.GetOptionalParam<hephaestus::InputParameters>(
       "SolverOptions", default_pars);

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -10,6 +10,9 @@ double lowV(const mfem::Vector &x, double t);
 
 double calcFlux(mfem::GridFunction *v_field, int face_attr);
 
+double calcFlux(mfem::GridFunction *v_field, int face_attr,
+                mfem::Coefficient &q);
+
 template <typename T> void ifDelete(T *ptr);
 
 void inheritBdrAttributes(const mfem::ParMesh *parent_mesh,
@@ -78,7 +81,7 @@ private:
   std::pair<int, int> elec_attrs_;
   mfem::Array<int> coil_domains_;
   mfem::Array<int> coil_markers_;
-  mfem::ConstantCoefficient coef1_;
+  mfem::Coefficient *coef1_;
   mfem::Coefficient *Itotal_;
   hephaestus::InputParameters solver_options_;
 
@@ -86,6 +89,7 @@ private:
   std::string J_gf_name_;
   std::string V_gf_name_;
   std::string I_coef_name_;
+  std::string cond_coef_name_;
 
   // Parent mesh, FE space, and current
   mfem::ParMesh *mesh_parent_;
@@ -117,7 +121,6 @@ private:
 
   // Final LinearForm
   mfem::ParLinearForm *final_lf_;
-
 };
 
 } // namespace hephaestus

--- a/test/unit/test_opencoil.cpp
+++ b/test/unit/test_opencoil.cpp
@@ -20,13 +20,17 @@ TEST(OpenCoilTest, CheckData) {
   mfem::ParGridFunction j(&HCurlFESpace);
 
   double Ival = 10.0;
+  double cond_val = 1e6;
   mfem::ConstantCoefficient Itot(Ival);
+  mfem::ConstantCoefficient Conductivity(cond_val);
 
   hephaestus::InputParameters ocs_params;
   hephaestus::BCMap bc_maps;
 
   hephaestus::Coefficients coefficients;
   coefficients.scalars.Register(std::string("Itotal"), &Itot, true);
+  coefficients.scalars.Register(std::string("Conductivity"), &Conductivity,
+                                true);
 
   hephaestus::FESpaces fespaces;
   fespaces.Register(std::string("HCurl"), &HCurlFESpace, true);
@@ -37,7 +41,7 @@ TEST(OpenCoilTest, CheckData) {
   ocs_params.SetParam("SourceName", std::string("J"));
   ocs_params.SetParam("IFuncCoefName", std::string("Itotal"));
   ocs_params.SetParam("PotentialName", std::string("V"));
-  ocs_params.SetParam("ConductivityCoefName", std::string("dummy"));
+  ocs_params.SetParam("ConductivityCoefName", std::string("Conductivity"));
 
   std::pair<int, int> elec_attrs{1, 2};
   mfem::Array<int> submesh_domains;
@@ -48,7 +52,7 @@ TEST(OpenCoilTest, CheckData) {
   mfem::ParLinearForm dummy(&HCurlFESpace);
   opencoil.Apply(&dummy);
 
-  double flux = hephaestus::calcFlux(&j, elec_attrs.first);
+  double flux = hephaestus::calcFlux(&j, elec_attrs.first, Conductivity);
 
   EXPECT_FLOAT_EQ(flux, Ival);
 }

--- a/test/unit/test_opencoil.cpp
+++ b/test/unit/test_opencoil.cpp
@@ -37,6 +37,7 @@ TEST(OpenCoilTest, CheckData) {
   ocs_params.SetParam("SourceName", std::string("J"));
   ocs_params.SetParam("IFuncCoefName", std::string("Itotal"));
   ocs_params.SetParam("PotentialName", std::string("V"));
+  ocs_params.SetParam("ConductivityCoefName", std::string("dummy"));
 
   std::pair<int, int> elec_attrs{1, 2};
   mfem::Array<int> submesh_domains;


### PR DESCRIPTION
Previously `OpenCoilSolver` would give incorrect current density distributions if the coil had inhomogeneous conductivity. This update addresses that.

Also:
- Boundary conditions on the scalar potential at terminals are now applied symmetrically, improving stability.
- Minor fix to ensure initial conditions in time domain formulations are now set consistently in `ConstructState` rather than `ImplictSolve`