### PR TITLE
Switch to a patched version of MFEM in the docker build, fixing OpenCoilSolver issues

### DIFF
--- a/docker/hephaestus-deps/Dockerfile
+++ b/docker/hephaestus-deps/Dockerfile
@@ -104,9 +104,9 @@ RUN cd /$WORKDIR/petsc/petsc-3.19.3 && \
 
 # Build MFEM and common miniapp
 RUN cd /$WORKDIR && \
-    git clone https://github.com/mfem/mfem.git && \
+    git clone https://github.com/Heinrich-BR/mfem.git && \
     cd mfem && \
-    git checkout master && \
+    git checkout SubmeshBoundary && \
     mkdir build && \
     cd build && \
     cmake .. \


### PR DESCRIPTION
Temporary switch to using a patched version of MFEM to enable support for BoundaryAttributes on SubMeshes that lie inside the computational domain. 

Necessary to fix `OpenCoilSolver` for key use cases until https://github.com/mfem/mfem/pull/4020 is merged.