### PR TITLE
Add checks to prevent objects stored in NamedFieldsMaps being overwritten during problem setup

### DIFF
--- a/src/boundary_conditions/Essential/function_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/function_dirichlet_bc.cpp
@@ -15,8 +15,8 @@ ScalarDirichletBC::ScalarDirichletBC(const std::string &name_,
 void ScalarDirichletBC::applyBC(mfem::GridFunction &gridfunc,
                                 mfem::Mesh *mesh_) {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
-  ess_bdrs = this->getMarkers(*mesh_);
-  gridfunc.ProjectBdrCoefficient(*(this->coeff), ess_bdrs);
+  ess_bdrs = getMarkers(*mesh_);
+  gridfunc.ProjectBdrCoefficient(*(coeff), ess_bdrs);
 }
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
@@ -2,53 +2,52 @@
 
 namespace hephaestus {
 
-VectorDirichletBC::VectorDirichletBC(
-    const std::string &name_, mfem::Array<int> bdr_attributes_)
+VectorDirichletBC::VectorDirichletBC(const std::string &name_,
+                                     mfem::Array<int> bdr_attributes_)
     : EssentialBC(name_, bdr_attributes_) {}
 
-VectorDirichletBC::VectorDirichletBC(
-    const std::string &name_, mfem::Array<int> bdr_attributes_,
-    mfem::VectorCoefficient *vec_coeff_,
-    mfem::VectorCoefficient *vec_coeff_im_,
-    APPLY_TYPE boundary_apply_type_)
+VectorDirichletBC::VectorDirichletBC(const std::string &name_,
+                                     mfem::Array<int> bdr_attributes_,
+                                     mfem::VectorCoefficient *vec_coeff_,
+                                     mfem::VectorCoefficient *vec_coeff_im_,
+                                     APPLY_TYPE boundary_apply_type_)
     : EssentialBC(name_, bdr_attributes_), vec_coeff(vec_coeff_),
       vec_coeff_im(vec_coeff_im_), boundary_apply_type(boundary_apply_type_) {}
 
 void VectorDirichletBC::applyBC(mfem::GridFunction &gridfunc,
-                                        mfem::Mesh *mesh_) {
+                                mfem::Mesh *mesh_) {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
-  ess_bdrs = this->getMarkers(*mesh_);
-  if (this->vec_coeff == NULL) {
+  ess_bdrs = getMarkers(*mesh_);
+  if (vec_coeff == NULL) {
     MFEM_ABORT(
         "Boundary condition does not store valid coefficients to specify the "
         "components of the vector at the Dirichlet boundary.");
   }
 
-  switch (boundary_apply_type)
-  {
+  switch (boundary_apply_type) {
   case STANDARD:
-    gridfunc.ProjectBdrCoefficient(*(this->vec_coeff), ess_bdrs);
+    gridfunc.ProjectBdrCoefficient(*(vec_coeff), ess_bdrs);
     break;
   case NORMAL:
-    gridfunc.ProjectBdrCoefficientNormal(*(this->vec_coeff), ess_bdrs);
+    gridfunc.ProjectBdrCoefficientNormal(*(vec_coeff), ess_bdrs);
     break;
   case TANGENTIAL:
-    gridfunc.ProjectBdrCoefficientTangent(*(this->vec_coeff), ess_bdrs);
+    gridfunc.ProjectBdrCoefficientTangent(*(vec_coeff), ess_bdrs);
   }
 }
 
 void VectorDirichletBC::applyBC(mfem::ParComplexGridFunction &gridfunc,
-                                        mfem::Mesh *mesh_) {
+                                mfem::Mesh *mesh_) {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
-  ess_bdrs = this->getMarkers(*mesh_);
-  if (this->vec_coeff == NULL || this->vec_coeff_im == NULL) {
+  ess_bdrs = getMarkers(*mesh_);
+  if (vec_coeff == NULL || vec_coeff_im == NULL) {
     MFEM_ABORT(
         "Boundary condition does not store valid coefficients to specify both "
         "the real and imaginary components of the vector at the Dirichlet "
         "boundary.");
   }
-  gridfunc.ProjectBdrCoefficientTangent(*(this->vec_coeff),
-                                        *(this->vec_coeff_im), ess_bdrs);
+  gridfunc.ProjectBdrCoefficientTangent(*(vec_coeff), *(vec_coeff_im),
+                                        ess_bdrs);
 }
 
 } // namespace hephaestus

--- a/src/executioners/steady_executioner.cpp
+++ b/src/executioners/steady_executioner.cpp
@@ -16,5 +16,5 @@ void SteadyExecutioner::Solve() const {
   // Output timestep summary to console
   problem->outputs.Write();
 }
-void SteadyExecutioner::Execute() const { this->Solve(); }
+void SteadyExecutioner::Execute() const { Solve(); }
 } // namespace hephaestus

--- a/src/formulations/AV/av_formulation.cpp
+++ b/src/formulations/AV/av_formulation.cpp
@@ -47,24 +47,22 @@ void AVFormulation::ConstructEquationSystem() {
   av_system_params.SetParam("ScalarPotentialName", _scalar_potential_name);
   av_system_params.SetParam("AlphaCoefName", _alpha_coef_name);
   av_system_params.SetParam("BetaCoefName", _beta_coef_name);
-  this->GetProblem()->td_equation_system =
+  GetProblem()->td_equation_system =
       std::make_unique<hephaestus::AVEquationSystem>(av_system_params);
 }
 
 void AVFormulation::ConstructOperator() {
-  this->problem->td_operator = std::make_unique<hephaestus::AVOperator>(
-      *(this->problem->pmesh), this->problem->fespaces,
-      this->problem->gridfunctions, this->problem->bc_map,
-      this->problem->coefficients, this->problem->sources,
-      this->problem->solver_options);
-  this->problem->td_operator->SetEquationSystem(
-      this->problem->td_equation_system.get());
-  this->problem->td_operator->SetGridFunctions();
+  problem->td_operator = std::make_unique<hephaestus::AVOperator>(
+      *(problem->pmesh), problem->fespaces, problem->gridfunctions,
+      problem->bc_map, problem->coefficients, problem->sources,
+      problem->solver_options);
+  problem->td_operator->SetEquationSystem(problem->td_equation_system.get());
+  problem->td_operator->SetGridFunctions();
 };
 
 void AVFormulation::RegisterGridFunctions() {
-  int &myid = this->GetProblem()->myid_;
-  hephaestus::GridFunctions &gridfunctions = this->GetProblem()->gridfunctions;
+  int &myid = GetProblem()->myid_;
+  hephaestus::GridFunctions &gridfunctions = GetProblem()->gridfunctions;
 
   // Register default ParGridFunctions of state gridfunctions if not provided
   if (!gridfunctions.Has(_vector_potential_name)) {
@@ -93,7 +91,7 @@ void AVFormulation::RegisterGridFunctions() {
 };
 
 void AVFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
   if (!coefficients.scalars.Has(_inv_alpha_coef_name)) {
     MFEM_ABORT(_inv_alpha_coef_name + " coefficient not found.");
   }
@@ -222,7 +220,7 @@ void AVOperator::ImplicitSolve(const double dt, const mfem::Vector &X,
     local_trial_vars.at(ind)->MakeRef(local_trial_vars.at(ind)->ParFESpace(),
                                       dX_dt, true_offsets[ind]);
   }
-  _coefficients.SetTime(this->GetTime());
+  _coefficients.SetTime(GetTime());
   _equation_system->setTimeStep(dt);
   _equation_system->updateEquationSystem(_bc_map, _sources);
 

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
@@ -23,7 +23,7 @@ void ComplexAFormulation::registerCurrentDensityAux(
     const std::string &j_field_imag_name) {
   //* Current density J = Jᵉ + σE
   //* Induced current density Jind = σE = -iωσA
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(j_field_imag_name,
                       new hephaestus::ScaledVectorGridFunctionAux(
                           _magnetic_vector_potential_real_name,
@@ -40,7 +40,7 @@ void ComplexAFormulation::registerMagneticFluxDensityAux(
     const std::string &b_field_real_name,
     const std::string &b_field_imag_name) {
   //* Magnetic flux density B = curl A
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       b_field_real_name,
       new hephaestus::CurlAuxSolver(_magnetic_vector_potential_real_name,
@@ -57,7 +57,7 @@ void ComplexAFormulation::registerElectricFieldAux(
     const std::string &e_field_real_name,
     const std::string &e_field_imag_name) {
   //* Electric field E =-dA/dt=-iωA
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(e_field_imag_name,
                       new hephaestus::ScaledVectorGridFunctionAux(
                           _magnetic_vector_potential_real_name,
@@ -77,7 +77,7 @@ void ComplexAFormulation::registerJouleHeatingDensityAux(
     const std::string &e_field_imag_name,
     const std::string &conductivity_coef_name) {
   //* Time averaged Joule heating density = E.J
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(
                           p_field_name, p_field_name, _loss_coef_name,

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -20,7 +20,7 @@ void ComplexEFormulation::registerCurrentDensityAux(
     const std::string &j_field_imag_name) {
   //* Current density J = Jᵉ + σE
   //* Induced electric current, Jind = σE
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(j_field_real_name,
                       new hephaestus::ScaledVectorGridFunctionAux(
                           _electric_field_real_name, j_field_real_name,
@@ -38,7 +38,7 @@ void ComplexEFormulation::registerMagneticFluxDensityAux(
     const std::string &b_field_imag_name) {
   //* Magnetic flux density B = (i/ω) curl E
   //* (∇×E = -dB/dt = -iωB)
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(b_field_imag_name,
                       new hephaestus::ScaledCurlVectorGridFunctionAux(
                           _electric_field_real_name, b_field_imag_name,
@@ -57,7 +57,7 @@ void ComplexEFormulation::registerJouleHeatingDensityAux(
     const std::string &e_field_imag_name,
     const std::string &conductivity_coef_name) {
   //* Time averaged Joule heating density = E.J
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       p_field_name,
       new hephaestus::VectorGridFunctionDotProductAux(

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
@@ -108,27 +108,25 @@ ComplexMaxwellFormulation::ComplexMaxwellFormulation(
       _loss_coef_name(std::string("maxwell_loss")) {}
 
 void ComplexMaxwellFormulation::ConstructOperator() {
-  hephaestus::InputParameters &solver_options =
-      this->GetProblem()->solver_options;
+  hephaestus::InputParameters &solver_options = GetProblem()->solver_options;
   solver_options.SetParam("HCurlVarComplexName", _h_curl_var_complex_name);
   solver_options.SetParam("HCurlVarRealName", _h_curl_var_real_name);
   solver_options.SetParam("HCurlVarImagName", _h_curl_var_imag_name);
   solver_options.SetParam("StiffnessCoefName", _alpha_coef_name);
   solver_options.SetParam("MassCoefName", _mass_coef_name);
   solver_options.SetParam("LossCoefName", _loss_coef_name);
-  this->problem->eq_sys_operator =
+  problem->eq_sys_operator =
       std::make_unique<hephaestus::ComplexMaxwellOperator>(
-          *(this->problem->pmesh), this->problem->fespaces,
-          this->problem->gridfunctions, this->problem->bc_map,
-          this->problem->coefficients, this->problem->sources,
-          this->problem->solver_options);
-  this->problem->GetOperator()->SetGridFunctions();
+          *(problem->pmesh), problem->fespaces, problem->gridfunctions,
+          problem->bc_map, problem->coefficients, problem->sources,
+          problem->solver_options);
+  problem->GetOperator()->SetGridFunctions();
 }
 
 void ComplexMaxwellFormulation::RegisterGridFunctions() {
-  int &myid = this->GetProblem()->myid_;
-  hephaestus::GridFunctions &gridfunctions = this->GetProblem()->gridfunctions;
-  hephaestus::FESpaces &fespaces = this->GetProblem()->fespaces;
+  int &myid = GetProblem()->myid_;
+  hephaestus::GridFunctions &gridfunctions = GetProblem()->gridfunctions;
+  hephaestus::FESpaces &fespaces = GetProblem()->fespaces;
 
   // Register default ParGridFunctions of state gridfunctions if not provided
   if (!gridfunctions.Has(_h_curl_var_real_name)) {
@@ -144,7 +142,7 @@ void ComplexMaxwellFormulation::RegisterGridFunctions() {
 }
 
 void ComplexMaxwellFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
 
   if (!coefficients.scalars.Has(_frequency_coef_name)) {
     MFEM_ABORT(_frequency_coef_name + " coefficient not found.");

--- a/src/formulations/Dual/dual_formulation.cpp
+++ b/src/formulations/Dual/dual_formulation.cpp
@@ -58,24 +58,22 @@ void DualFormulation::ConstructEquationSystem() {
   weak_form_params.SetParam("HDivVarName", _h_div_var_name);
   weak_form_params.SetParam("AlphaCoefName", _alpha_coef_name);
   weak_form_params.SetParam("BetaCoefName", _beta_coef_name);
-  this->GetProblem()->td_equation_system =
+  GetProblem()->td_equation_system =
       std::make_unique<hephaestus::WeakCurlEquationSystem>(weak_form_params);
 }
 
 void DualFormulation::ConstructOperator() {
-  this->problem->td_operator = std::make_unique<hephaestus::DualOperator>(
-      *(this->problem->pmesh), this->problem->fespaces,
-      this->problem->gridfunctions, this->problem->bc_map,
-      this->problem->coefficients, this->problem->sources,
-      this->problem->solver_options);
-  this->problem->td_operator->SetEquationSystem(
-      this->problem->td_equation_system.get());
-  this->problem->td_operator->SetGridFunctions();
+  problem->td_operator = std::make_unique<hephaestus::DualOperator>(
+      *(problem->pmesh), problem->fespaces, problem->gridfunctions,
+      problem->bc_map, problem->coefficients, problem->sources,
+      problem->solver_options);
+  problem->td_operator->SetEquationSystem(problem->td_equation_system.get());
+  problem->td_operator->SetGridFunctions();
 };
 
 void DualFormulation::RegisterGridFunctions() {
-  int &myid = this->GetProblem()->myid_;
-  hephaestus::GridFunctions &gridfunctions = this->GetProblem()->gridfunctions;
+  int &myid = GetProblem()->myid_;
+  hephaestus::GridFunctions &gridfunctions = GetProblem()->gridfunctions;
 
   // Register default ParGridFunctions of state gridfunctions if not provided
   if (!gridfunctions.Has(_h_curl_var_name)) {
@@ -102,7 +100,7 @@ void DualFormulation::RegisterGridFunctions() {
 };
 
 void DualFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
 
   if (!coefficients.scalars.Has(_alpha_coef_name)) {
     MFEM_ABORT(_alpha_coef_name + " coefficient not found.");
@@ -191,7 +189,7 @@ void DualOperator::ImplicitSolve(const double dt, const mfem::Vector &X,
     local_trial_vars.at(ind)->MakeRef(local_trial_vars.at(ind)->ParFESpace(),
                                       dX_dt, true_offsets[ind]);
   }
-  _coefficients.SetTime(this->GetTime());
+  _coefficients.SetTime(GetTime());
   _equation_system->setTimeStep(dt);
   _equation_system->updateEquationSystem(_bc_map, _sources);
 

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -15,7 +15,7 @@ void EBDualFormulation::registerCurrentDensityAux(
     const std::string &j_field_name) {
   //* Current density J = Jᵉ + σE
   //* Induced electric field, Jind = σE
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       j_field_name,
       new hephaestus::ScaledVectorGridFunctionAux(
@@ -27,7 +27,7 @@ void EBDualFormulation::registerLorentzForceDensityAux(
     const std::string &f_field_name, const std::string &b_field_name,
     const std::string &j_field_name) {
   //* Lorentz force density = J x B
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       f_field_name,
       new hephaestus::VectorGridFunctionCrossProductAux(
@@ -40,7 +40,7 @@ void EBDualFormulation::registerJouleHeatingDensityAux(
     const std::string &p_field_name, const std::string &e_field_name,
     const std::string &conductivity_coef_name) {
   //* Joule heating density = E.J
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(
                           p_field_name, p_field_name,
@@ -51,7 +51,7 @@ void EBDualFormulation::registerJouleHeatingDensityAux(
 }
 
 void EBDualFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
   if (!coefficients.scalars.Has(_magnetic_permeability_name)) {
     MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -28,7 +28,7 @@ AFormulation::AFormulation(const std::string &magnetic_reluctivity_name,
 void AFormulation::registerCurrentDensityAux(const std::string &j_field_name) {
   //* Current density J = Jᵉ -σdA/dt
   //* Induced electric field, Jind = -σdA/dt
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(j_field_name,
                       new hephaestus::ScaledVectorGridFunctionAux(
                           GetTimeDerivativeName(_h_curl_var_name), j_field_name,
@@ -39,7 +39,7 @@ void AFormulation::registerCurrentDensityAux(const std::string &j_field_name) {
 void AFormulation::registerMagneticFluxDensityAux(
     const std::string &b_field_name) {
   //* Magnetic flux density, B = ∇×A
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       b_field_name,
       new hephaestus::CurlAuxSolver(_h_curl_var_name, b_field_name), true);
@@ -48,7 +48,7 @@ void AFormulation::registerMagneticFluxDensityAux(
 void AFormulation::registerElectricFieldAux(const std::string &e_field_name) {
   //* Total electric field, E = ρJᵉ -dA/dt
   //* Induced electric field, Eind = -dA/dt
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       e_field_name,
       new hephaestus::ScaledVectorGridFunctionAux(
@@ -58,7 +58,7 @@ void AFormulation::registerElectricFieldAux(const std::string &e_field_name) {
 
 void AFormulation::registerMagneticFieldAux(const std::string &h_field_name) {
   //* Magnetic field H = ν∇×A
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       h_field_name,
       new hephaestus::ScaledCurlVectorGridFunctionAux(
@@ -70,7 +70,7 @@ void AFormulation::registerLorentzForceDensityAux(
     const std::string &f_field_name, const std::string &b_field_name,
     const std::string &j_field_name) {
   //* Lorentz force density = J x B
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       f_field_name,
       new hephaestus::VectorGridFunctionCrossProductAux(
@@ -83,7 +83,7 @@ void AFormulation::registerJouleHeatingDensityAux(
     const std::string &p_field_name, const std::string &e_field_name,
     const std::string &conductivity_coef_name) {
   //* Joule heating density = E.J
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(
                           p_field_name, p_field_name,
@@ -94,7 +94,7 @@ void AFormulation::registerJouleHeatingDensityAux(
 }
 
 void AFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
   if (!coefficients.scalars.Has(_magnetic_permeability_name)) {
     MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -25,7 +25,7 @@ EFormulation::EFormulation(const std::string &magnetic_reluctivity_name,
       _magnetic_permeability_name(magnetic_permeability_name) {}
 
 void EFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
   if (!coefficients.scalars.Has(_magnetic_permeability_name)) {
     MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }
@@ -43,7 +43,7 @@ void EFormulation::RegisterCoefficients() {
 void EFormulation::registerCurrentDensityAux(const std::string &j_field_name) {
   //* Current density J = Jᵉ + σE
   //* Induced electric field, Jind = σE
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       j_field_name,
       new hephaestus::ScaledVectorGridFunctionAux(
@@ -55,7 +55,7 @@ void EFormulation::registerJouleHeatingDensityAux(
     const std::string &p_field_name, const std::string &e_field_name,
     const std::string &conductivity_coef_name) {
   //* Joule heating density = E.J
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(
                           p_field_name, p_field_name,

--- a/src/formulations/HCurl/h_formulation.cpp
+++ b/src/formulations/HCurl/h_formulation.cpp
@@ -25,7 +25,7 @@ HFormulation::HFormulation(const std::string &electric_resistivity_name,
 
 void HFormulation::registerCurrentDensityAux(const std::string &j_field_name) {
   //* Current density J = ∇×H
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       j_field_name,
       new hephaestus::CurlAuxSolver(_h_curl_var_name, j_field_name), true);
@@ -35,7 +35,7 @@ void HFormulation::registerMagneticFluxDensityAux(
     const std::string &b_field_name) {
   //* Magnetic flux density, B = Bᵉ + μH
   //* Induced flux density, B = μH
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       b_field_name,
       new hephaestus::ScaledVectorGridFunctionAux(
@@ -45,7 +45,7 @@ void HFormulation::registerMagneticFluxDensityAux(
 
 void HFormulation::registerElectricFieldAux(const std::string &e_field_name) {
   //* Electric field, E = ρ∇×H
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       e_field_name,
       new hephaestus::ScaledCurlVectorGridFunctionAux(
@@ -61,7 +61,7 @@ void HFormulation::registerLorentzForceDensityAux(
     const std::string &f_field_name, const std::string &b_field_name,
     const std::string &j_field_name) {
   //* Lorentz force density = J x B
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       f_field_name,
       new hephaestus::VectorGridFunctionCrossProductAux(
@@ -74,7 +74,7 @@ void HFormulation::registerJouleHeatingDensityAux(
     const std::string &p_field_name, const std::string &e_field_name,
     const std::string &conductivity_coef_name) {
   //* Joule heating density = E.J
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(
                           p_field_name, p_field_name,
@@ -85,7 +85,7 @@ void HFormulation::registerJouleHeatingDensityAux(
 }
 
 void HFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
   if (!coefficients.scalars.Has(_electric_conductivity_name)) {
     MFEM_ABORT(_electric_conductivity_name + " coefficient not found.");
   }

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -51,25 +51,23 @@ void HCurlFormulation::ConstructEquationSystem() {
   weak_form_params.SetParam("HCurlVarName", _h_curl_var_name);
   weak_form_params.SetParam("AlphaCoefName", _alpha_coef_name);
   weak_form_params.SetParam("BetaCoefName", _beta_coef_name);
-  this->GetProblem()->td_equation_system =
+  GetProblem()->td_equation_system =
       std::make_unique<hephaestus::CurlCurlEquationSystem>(weak_form_params);
 }
 
 void HCurlFormulation::ConstructOperator() {
-  this->problem->td_operator = std::make_unique<hephaestus::HCurlOperator>(
-      *(this->problem->pmesh), this->problem->fespaces,
-      this->problem->gridfunctions, this->problem->bc_map,
-      this->problem->coefficients, this->problem->sources,
-      this->problem->solver_options);
-  this->problem->td_operator->SetEquationSystem(
-      this->problem->td_equation_system.get());
-  this->problem->td_operator->SetGridFunctions();
+  problem->td_operator = std::make_unique<hephaestus::HCurlOperator>(
+      *(problem->pmesh), problem->fespaces, problem->gridfunctions,
+      problem->bc_map, problem->coefficients, problem->sources,
+      problem->solver_options);
+  problem->td_operator->SetEquationSystem(problem->td_equation_system.get());
+  problem->td_operator->SetGridFunctions();
 };
 
 void HCurlFormulation::RegisterGridFunctions() {
-  int &myid = this->GetProblem()->myid_;
-  hephaestus::GridFunctions &gridfunctions = this->GetProblem()->gridfunctions;
-  hephaestus::FESpaces &fespaces = this->GetProblem()->fespaces;
+  int &myid = GetProblem()->myid_;
+  hephaestus::GridFunctions &gridfunctions = GetProblem()->gridfunctions;
+  hephaestus::FESpaces &fespaces = GetProblem()->fespaces;
 
   // Register default ParGridFunctions of state gridfunctions if not provided
   if (!gridfunctions.Has(_h_curl_var_name)) {
@@ -129,7 +127,7 @@ void CurlCurlEquationSystem::addKernels() {
 }
 
 void HCurlFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
   if (!coefficients.scalars.Has(_alpha_coef_name)) {
     MFEM_ABORT(_alpha_coef_name + " coefficient not found.");
   }
@@ -173,7 +171,7 @@ void HCurlOperator::ImplicitSolve(const double dt, const mfem::Vector &X,
     local_trial_vars.at(ind)->MakeRef(local_trial_vars.at(ind)->ParFESpace(),
                                       dX_dt, true_offsets[ind]);
   }
-  _coefficients.SetTime(this->GetTime());
+  _coefficients.SetTime(GetTime());
   _equation_system->setTimeStep(dt);
   _equation_system->updateEquationSystem(_bc_map, _sources);
 

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
@@ -27,7 +27,7 @@ MagnetostaticFormulation::MagnetostaticFormulation(
 void MagnetostaticFormulation::registerMagneticFluxDensityAux(
     const std::string &b_field_name) {
   //* Magnetic flux density, B = ∇×A
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       b_field_name,
       new hephaestus::CurlAuxSolver(_h_curl_var_name, b_field_name), true);
@@ -36,7 +36,7 @@ void MagnetostaticFormulation::registerMagneticFluxDensityAux(
 void MagnetostaticFormulation::registerMagneticFieldAux(
     const std::string &h_field_name) {
   //* Magnetic field H = ν∇×A
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       h_field_name,
       new hephaestus::ScaledCurlVectorGridFunctionAux(
@@ -48,7 +48,7 @@ void MagnetostaticFormulation::registerLorentzForceDensityAux(
     const std::string &f_field_name, const std::string &b_field_name,
     const std::string &j_field_name) {
   //* Lorentz force density = J x B
-  hephaestus::AuxSolvers &auxsolvers = this->GetProblem()->postprocessors;
+  hephaestus::AuxSolvers &auxsolvers = GetProblem()->postprocessors;
   auxsolvers.Register(
       f_field_name,
       new hephaestus::VectorGridFunctionCrossProductAux(
@@ -58,7 +58,7 @@ void MagnetostaticFormulation::registerLorentzForceDensityAux(
 }
 
 void MagnetostaticFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
   if (!coefficients.scalars.Has(_magnetic_permeability_name)) {
     MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -35,23 +35,20 @@ StaticsFormulation::StaticsFormulation(const std::string &alpha_coef_name,
       _h_curl_var_name(h_curl_var_name) {}
 
 void StaticsFormulation::ConstructOperator() {
-  hephaestus::InputParameters &solver_options =
-      this->GetProblem()->solver_options;
+  hephaestus::InputParameters &solver_options = GetProblem()->solver_options;
   solver_options.SetParam("HCurlVarName", _h_curl_var_name);
   solver_options.SetParam("StiffnessCoefName", _alpha_coef_name);
-  this->problem->eq_sys_operator =
-      std::make_unique<hephaestus::StaticsOperator>(
-          *(this->problem->pmesh), this->problem->fespaces,
-          this->problem->gridfunctions, this->problem->bc_map,
-          this->problem->coefficients, this->problem->sources,
-          this->problem->solver_options);
-  this->problem->GetOperator()->SetGridFunctions();
+  problem->eq_sys_operator = std::make_unique<hephaestus::StaticsOperator>(
+      *(problem->pmesh), problem->fespaces, problem->gridfunctions,
+      problem->bc_map, problem->coefficients, problem->sources,
+      problem->solver_options);
+  problem->GetOperator()->SetGridFunctions();
 };
 
 void StaticsFormulation::RegisterGridFunctions() {
-  int &myid = this->GetProblem()->myid_;
-  hephaestus::GridFunctions &gridfunctions = this->GetProblem()->gridfunctions;
-  hephaestus::FESpaces &fespaces = this->GetProblem()->fespaces;
+  int &myid = GetProblem()->myid_;
+  hephaestus::GridFunctions &gridfunctions = GetProblem()->gridfunctions;
+  hephaestus::FESpaces &fespaces = GetProblem()->fespaces;
 
   // Register default ParGridFunctions of state gridfunctions if not provided
   if (!gridfunctions.Has(_h_curl_var_name)) {
@@ -65,7 +62,7 @@ void StaticsFormulation::RegisterGridFunctions() {
 };
 
 void StaticsFormulation::RegisterCoefficients() {
-  hephaestus::Coefficients &coefficients = this->GetProblem()->coefficients;
+  hephaestus::Coefficients &coefficients = GetProblem()->coefficients;
   if (!coefficients.scalars.Has(_alpha_coef_name)) {
     MFEM_ABORT(_alpha_coef_name + " coefficient not found.");
   }

--- a/src/formulations/equation_system_operator.cpp
+++ b/src/formulations/equation_system_operator.cpp
@@ -22,8 +22,8 @@ void EquationSystemOperator::SetGridFunctions() {
   }
   true_offsets.PartialSum();
 
-  this->height = true_offsets[local_test_vars.size()];
-  this->width = true_offsets[local_test_vars.size()];
+  height = true_offsets[local_test_vars.size()];
+  width = true_offsets[local_test_vars.size()];
   trueX.Update(block_trueOffsets);
   trueRhs.Update(block_trueOffsets);
 

--- a/src/formulations/time_domain_equation_system_operator.cpp
+++ b/src/formulations/time_domain_equation_system_operator.cpp
@@ -38,8 +38,8 @@ void TimeDomainEquationSystemOperator::SetGridFunctions() {
   }
   true_offsets.PartialSum();
 
-  this->height = true_offsets[local_test_vars.size()];
-  this->width = true_offsets[local_test_vars.size()];
+  height = true_offsets[local_test_vars.size()];
+  width = true_offsets[local_test_vars.size()];
   trueX.Update(block_trueOffsets);
   trueRhs.Update(block_trueOffsets);
 
@@ -76,7 +76,7 @@ void TimeDomainEquationSystemOperator::ImplicitSolve(const double dt,
     local_trial_vars.at(ind)->MakeRef(local_trial_vars.at(ind)->ParFESpace(),
                                       dX_dt, true_offsets[ind]);
   }
-  _coefficients.SetTime(this->GetTime());
+  _coefficients.SetTime(GetTime());
   _equation_system->setTimeStep(dt);
   _equation_system->updateEquationSystem(_bc_map, _sources);
 

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -46,6 +46,12 @@ void ProblemBuilder::SetCoefficients(hephaestus::Coefficients &coefficients) {
 
 void ProblemBuilder::AddFESpace(std::string fespace_name, std::string fec_name,
                                 int vdim, int ordering) {
+  if (this->GetProblem()->fespaces.Has(fespace_name)) {
+    const std::string error_message =
+        "A fespace with the name " + fespace_name +
+        " has already been added to the problem fespaces.";
+    mfem::mfem_error(error_message.c_str());
+  }
   if (!this->GetProblem()->fecs.Has(fec_name)) {
     mfem::FiniteElementCollection *fec =
         mfem::FiniteElementCollection::New(fec_name.c_str());
@@ -68,6 +74,12 @@ void ProblemBuilder::AddFESpace(std::string fespace_name, std::string fec_name,
 
 void ProblemBuilder::AddGridFunction(std::string gridfunction_name,
                                      std::string fespace_name) {
+  if (this->GetProblem()->gridfunctions.Has(gridfunction_name)) {
+    const std::string error_message =
+        "A gridfunction with the name " + gridfunction_name +
+        " has already been added to the problem gridfunctions.";
+    mfem::mfem_error(error_message.c_str());
+  }
   mfem::ParFiniteElementSpace *fespace(
       this->GetProblem()->fespaces.Get(fespace_name));
   if (fespace == NULL) {
@@ -88,22 +100,46 @@ void ProblemBuilder::AddGridFunction(std::string gridfunction_name,
 void ProblemBuilder::AddBoundaryCondition(std::string bc_name,
                                           hephaestus::BoundaryCondition *bc,
                                           bool own_data) {
+  if (this->GetProblem()->bc_map.Has(bc_name)) {
+    const std::string error_message =
+        "A boundary condition with the name " + bc_name +
+        " has already been added to the problem boundary conditions.";
+    mfem::mfem_error(error_message.c_str());
+  }
   this->GetProblem()->bc_map.Register(bc_name, bc, own_data);
 }
 
 void ProblemBuilder::AddAuxSolver(std::string auxsolver_name,
                                   hephaestus::AuxSolver *aux, bool own_data) {
+  if (this->GetProblem()->preprocessors.Has(auxsolver_name)) {
+    const std::string error_message =
+        "An auxsolver with the name " + auxsolver_name +
+        " has already been added to the problem preprocessors.";
+    mfem::mfem_error(error_message.c_str());
+  }
   this->GetProblem()->preprocessors.Register(auxsolver_name, aux, own_data);
 }
 
 void ProblemBuilder::AddPostprocessor(std::string auxsolver_name,
                                       hephaestus::AuxSolver *aux,
                                       bool own_data) {
+  if (this->GetProblem()->postprocessors.Has(auxsolver_name)) {
+    const std::string error_message =
+        "An auxsolver with the name " + auxsolver_name +
+        " has already been added to the problem postprocessors.";
+    mfem::mfem_error(error_message.c_str());
+  }
   this->GetProblem()->postprocessors.Register(auxsolver_name, aux, own_data);
 }
 
 void ProblemBuilder::AddSource(std::string source_name,
                                hephaestus::Source *source, bool own_data) {
+  if (this->GetProblem()->sources.Has(source_name)) {
+    const std::string error_message =
+        "A source with the name " + source_name +
+        " has already been added to the problem sources.";
+    mfem::mfem_error(error_message.c_str());
+  }
   this->GetProblem()->sources.Register(source_name, source, own_data);
 }
 

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -2,86 +2,86 @@
 
 namespace hephaestus {
 void ProblemBuilder::SetMesh(std::shared_ptr<mfem::ParMesh> pmesh) {
-  this->GetProblem()->pmesh = pmesh;
-  MPI_Comm_rank(pmesh->GetComm(), &(this->GetProblem()->myid_));
+  GetProblem()->pmesh = pmesh;
+  MPI_Comm_rank(pmesh->GetComm(), &(GetProblem()->myid_));
 }
 
 void ProblemBuilder::SetFESpaces(hephaestus::FESpaces &fespaces) {
-  this->GetProblem()->fespaces = fespaces;
+  GetProblem()->fespaces = fespaces;
 }
 
 void ProblemBuilder::SetGridFunctions(
     hephaestus::GridFunctions &gridfunctions) {
-  this->GetProblem()->gridfunctions = gridfunctions;
+  GetProblem()->gridfunctions = gridfunctions;
 }
 
 void ProblemBuilder::SetBoundaryConditions(hephaestus::BCMap &bc_map) {
-  this->GetProblem()->bc_map = bc_map;
+  GetProblem()->bc_map = bc_map;
 }
 
 void ProblemBuilder::SetAuxSolvers(hephaestus::AuxSolvers &preprocessors) {
-  this->GetProblem()->preprocessors = preprocessors;
+  GetProblem()->preprocessors = preprocessors;
 }
 
 void ProblemBuilder::SetPostprocessors(hephaestus::AuxSolvers &postprocessors) {
-  this->GetProblem()->postprocessors = postprocessors;
+  GetProblem()->postprocessors = postprocessors;
 }
 
 void ProblemBuilder::SetSources(hephaestus::Sources &sources) {
-  this->GetProblem()->sources = sources;
+  GetProblem()->sources = sources;
 }
 
 void ProblemBuilder::SetOutputs(hephaestus::Outputs &outputs) {
-  this->GetProblem()->outputs = outputs;
+  GetProblem()->outputs = outputs;
 }
 
 void ProblemBuilder::SetSolverOptions(
     hephaestus::InputParameters &solver_options) {
-  this->GetProblem()->solver_options = solver_options;
+  GetProblem()->solver_options = solver_options;
 }
 
 void ProblemBuilder::SetCoefficients(hephaestus::Coefficients &coefficients) {
-  this->GetProblem()->coefficients = coefficients;
+  GetProblem()->coefficients = coefficients;
 }
 
 void ProblemBuilder::AddFESpace(std::string fespace_name, std::string fec_name,
                                 int vdim, int ordering) {
-  if (this->GetProblem()->fespaces.Has(fespace_name)) {
+  if (GetProblem()->fespaces.Has(fespace_name)) {
     const std::string error_message =
         "A fespace with the name " + fespace_name +
         " has already been added to the problem fespaces.";
     mfem::mfem_error(error_message.c_str());
   }
-  if (!this->GetProblem()->fecs.Has(fec_name)) {
+  if (!GetProblem()->fecs.Has(fec_name)) {
     mfem::FiniteElementCollection *fec =
         mfem::FiniteElementCollection::New(fec_name.c_str());
-    this->GetProblem()->fecs.Register(fec_name, fec, true);
+    GetProblem()->fecs.Register(fec_name, fec, true);
   }
 
-  if (!this->GetProblem()->fespaces.Has(fespace_name)) {
-    mfem::ParMesh *pmesh = this->GetProblem()->pmesh.get();
+  if (!GetProblem()->fespaces.Has(fespace_name)) {
+    mfem::ParMesh *pmesh = GetProblem()->pmesh.get();
     if (pmesh == NULL) {
       MFEM_ABORT("ParMesh not found when trying to add " << fespace_name
                                                          << " to fespaces.");
     }
     mfem::ParFiniteElementSpace *pfes = new mfem::ParFiniteElementSpace(
-        this->GetProblem()->pmesh.get(), this->GetProblem()->fecs.Get(fec_name),
-        vdim, ordering);
+        GetProblem()->pmesh.get(), GetProblem()->fecs.Get(fec_name), vdim,
+        ordering);
 
-    this->GetProblem()->fespaces.Register(fespace_name, pfes, true);
+    GetProblem()->fespaces.Register(fespace_name, pfes, true);
   }
 }
 
 void ProblemBuilder::AddGridFunction(std::string gridfunction_name,
                                      std::string fespace_name) {
-  if (this->GetProblem()->gridfunctions.Has(gridfunction_name)) {
+  if (GetProblem()->gridfunctions.Has(gridfunction_name)) {
     const std::string error_message =
         "A gridfunction with the name " + gridfunction_name +
         " has already been added to the problem gridfunctions.";
     mfem::mfem_error(error_message.c_str());
   }
   mfem::ParFiniteElementSpace *fespace(
-      this->GetProblem()->fespaces.Get(fespace_name));
+      GetProblem()->fespaces.Get(fespace_name));
   if (fespace == NULL) {
     MFEM_ABORT(
         "FESpace " << fespace_name
@@ -94,64 +94,64 @@ void ProblemBuilder::AddGridFunction(std::string gridfunction_name,
   mfem::ParGridFunction *gridfunc = new mfem::ParGridFunction(fespace);
   *gridfunc = 0.0;
 
-  this->GetProblem()->gridfunctions.Register(gridfunction_name, gridfunc, true);
+  GetProblem()->gridfunctions.Register(gridfunction_name, gridfunc, true);
 }
 
 void ProblemBuilder::AddBoundaryCondition(std::string bc_name,
                                           hephaestus::BoundaryCondition *bc,
                                           bool own_data) {
-  if (this->GetProblem()->bc_map.Has(bc_name)) {
+  if (GetProblem()->bc_map.Has(bc_name)) {
     const std::string error_message =
         "A boundary condition with the name " + bc_name +
         " has already been added to the problem boundary conditions.";
     mfem::mfem_error(error_message.c_str());
   }
-  this->GetProblem()->bc_map.Register(bc_name, bc, own_data);
+  GetProblem()->bc_map.Register(bc_name, bc, own_data);
 }
 
 void ProblemBuilder::AddAuxSolver(std::string auxsolver_name,
                                   hephaestus::AuxSolver *aux, bool own_data) {
-  if (this->GetProblem()->preprocessors.Has(auxsolver_name)) {
+  if (GetProblem()->preprocessors.Has(auxsolver_name)) {
     const std::string error_message =
         "An auxsolver with the name " + auxsolver_name +
         " has already been added to the problem preprocessors.";
     mfem::mfem_error(error_message.c_str());
   }
-  this->GetProblem()->preprocessors.Register(auxsolver_name, aux, own_data);
+  GetProblem()->preprocessors.Register(auxsolver_name, aux, own_data);
 }
 
 void ProblemBuilder::AddPostprocessor(std::string auxsolver_name,
                                       hephaestus::AuxSolver *aux,
                                       bool own_data) {
-  if (this->GetProblem()->postprocessors.Has(auxsolver_name)) {
+  if (GetProblem()->postprocessors.Has(auxsolver_name)) {
     const std::string error_message =
         "An auxsolver with the name " + auxsolver_name +
         " has already been added to the problem postprocessors.";
     mfem::mfem_error(error_message.c_str());
   }
-  this->GetProblem()->postprocessors.Register(auxsolver_name, aux, own_data);
+  GetProblem()->postprocessors.Register(auxsolver_name, aux, own_data);
 }
 
 void ProblemBuilder::AddSource(std::string source_name,
                                hephaestus::Source *source, bool own_data) {
-  if (this->GetProblem()->sources.Has(source_name)) {
+  if (GetProblem()->sources.Has(source_name)) {
     const std::string error_message =
         "A source with the name " + source_name +
         " has already been added to the problem sources.";
     mfem::mfem_error(error_message.c_str());
   }
-  this->GetProblem()->sources.Register(source_name, source, own_data);
+  GetProblem()->sources.Register(source_name, source, own_data);
 }
 
 void ProblemBuilder::InitializeAuxSolvers() {
-  this->GetProblem()->preprocessors.Init(this->GetProblem()->gridfunctions,
-                                         this->GetProblem()->coefficients);
-  this->GetProblem()->postprocessors.Init(this->GetProblem()->gridfunctions,
-                                          this->GetProblem()->coefficients);
+  GetProblem()->preprocessors.Init(GetProblem()->gridfunctions,
+                                   GetProblem()->coefficients);
+  GetProblem()->postprocessors.Init(GetProblem()->gridfunctions,
+                                    GetProblem()->coefficients);
 }
 
 void ProblemBuilder::InitializeOutputs() {
-  this->GetProblem()->outputs.Init(this->GetProblem()->gridfunctions);
+  GetProblem()->outputs.Init(GetProblem()->gridfunctions);
 }
 
 } // namespace hephaestus

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -59,8 +59,8 @@ public:
   void AddGridFunction(std::string gridfunction_name, std::string fespace_name);
   template <class T>
   void AddKernel(std::string var_name, hephaestus::Kernel<T> *kernel) {
-    this->GetProblem()->GetEquationSystem()->addVariableNameIfMissing(var_name);
-    this->GetProblem()->GetEquationSystem()->addKernel(var_name, kernel);
+    GetProblem()->GetEquationSystem()->addVariableNameIfMissing(var_name);
+    GetProblem()->GetEquationSystem()->addKernel(var_name, kernel);
   };
   void AddBoundaryCondition(std::string bc_name,
                             hephaestus::BoundaryCondition *bc, bool own_data);
@@ -108,28 +108,28 @@ public:
    */
   void ConstructOperatorProblem() {
     // SteadyStateProblem
-    this->problem_builder->RegisterFESpaces();
-    this->problem_builder->RegisterGridFunctions();
-    this->problem_builder->RegisterAuxSolvers();
-    this->problem_builder->RegisterCoefficients();
-    this->problem_builder->InitializeKernels();
-    this->problem_builder->ConstructOperator();
-    this->problem_builder->ConstructState();
-    this->problem_builder->InitializeAuxSolvers();
-    this->problem_builder->InitializeOutputs();
+    problem_builder->RegisterFESpaces();
+    problem_builder->RegisterGridFunctions();
+    problem_builder->RegisterAuxSolvers();
+    problem_builder->RegisterCoefficients();
+    problem_builder->InitializeKernels();
+    problem_builder->ConstructOperator();
+    problem_builder->ConstructState();
+    problem_builder->InitializeAuxSolvers();
+    problem_builder->InitializeOutputs();
   }
   void ConstructEquationSystemProblem() {
-    this->problem_builder->RegisterFESpaces();
-    this->problem_builder->RegisterGridFunctions();
-    this->problem_builder->RegisterAuxSolvers();
-    this->problem_builder->RegisterCoefficients();
-    this->problem_builder->ConstructEquationSystem();
-    this->problem_builder->InitializeKernels();
-    this->problem_builder->ConstructOperator();
-    this->problem_builder->ConstructState();
-    this->problem_builder->ConstructSolver();
-    this->problem_builder->InitializeAuxSolvers();
-    this->problem_builder->InitializeOutputs();
+    problem_builder->RegisterFESpaces();
+    problem_builder->RegisterGridFunctions();
+    problem_builder->RegisterAuxSolvers();
+    problem_builder->RegisterCoefficients();
+    problem_builder->ConstructEquationSystem();
+    problem_builder->InitializeKernels();
+    problem_builder->ConstructOperator();
+    problem_builder->ConstructState();
+    problem_builder->ConstructSolver();
+    problem_builder->InitializeAuxSolvers();
+    problem_builder->InitializeOutputs();
   }
 };
 

--- a/src/problem_builders/steady_state_problem_builder.cpp
+++ b/src/problem_builders/steady_state_problem_builder.cpp
@@ -3,26 +3,22 @@
 namespace hephaestus {
 
 void SteadyStateProblemBuilder::InitializeKernels() {
-  this->problem->preprocessors.Init(this->problem->gridfunctions,
-                                    this->problem->coefficients);
-  this->problem->sources.Init(this->problem->gridfunctions,
-                              this->problem->fespaces, this->problem->bc_map,
-                              this->problem->coefficients);
+  problem->preprocessors.Init(problem->gridfunctions, problem->coefficients);
+  problem->sources.Init(problem->gridfunctions, problem->fespaces,
+                        problem->bc_map, problem->coefficients);
 }
 void SteadyStateProblemBuilder::ConstructOperator() {
-  this->problem->eq_sys_operator =
+  problem->eq_sys_operator =
       std::make_unique<hephaestus::EquationSystemOperator>(
-          *(this->problem->pmesh), this->problem->fespaces,
-          this->problem->gridfunctions, this->problem->bc_map,
-          this->problem->coefficients, this->problem->sources,
-          this->problem->solver_options);
-  this->problem->eq_sys_operator->SetGridFunctions();
+          *(problem->pmesh), problem->fespaces, problem->gridfunctions,
+          problem->bc_map, problem->coefficients, problem->sources,
+          problem->solver_options);
+  problem->eq_sys_operator->SetGridFunctions();
 }
 
 void SteadyStateProblemBuilder::ConstructState() {
-  this->problem->F = new mfem::BlockVector(
-      this->problem->eq_sys_operator->true_offsets); // Vector of dofs
-  this->problem->eq_sys_operator->Init(
-      *(this->problem->F)); // Set up initial conditions
+  problem->F = new mfem::BlockVector(
+      problem->eq_sys_operator->true_offsets);   // Vector of dofs
+  problem->eq_sys_operator->Init(*(problem->F)); // Set up initial conditions
 }
 } // namespace hephaestus

--- a/src/problem_builders/steady_state_problem_builder.hpp
+++ b/src/problem_builders/steady_state_problem_builder.hpp
@@ -25,7 +25,7 @@ protected:
   mfem::ConstantCoefficient oneCoef{1.0};
 
   virtual hephaestus::SteadyStateProblem *GetProblem() override {
-    return this->problem.get();
+    return problem.get();
   };
 
 public:
@@ -33,7 +33,7 @@ public:
       : problem(std::make_unique<hephaestus::SteadyStateProblem>()){};
 
   virtual std::unique_ptr<hephaestus::SteadyStateProblem> ReturnProblem() {
-    return std::move(this->problem);
+    return std::move(problem);
   };
 
   virtual void RegisterFESpaces() override{};

--- a/src/problem_builders/time_domain_problem_builder.cpp
+++ b/src/problem_builders/time_domain_problem_builder.cpp
@@ -22,55 +22,48 @@ TimeDomainProblemBuilder::RegisterTimeDerivatives(
 
 void TimeDomainProblemBuilder::RegisterGridFunctions() {
   std::vector<std::string> gridfunction_names;
-  for (auto const &[name, gf] : this->problem->gridfunctions) {
+  for (auto const &[name, gf] : problem->gridfunctions) {
     gridfunction_names.push_back(name);
   }
-  this->RegisterTimeDerivatives(gridfunction_names,
-                                this->problem->gridfunctions);
+  RegisterTimeDerivatives(gridfunction_names, problem->gridfunctions);
 }
 
 void TimeDomainProblemBuilder::ConstructEquationSystem() {
   hephaestus::InputParameters params;
-  this->problem->td_equation_system =
+  problem->td_equation_system =
       std::make_unique<hephaestus::TimeDependentEquationSystem>(params);
 }
 
 void TimeDomainProblemBuilder::InitializeKernels() {
-  this->problem->td_equation_system->Init(
-      this->problem->gridfunctions, this->problem->fespaces,
-      this->problem->bc_map, this->problem->coefficients);
+  problem->td_equation_system->Init(problem->gridfunctions, problem->fespaces,
+                                    problem->bc_map, problem->coefficients);
 
-  this->problem->preprocessors.Init(this->problem->gridfunctions,
-                                    this->problem->coefficients);
-  this->problem->sources.Init(this->problem->gridfunctions,
-                              this->problem->fespaces, this->problem->bc_map,
-                              this->problem->coefficients);
+  problem->preprocessors.Init(problem->gridfunctions, problem->coefficients);
+  problem->sources.Init(problem->gridfunctions, problem->fespaces,
+                        problem->bc_map, problem->coefficients);
 }
 
 void TimeDomainProblemBuilder::ConstructOperator() {
-  this->problem->td_operator =
+  problem->td_operator =
       std::make_unique<hephaestus::TimeDomainEquationSystemOperator>(
-          *(this->problem->pmesh), this->problem->fespaces,
-          this->problem->gridfunctions, this->problem->bc_map,
-          this->problem->coefficients, this->problem->sources,
-          this->problem->solver_options);
-  this->problem->td_operator->SetEquationSystem(
-      this->problem->td_equation_system.get());
-  this->problem->td_operator->SetGridFunctions();
+          *(problem->pmesh), problem->fespaces, problem->gridfunctions,
+          problem->bc_map, problem->coefficients, problem->sources,
+          problem->solver_options);
+  problem->td_operator->SetEquationSystem(problem->td_equation_system.get());
+  problem->td_operator->SetGridFunctions();
 }
 
 void TimeDomainProblemBuilder::ConstructState() {
-  this->problem->F = new mfem::BlockVector(
-      this->problem->td_operator->true_offsets); // Vector of dofs
-  *(problem->F) = 0.0;                           // give initial value
-  this->problem->td_operator->Init(
-      *(this->problem->F)); // Set up initial conditions
-  this->problem->td_operator->SetTime(0.0);
+  problem->F = new mfem::BlockVector(
+      problem->td_operator->true_offsets);   // Vector of dofs
+  *(problem->F) = 0.0;                       // give initial value
+  problem->td_operator->Init(*(problem->F)); // Set up initial conditions
+  problem->td_operator->SetTime(0.0);
 }
 
 void TimeDomainProblemBuilder::ConstructSolver() {
-  this->problem->ode_solver = new mfem::BackwardEulerSolver;
-  this->problem->ode_solver->Init(*(this->problem->td_operator));
+  problem->ode_solver = new mfem::BackwardEulerSolver;
+  problem->ode_solver->Init(*(problem->td_operator));
 }
 
 } // namespace hephaestus

--- a/src/problem_builders/time_domain_problem_builder.hpp
+++ b/src/problem_builders/time_domain_problem_builder.hpp
@@ -27,7 +27,7 @@ protected:
   mfem::ConstantCoefficient oneCoef{1.0};
 
   virtual hephaestus::TimeDomainProblem *GetProblem() override {
-    return this->problem.get();
+    return problem.get();
   };
 
 public:
@@ -35,7 +35,7 @@ public:
       : problem(std::make_unique<hephaestus::TimeDomainProblem>()){};
 
   virtual std::unique_ptr<hephaestus::TimeDomainProblem> ReturnProblem() {
-    return std::move(this->problem);
+    return std::move(problem);
   };
 
   static std::vector<mfem::ParGridFunction *>

--- a/src/sources/div_free_source.cpp
+++ b/src/sources/div_free_source.cpp
@@ -62,7 +62,7 @@ void DivFreeSource::Init(hephaestus::GridFunctions &gridfunctions,
   gridfunctions_ = &gridfunctions;
   fespaces_ = &fespaces;
 
-  this->buildHCurlMass();
+  buildHCurlMass();
 }
 
 void DivFreeSource::buildHCurlMass() {

--- a/src/sources/scalar_potential_source.cpp
+++ b/src/sources/scalar_potential_source.cpp
@@ -59,8 +59,8 @@ void ScalarPotentialSource::Init(hephaestus::GridFunctions &gridfunctions,
   a0->AddDomainIntegrator(new mfem::DiffusionIntegrator(*betaCoef));
   a0->Assemble();
 
-  this->buildGrad();
-  this->buildM1(betaCoef);
+  buildGrad();
+  buildM1(betaCoef);
   // a0(p, p') = (β ∇ p, ∇ p')
   b0 = new mfem::ParLinearForm(H1FESpace_);
   A0 = new mfem::HypreParMatrix;

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -161,7 +161,6 @@ TEST_F(TestComplexAFormRod, CheckRun) {
   problem_builder->AddFESpace(std::string("H1"), std::string("H1_3D_P1"));
   problem_builder->AddGridFunction("magnetic_vector_potential_real", "HCurl");
   problem_builder->AddGridFunction("magnetic_vector_potential_imag", "HCurl");
-  problem_builder->AddFESpace(std::string("H1"), std::string("H1_3D_P1"));
   problem_builder->SetBoundaryConditions(bc_map);
   problem_builder->SetAuxSolvers(preprocessors);
   problem_builder->SetCoefficients(coefficients);


### PR DESCRIPTION
`hephaestus::ProblemBuilder` now checks whether objects of the same name are already stored in `NamedFieldsMaps` prior to addition, reducing chance of user error.

Also removes superfluous usage of 'this'