### PR TITLE
Add pre-commit dependency and clang-format hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v14.0.6
+  hooks:
+  - id: clang-format

--- a/docker/hephaestus-deps/Dockerfile
+++ b/docker/hephaestus-deps/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
     doxygen \
     git \
     ninja-build \
+    pre-commit \
     python3 \
     python3-dev \
     python3-distutils \

--- a/docker/hephaestus/Dockerfile
+++ b/docker/hephaestus/Dockerfile
@@ -20,6 +20,11 @@ RUN cd /$WORKDIR/hephaestus/ && \
     cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/$WORKDIR/mfem/build -DMFEM_COMMON_INCLUDES=/$WORKDIR/mfem/miniapps/common  .. && \
     make -j1
 
+# Install and run pre-commit hooks
+RUN cd /$WORKDIR/hephaestus/ && \
+    pre-commit install && \
+    pre-commit run --all-files
+
 # Test Hephaestus
 RUN cd /$WORKDIR/hephaestus/build && \
     make test


### PR DESCRIPTION
Adds pre-commit hook to run clang-format on commits, to enforce consistent formatting on new code, in support of #53 