### PR TITLE
Clang-tidy style enforcement

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,14 +1,15 @@
+HeaderFilterRegex: 'hephaestus/[ste]'
 Checks:              '-*,readability-identifier-naming'
 CheckOptions:
   - key:             readability-identifier-naming.AggressiveDependentMemberLookup
     value:           true
   - key:             readability-identifier-naming.ClassCase
     value:           'CamelCase'
-  - key:             readability-identifier-naming.MethodCase
-    value:           'camelBack'    
-  - key:             readability-identifier-naming.MemberCase
-    value:           'lower_case'
-  - key:             readability-identifier-naming.MemberPrefix
-    value:           '_'
-  - key:             readability-identifier-naming.LocalVariableCase
-    value:           'lower_case'
+  # - key:             readability-identifier-naming.MethodCase
+  #   value:           'camelBack'    
+  # - key:             readability-identifier-naming.MemberCase
+  #   value:           'lower_case'
+  # - key:             readability-identifier-naming.MemberPrefix
+  #   value:           '_'
+  # - key:             readability-identifier-naming.LocalVariableCase
+  #   value:           'lower_case'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,14 @@
+Checks:              '-*,readability-identifier-naming'
+CheckOptions:
+  - key:             readability-identifier-naming.AggressiveDependentMemberLookup
+    value:           true
+  - key:             readability-identifier-naming.ClassCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.MethodCase
+    value:           'camelBack'    
+  - key:             readability-identifier-naming.MemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.MemberPrefix
+    value:           '_'
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           'lower_case'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 HeaderFilterRegex: 'hephaestus/[ste]'
-Checks:              '-*,readability-identifier-naming,modernize-*,-modernize-use-trailing-return-type'
+Checks:              '-*,readability-identifier-naming,readability-redundant-member-init,modernize-*,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays'
 CheckOptions:
   - key:             readability-identifier-naming.AggressiveDependentMemberLookup
     value:           true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,12 +1,12 @@
 HeaderFilterRegex: 'hephaestus/[ste]'
-Checks:              '-*,readability-identifier-naming'
+Checks:              '-*,readability-identifier-naming,modernize-*,-modernize-use-trailing-return-type'
 CheckOptions:
   - key:             readability-identifier-naming.AggressiveDependentMemberLookup
     value:           true
   - key:             readability-identifier-naming.ClassCase
     value:           'CamelCase'
   # - key:             readability-identifier-naming.MethodCase
-  #   value:           'camelBack'    
+  #   value:           'CamelCase'    
   # - key:             readability-identifier-naming.MemberCase
   #   value:           'lower_case'
   # - key:             readability-identifier-naming.MemberPrefix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,9 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v17.0.6
+  rev: v14.0.6
   hooks:
   - id: clang-format
 
-repos:
 - repo: https://github.com/pocc/pre-commit-hooks
   rev: v1.3.5
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,4 @@ repos:
   rev: v1.3.5
   hooks:
   - id: clang-tidy
-    args: [-p=./build, -config-file=./.clang-tidy, --export-fixes=clang-tidy-suggested-fixes.yml, -header-filter=src/*, -extra-arg=-std=c++17, -extra-arg=-stdlib=libstdc++]
+    args: [-p=./build, -config-file=./.clang-tidy, --warnings-as-errors=*, -extra-arg=-std=c++17, -extra-arg=-stdlib=libstdc++]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,12 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v14.0.6
+  rev: v17.0.6
   hooks:
   - id: clang-format
+
+repos:
+- repo: https://github.com/pocc/pre-commit-hooks
+  rev: v1.3.5
+  hooks:
+  - id: clang-tidy
+    args: [-p=./build, -extra-arg=-std=c++17, -extra-arg=-stdlib=libstdc++]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,4 @@ repos:
   rev: v1.3.5
   hooks:
   - id: clang-tidy
-    args: [-p=./build, -extra-arg=-std=c++17, -extra-arg=-stdlib=libstdc++]
+    args: [-p=./build, -config-file=./.clang-tidy, --export-fixes=clang-tidy-suggested-fixes.yml, -header-filter=src/*, -extra-arg=-std=c++17, -extra-arg=-stdlib=libstdc++]

--- a/docker/hephaestus-deps/Dockerfile
+++ b/docker/hephaestus-deps/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
     bison \
     flex \
     clang-format \
+    clang-tidy \
     curl \
     doxygen \
     git \

--- a/docker/hephaestus-deps/Dockerfile
+++ b/docker/hephaestus-deps/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
     libglm-dev \
     libhdf5-mpich-dev \
     libnetcdf-dev \
+    libomp-14-dev \
     libpng-dev \
     libsdl2-dev \
     libssl-dev \

--- a/docker/hephaestus/Dockerfile
+++ b/docker/hephaestus/Dockerfile
@@ -13,17 +13,17 @@ RUN cd /$WORKDIR && \
     git checkout "$build_git_sha" && \
     git submodule update --init --recursive
 
-# Install and run pre-commit hooks
-RUN cd /$WORKDIR/hephaestus/ && \
-    pre-commit install && \
-    pre-commit run --all-files
-
 # Build Hephaestus
 RUN cd /$WORKDIR/hephaestus/ && \
     mkdir build && \
     cd build && \
-    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/$WORKDIR/mfem/build -DMFEM_COMMON_INCLUDES=/$WORKDIR/mfem/miniapps/common  .. && \
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/$WORKDIR/mfem/build -DMFEM_COMMON_INCLUDES=/$WORKDIR/mfem/miniapps/common -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. && \
     make -j1
+
+# Install and run pre-commit hooks
+RUN cd /$WORKDIR/hephaestus/ && \
+    pre-commit install && \
+    pre-commit run --all-files
 
 # Test Hephaestus
 RUN cd /$WORKDIR/hephaestus/build && \

--- a/docker/hephaestus/Dockerfile
+++ b/docker/hephaestus/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /$WORKDIR && \
 RUN cd /$WORKDIR/hephaestus/ && \
     mkdir build && \
     cd build && \
-    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/$WORKDIR/mfem/build -DMFEM_COMMON_INCLUDES=/$WORKDIR/mfem/miniapps/common .. && \
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/$WORKDIR/mfem/build -DMFEM_COMMON_INCLUDES=/$WORKDIR/mfem/miniapps/common -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. && \
     make -j1
 
 # Install and run pre-commit hooks

--- a/docker/hephaestus/Dockerfile
+++ b/docker/hephaestus/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /$WORKDIR && \
 RUN cd /$WORKDIR/hephaestus/ && \
     mkdir build && \
     cd build && \
-    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/$WORKDIR/mfem/build -DMFEM_COMMON_INCLUDES=/$WORKDIR/mfem/miniapps/common -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. && \
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/$WORKDIR/mfem/build -DMFEM_COMMON_INCLUDES=/$WORKDIR/mfem/miniapps/common .. && \
     make -j1
 
 # Install and run pre-commit hooks

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ foreach (_srcFile ${src_files})
 endforeach()
 list (REMOVE_DUPLICATES ${PROJECT_NAME}_INCLUDE_DIRS)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # make a shared object library to link against for testing
 add_library(${PROJECT_LIB_NAME} SHARED ${src_files})
 target_compile_options(${PROJECT_LIB_NAME} PRIVATE ${BUILD_TYPE_COMPILE_FLAGS})

--- a/src/auxsolvers/auxsolver_base.hpp
+++ b/src/auxsolvers/auxsolver_base.hpp
@@ -18,7 +18,7 @@ public:
   AuxSolver() = default;
 
   // NB: require virtual destructor to avoid leaks.
-  virtual ~AuxSolver() {}
+  virtual ~AuxSolver() = default;
 
   virtual void Init(const hephaestus::GridFunctions & gridfunctions,
                     hephaestus::Coefficients & coefficients) = 0;
@@ -28,7 +28,7 @@ public:
   // Set priority. Lower values are evaluated first.
   void SetPriority(const int priority) { _priority = priority; };
 
-  inline int Priority() const { return _priority; }
+  [[nodiscard]] inline int Priority() const { return _priority; }
 
   static bool PriorityComparator(const AuxSolver * first, const AuxSolver * second)
   {

--- a/src/auxsolvers/coefficient_aux.cpp
+++ b/src/auxsolvers/coefficient_aux.cpp
@@ -5,8 +5,8 @@
 namespace hephaestus
 {
 
-CoefficientAux::CoefficientAux(std::string  gf_name, std::string  coef_name)
-  :  _gf_name(std::move(gf_name)), _coef_name(std::move(coef_name))
+CoefficientAux::CoefficientAux(std::string gf_name, std::string coef_name)
+  : _gf_name(std::move(gf_name)), _coef_name(std::move(coef_name))
 {
 }
 

--- a/src/auxsolvers/coefficient_aux.cpp
+++ b/src/auxsolvers/coefficient_aux.cpp
@@ -1,10 +1,12 @@
 #include "coefficient_aux.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
-CoefficientAux::CoefficientAux(const std::string & gf_name, const std::string & coef_name)
-  : AuxSolver(), _gf_name(gf_name), _coef_name(coef_name)
+CoefficientAux::CoefficientAux(std::string  gf_name, std::string  coef_name)
+  :  _gf_name(std::move(gf_name)), _coef_name(std::move(coef_name))
 {
 }
 

--- a/src/auxsolvers/coefficient_aux.hpp
+++ b/src/auxsolvers/coefficient_aux.hpp
@@ -8,9 +8,9 @@ namespace hephaestus
 class CoefficientAux : public AuxSolver
 {
 public:
-  CoefficientAux(const std::string & gf_name, const std::string & coef_name);
+  CoefficientAux(std::string  gf_name, std::string  coef_name);
 
-  ~CoefficientAux() override {}
+  ~CoefficientAux() override = default;
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;

--- a/src/auxsolvers/coefficient_aux.hpp
+++ b/src/auxsolvers/coefficient_aux.hpp
@@ -8,7 +8,7 @@ namespace hephaestus
 class CoefficientAux : public AuxSolver
 {
 public:
-  CoefficientAux(std::string  gf_name, std::string  coef_name);
+  CoefficientAux(std::string gf_name, std::string coef_name);
 
   ~CoefficientAux() override = default;
 

--- a/src/auxsolvers/coupled_coefficient_aux.cpp
+++ b/src/auxsolvers/coupled_coefficient_aux.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 CoupledCoefficient::CoupledCoefficient(const hephaestus::InputParameters & params)
-  :  coupled_var_name(params.GetParam<std::string>("CoupledVariableName"))
+  : coupled_var_name(params.GetParam<std::string>("CoupledVariableName"))
 {
 }
 

--- a/src/auxsolvers/coupled_coefficient_aux.cpp
+++ b/src/auxsolvers/coupled_coefficient_aux.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 CoupledCoefficient::CoupledCoefficient(const hephaestus::InputParameters & params)
-  : AuxSolver(), coupled_var_name(params.GetParam<std::string>("CoupledVariableName"))
+  :  coupled_var_name(params.GetParam<std::string>("CoupledVariableName"))
 {
 }
 

--- a/src/auxsolvers/coupled_coefficient_aux.hpp
+++ b/src/auxsolvers/coupled_coefficient_aux.hpp
@@ -19,12 +19,12 @@ protected:
 public:
   CoupledCoefficient(const hephaestus::InputParameters & params);
 
-  ~CoupledCoefficient() override {}
+  ~CoupledCoefficient() override = default;
 
-  virtual void Init(const hephaestus::GridFunctions & gridfunctions,
+  void Init(const hephaestus::GridFunctions & gridfunctions,
                     hephaestus::Coefficients & coefficients) override;
 
-  virtual double Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip) override;
+  double Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip) override;
 
   void Solve(double t = 0.0) override{};
 

--- a/src/auxsolvers/coupled_coefficient_aux.hpp
+++ b/src/auxsolvers/coupled_coefficient_aux.hpp
@@ -22,7 +22,7 @@ public:
   ~CoupledCoefficient() override = default;
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
-                    hephaestus::Coefficients & coefficients) override;
+            hephaestus::Coefficients & coefficients) override;
 
   double Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip) override;
 

--- a/src/auxsolvers/curl_aux.cpp
+++ b/src/auxsolvers/curl_aux.cpp
@@ -5,8 +5,8 @@
 namespace hephaestus
 {
 
-CurlAuxSolver::CurlAuxSolver(std::string  input_gf_name, std::string  curl_gf_name)
-  :  _input_gf_name(std::move(input_gf_name)), _curl_gf_name(std::move(curl_gf_name))
+CurlAuxSolver::CurlAuxSolver(std::string input_gf_name, std::string curl_gf_name)
+  : _input_gf_name(std::move(input_gf_name)), _curl_gf_name(std::move(curl_gf_name))
 {
 }
 

--- a/src/auxsolvers/curl_aux.cpp
+++ b/src/auxsolvers/curl_aux.cpp
@@ -1,10 +1,12 @@
 #include "curl_aux.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
-CurlAuxSolver::CurlAuxSolver(const std::string & input_gf_name, const std::string & curl_gf_name)
-  : AuxSolver(), _input_gf_name(input_gf_name), _curl_gf_name(curl_gf_name)
+CurlAuxSolver::CurlAuxSolver(std::string  input_gf_name, std::string  curl_gf_name)
+  :  _input_gf_name(std::move(input_gf_name)), _curl_gf_name(std::move(curl_gf_name))
 {
 }
 

--- a/src/auxsolvers/curl_aux.hpp
+++ b/src/auxsolvers/curl_aux.hpp
@@ -8,7 +8,7 @@ namespace hephaestus
 class CurlAuxSolver : public AuxSolver
 {
 public:
-  CurlAuxSolver(std::string  input_gf_name, std::string  curl_gf_name);
+  CurlAuxSolver(std::string input_gf_name, std::string curl_gf_name);
 
   ~CurlAuxSolver() override = default;
 

--- a/src/auxsolvers/curl_aux.hpp
+++ b/src/auxsolvers/curl_aux.hpp
@@ -8,9 +8,9 @@ namespace hephaestus
 class CurlAuxSolver : public AuxSolver
 {
 public:
-  CurlAuxSolver(const std::string & input_gf_name, const std::string & curl_gf_name);
+  CurlAuxSolver(std::string  input_gf_name, std::string  curl_gf_name);
 
-  ~CurlAuxSolver() override {}
+  ~CurlAuxSolver() override = default;
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;

--- a/src/auxsolvers/helmholtz_projector.cpp
+++ b/src/auxsolvers/helmholtz_projector.cpp
@@ -8,11 +8,9 @@ HelmholtzProjector::HelmholtzProjector(const hephaestus::InputParameters & param
     hcurl_fespace_name_(params.GetOptionalParam<std::string>("HCurlFESpaceName", "HCurlFES_Name")),
     gf_grad_name_(params.GetParam<std::string>("VectorGridFunctionName")),
     gf_name_(params.GetOptionalParam<std::string>("ScalarGridFunctionName", "ScalarGF_Name")),
-    H1FESpace_(nullptr),
-    HCurlFESpace_(nullptr),
-    q_(nullptr),
+    
     g(nullptr),
-    div_free_src_gf_(nullptr),
+    
     gDiv_(nullptr),
     weakDiv_(nullptr),
     grad_(nullptr),

--- a/src/auxsolvers/helmholtz_projector.cpp
+++ b/src/auxsolvers/helmholtz_projector.cpp
@@ -8,9 +8,9 @@ HelmholtzProjector::HelmholtzProjector(const hephaestus::InputParameters & param
     hcurl_fespace_name_(params.GetOptionalParam<std::string>("HCurlFESpaceName", "HCurlFES_Name")),
     gf_grad_name_(params.GetParam<std::string>("VectorGridFunctionName")),
     gf_name_(params.GetOptionalParam<std::string>("ScalarGridFunctionName", "ScalarGF_Name")),
-    
+
     g(nullptr),
-    
+
     gDiv_(nullptr),
     weakDiv_(nullptr),
     grad_(nullptr),

--- a/src/auxsolvers/helmholtz_projector.hpp
+++ b/src/auxsolvers/helmholtz_projector.hpp
@@ -25,14 +25,14 @@ private:
   std::string gf_name_;
   hephaestus::InputParameters solver_options_;
 
-  mfem::ParFiniteElementSpace * H1FESpace_;
-  mfem::ParFiniteElementSpace * HCurlFESpace_;
-  mfem::ParGridFunction * q_;
+  mfem::ParFiniteElementSpace * H1FESpace_{nullptr};
+  mfem::ParFiniteElementSpace * HCurlFESpace_{nullptr};
+  mfem::ParGridFunction * q_{nullptr};
 
   // H(Curl) projection of user specified source
   std::unique_ptr<mfem::ParGridFunction> g;
 
-  mfem::ParGridFunction * div_free_src_gf_; // Divergence free projected source
+  mfem::ParGridFunction * div_free_src_gf_{nullptr}; // Divergence free projected source
 
   std::unique_ptr<mfem::ParLinearForm> gDiv_;
   std::unique_ptr<mfem::ParBilinearForm> a0_;

--- a/src/auxsolvers/l2_error_vector_aux.cpp
+++ b/src/auxsolvers/l2_error_vector_aux.cpp
@@ -4,8 +4,7 @@ namespace hephaestus
 {
 
 L2ErrorVectorPostprocessor::L2ErrorVectorPostprocessor(const hephaestus::InputParameters & params)
-  : 
-    var_name(params.GetParam<std::string>("VariableName")),
+  : var_name(params.GetParam<std::string>("VariableName")),
     vec_coef_name(params.GetParam<std::string>("VectorCoefficientName"))
 {
 }

--- a/src/auxsolvers/l2_error_vector_aux.cpp
+++ b/src/auxsolvers/l2_error_vector_aux.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 L2ErrorVectorPostprocessor::L2ErrorVectorPostprocessor(const hephaestus::InputParameters & params)
-  : AuxSolver(),
+  : 
     var_name(params.GetParam<std::string>("VariableName")),
     vec_coef_name(params.GetParam<std::string>("VectorCoefficientName"))
 {

--- a/src/auxsolvers/l2_error_vector_aux.hpp
+++ b/src/auxsolvers/l2_error_vector_aux.hpp
@@ -11,15 +11,15 @@ class L2ErrorVectorPostprocessor : public AuxSolver
 {
 
 public:
-  L2ErrorVectorPostprocessor(){};
+  L2ErrorVectorPostprocessor() = default;
   L2ErrorVectorPostprocessor(const hephaestus::InputParameters & params);
 
-  ~L2ErrorVectorPostprocessor() override {}
+  ~L2ErrorVectorPostprocessor() override = default;
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;
 
-  virtual void Solve(double t = 0.0) override;
+  void Solve(double t = 0.0) override;
 
   std::string var_name;      // name of the variable
   std::string vec_coef_name; // name of the vector coefficient

--- a/src/auxsolvers/scaled_curl_vector_gridfunction_aux.hpp
+++ b/src/auxsolvers/scaled_curl_vector_gridfunction_aux.hpp
@@ -17,8 +17,8 @@ public:
       const double & aConst = 1.0,
       const hephaestus::InputParameters & solver_options = hephaestus::InputParameters());
 
-  ~ScaledCurlVectorGridFunctionAux() override {}
+  ~ScaledCurlVectorGridFunctionAux() override = default;
 
-  virtual void buildMixedBilinearForm() override;
+  void buildMixedBilinearForm() override;
 };
 } // namespace hephaestus

--- a/src/auxsolvers/scaled_vector_gridfunction_aux.cpp
+++ b/src/auxsolvers/scaled_vector_gridfunction_aux.cpp
@@ -5,19 +5,17 @@
 namespace hephaestus
 {
 
-ScaledVectorGridFunctionAux::ScaledVectorGridFunctionAux(
-    std::string  input_gf_name,
-    std::string  scaled_gf_name,
-    std::string  coef_name,
-    const double & aConst,
-    hephaestus::InputParameters  solver_options)
-  : 
-    _input_gf_name(std::move(input_gf_name)),
+ScaledVectorGridFunctionAux::ScaledVectorGridFunctionAux(std::string input_gf_name,
+                                                         std::string scaled_gf_name,
+                                                         std::string coef_name,
+                                                         const double & aConst,
+                                                         hephaestus::InputParameters solver_options)
+  : _input_gf_name(std::move(input_gf_name)),
     _scaled_gf_name(std::move(scaled_gf_name)),
     _coef_name(std::move(coef_name)),
     _aConst(aConst),
     _solver_options(std::move(solver_options)),
-    
+
     a(nullptr),
     a_mixed(nullptr),
     a_mat(nullptr),

--- a/src/auxsolvers/scaled_vector_gridfunction_aux.cpp
+++ b/src/auxsolvers/scaled_vector_gridfunction_aux.cpp
@@ -1,25 +1,23 @@
 #include "scaled_vector_gridfunction_aux.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
 ScaledVectorGridFunctionAux::ScaledVectorGridFunctionAux(
-    const std::string & input_gf_name,
-    const std::string & scaled_gf_name,
-    const std::string & coef_name,
+    std::string  input_gf_name,
+    std::string  scaled_gf_name,
+    std::string  coef_name,
     const double & aConst,
-    const hephaestus::InputParameters & solver_options)
-  : AuxSolver(),
-    _input_gf_name(input_gf_name),
-    _scaled_gf_name(scaled_gf_name),
-    _coef_name(coef_name),
+    hephaestus::InputParameters  solver_options)
+  : 
+    _input_gf_name(std::move(input_gf_name)),
+    _scaled_gf_name(std::move(scaled_gf_name)),
+    _coef_name(std::move(coef_name)),
     _aConst(aConst),
-    _solver_options(solver_options),
-    coef(nullptr),
-    input_gf(nullptr),
-    scaled_gf(nullptr),
-    test_fes(nullptr),
-    trial_fes(nullptr),
+    _solver_options(std::move(solver_options)),
+    
     a(nullptr),
     a_mixed(nullptr),
     a_mat(nullptr),

--- a/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
+++ b/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
@@ -11,16 +11,16 @@ class ScaledVectorGridFunctionAux : public AuxSolver
 {
 public:
   ScaledVectorGridFunctionAux(
-      std::string  input_gf_name,
-      std::string  scaled_gf_name,
-      std::string  coef_name,
+      std::string input_gf_name,
+      std::string scaled_gf_name,
+      std::string coef_name,
       const double & aConst = 1.0,
-      hephaestus::InputParameters  solver_options = hephaestus::InputParameters());
+      hephaestus::InputParameters solver_options = hephaestus::InputParameters());
 
   ~ScaledVectorGridFunctionAux() override = default;
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
-                    hephaestus::Coefficients & coefficients) override;
+            hephaestus::Coefficients & coefficients) override;
   virtual void buildBilinearForm();
   virtual void buildMixedBilinearForm();
   void Solve(double t = 0.0) override;

--- a/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
+++ b/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
@@ -11,31 +11,31 @@ class ScaledVectorGridFunctionAux : public AuxSolver
 {
 public:
   ScaledVectorGridFunctionAux(
-      const std::string & input_gf_name,
-      const std::string & scaled_gf_name,
-      const std::string & coef_name,
+      std::string  input_gf_name,
+      std::string  scaled_gf_name,
+      std::string  coef_name,
       const double & aConst = 1.0,
-      const hephaestus::InputParameters & solver_options = hephaestus::InputParameters());
+      hephaestus::InputParameters  solver_options = hephaestus::InputParameters());
 
-  ~ScaledVectorGridFunctionAux() override {}
+  ~ScaledVectorGridFunctionAux() override = default;
 
-  virtual void Init(const hephaestus::GridFunctions & gridfunctions,
+  void Init(const hephaestus::GridFunctions & gridfunctions,
                     hephaestus::Coefficients & coefficients) override;
   virtual void buildBilinearForm();
   virtual void buildMixedBilinearForm();
-  virtual void Solve(double t = 0.0) override;
+  void Solve(double t = 0.0) override;
 
 protected:
   // Pointers to store trial and test FE spaces
-  mfem::ParFiniteElementSpace * trial_fes;
-  mfem::ParFiniteElementSpace * test_fes;
+  mfem::ParFiniteElementSpace * trial_fes{nullptr};
+  mfem::ParFiniteElementSpace * test_fes{nullptr};
 
   // Bilinear forms
   std::unique_ptr<mfem::ParBilinearForm> a{nullptr};
   std::unique_ptr<mfem::ParMixedBilinearForm> a_mixed{nullptr};
 
   // Coefficient to scale input gridfunction by
-  mfem::Coefficient * coef;
+  mfem::Coefficient * coef{nullptr};
   // Optional constant to scale input gridfunction by
 
 private:
@@ -46,10 +46,10 @@ private:
   const hephaestus::InputParameters _solver_options;
 
   // Input gridfunction to be scaled by a scalar coefficient
-  mfem::ParGridFunction * input_gf;
+  mfem::ParGridFunction * input_gf{nullptr};
 
   // Gridfunction in which to store result
-  mfem::ParGridFunction * scaled_gf;
+  mfem::ParGridFunction * scaled_gf{nullptr};
 
   // Operator matrices
   std::unique_ptr<mfem::HypreParMatrix> a_mat{nullptr};

--- a/src/auxsolvers/vector_coefficient_aux.cpp
+++ b/src/auxsolvers/vector_coefficient_aux.cpp
@@ -5,9 +5,8 @@
 namespace hephaestus
 {
 
-VectorCoefficientAux::VectorCoefficientAux(std::string  gf_name,
-                                           std::string  vec_coef_name)
-  :  _gf_name(std::move(gf_name)), _vec_coef_name(std::move(vec_coef_name))
+VectorCoefficientAux::VectorCoefficientAux(std::string gf_name, std::string vec_coef_name)
+  : _gf_name(std::move(gf_name)), _vec_coef_name(std::move(vec_coef_name))
 {
 }
 

--- a/src/auxsolvers/vector_coefficient_aux.cpp
+++ b/src/auxsolvers/vector_coefficient_aux.cpp
@@ -1,11 +1,13 @@
 #include "vector_coefficient_aux.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
-VectorCoefficientAux::VectorCoefficientAux(const std::string & gf_name,
-                                           const std::string & vec_coef_name)
-  : AuxSolver(), _gf_name(gf_name), _vec_coef_name(vec_coef_name)
+VectorCoefficientAux::VectorCoefficientAux(std::string  gf_name,
+                                           std::string  vec_coef_name)
+  :  _gf_name(std::move(gf_name)), _vec_coef_name(std::move(vec_coef_name))
 {
 }
 

--- a/src/auxsolvers/vector_coefficient_aux.hpp
+++ b/src/auxsolvers/vector_coefficient_aux.hpp
@@ -8,9 +8,9 @@ namespace hephaestus
 class VectorCoefficientAux : public AuxSolver
 {
 public:
-  VectorCoefficientAux(const std::string & gf_name, const std::string & vec_coef_name);
+  VectorCoefficientAux(std::string  gf_name, std::string  vec_coef_name);
 
-  ~VectorCoefficientAux() override {}
+  ~VectorCoefficientAux() override = default;
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;

--- a/src/auxsolvers/vector_coefficient_aux.hpp
+++ b/src/auxsolvers/vector_coefficient_aux.hpp
@@ -8,7 +8,7 @@ namespace hephaestus
 class VectorCoefficientAux : public AuxSolver
 {
 public:
-  VectorCoefficientAux(std::string  gf_name, std::string  vec_coef_name);
+  VectorCoefficientAux(std::string gf_name, std::string vec_coef_name);
 
   ~VectorCoefficientAux() override = default;
 

--- a/src/auxsolvers/vector_gridfunction_cross_product_aux.cpp
+++ b/src/auxsolvers/vector_gridfunction_cross_product_aux.cpp
@@ -28,12 +28,12 @@ VectorGridFunctionCrossProductCoefficient::Eval(mfem::Vector & uxv,
 VectorGridFunctionCrossProductAux::VectorGridFunctionCrossProductAux(
     const std::string & cross_product_gf_name,
     const std::string & cross_product_coef_name,
-    std::string  u_gf_name,
-    std::string  v_gf_name)
+    std::string u_gf_name,
+    std::string v_gf_name)
   : VectorCoefficientAux(cross_product_gf_name, cross_product_coef_name),
     _u_gf_name(std::move(u_gf_name)),
     _v_gf_name(std::move(v_gf_name))
-    
+
 {
 }
 

--- a/src/auxsolvers/vector_gridfunction_cross_product_aux.cpp
+++ b/src/auxsolvers/vector_gridfunction_cross_product_aux.cpp
@@ -1,5 +1,7 @@
 #include "vector_gridfunction_cross_product_aux.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
@@ -26,13 +28,12 @@ VectorGridFunctionCrossProductCoefficient::Eval(mfem::Vector & uxv,
 VectorGridFunctionCrossProductAux::VectorGridFunctionCrossProductAux(
     const std::string & cross_product_gf_name,
     const std::string & cross_product_coef_name,
-    const std::string & u_gf_name,
-    const std::string & v_gf_name)
+    std::string  u_gf_name,
+    std::string  v_gf_name)
   : VectorCoefficientAux(cross_product_gf_name, cross_product_coef_name),
-    _u_gf_name(u_gf_name),
-    _v_gf_name(v_gf_name),
-    _u_gf(nullptr),
-    _v_gf(nullptr)
+    _u_gf_name(std::move(u_gf_name)),
+    _v_gf_name(std::move(v_gf_name))
+    
 {
 }
 

--- a/src/auxsolvers/vector_gridfunction_cross_product_aux.hpp
+++ b/src/auxsolvers/vector_gridfunction_cross_product_aux.hpp
@@ -22,10 +22,10 @@ public:
   {
   }
 
-  virtual ~VectorGridFunctionCrossProductCoefficient() {}
+  ~VectorGridFunctionCrossProductCoefficient() override = default;
 
-  virtual void
-  Eval(mfem::Vector & uxv, mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip);
+  void
+  Eval(mfem::Vector & uxv, mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip) override;
 };
 
 // Auxsolver to project the cross product of two vector gridfunctions onto a
@@ -33,8 +33,8 @@ public:
 class VectorGridFunctionCrossProductAux : public VectorCoefficientAux
 {
 private:
-  mfem::ParGridFunction * _u_gf;
-  mfem::ParGridFunction * _v_gf;
+  mfem::ParGridFunction * _u_gf{nullptr};
+  mfem::ParGridFunction * _v_gf{nullptr};
 
   const std::string _u_gf_name;
   const std::string _v_gf_name;
@@ -42,8 +42,8 @@ private:
 public:
   VectorGridFunctionCrossProductAux(const std::string & cross_product_gf_name,
                                     const std::string & cross_product_coef_name,
-                                    const std::string & u_gf_name,
-                                    const std::string & v_gf_name);
+                                    std::string  u_gf_name,
+                                    std::string  v_gf_name);
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;

--- a/src/auxsolvers/vector_gridfunction_cross_product_aux.hpp
+++ b/src/auxsolvers/vector_gridfunction_cross_product_aux.hpp
@@ -24,8 +24,9 @@ public:
 
   ~VectorGridFunctionCrossProductCoefficient() override = default;
 
-  void
-  Eval(mfem::Vector & uxv, mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip) override;
+  void Eval(mfem::Vector & uxv,
+            mfem::ElementTransformation & T,
+            const mfem::IntegrationPoint & ip) override;
 };
 
 // Auxsolver to project the cross product of two vector gridfunctions onto a
@@ -42,8 +43,8 @@ private:
 public:
   VectorGridFunctionCrossProductAux(const std::string & cross_product_gf_name,
                                     const std::string & cross_product_coef_name,
-                                    std::string  u_gf_name,
-                                    std::string  v_gf_name);
+                                    std::string u_gf_name,
+                                    std::string v_gf_name);
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;

--- a/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
+++ b/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
@@ -1,5 +1,7 @@
 #include "vector_gridfunction_dot_product_aux.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
@@ -32,24 +34,20 @@ VectorGridFunctionDotProductCoefficient::Eval(mfem::ElementTransformation & T,
 VectorGridFunctionDotProductAux::VectorGridFunctionDotProductAux(
     const std::string & dot_product_gf_name,
     const std::string & dot_product_coef_name,
-    const std::string & scaling_coef_name,
-    const std::string & u_gf_real_name,
-    const std::string & v_gf_real_name,
-    const std::string & u_gf_imag_name,
-    const std::string & v_gf_imag_name,
+    std::string  scaling_coef_name,
+    std::string  u_gf_real_name,
+    std::string  v_gf_real_name,
+    std::string  u_gf_imag_name,
+    std::string  v_gf_imag_name,
     const bool complex_average)
   : CoefficientAux(dot_product_gf_name, dot_product_coef_name),
-    _u_gf_real_name(u_gf_real_name),
-    _v_gf_real_name(v_gf_real_name),
-    _u_gf_imag_name(u_gf_imag_name),
-    _v_gf_imag_name(v_gf_imag_name),
-    _scaling_coef_name(scaling_coef_name),
-    _complex_average(complex_average),
-    _scaling_coef(nullptr),
-    _u_gf_re(nullptr),
-    _u_gf_im(nullptr),
-    _v_gf_re(nullptr),
-    _v_gf_im(nullptr)
+    _u_gf_real_name(std::move(u_gf_real_name)),
+    _v_gf_real_name(std::move(v_gf_real_name)),
+    _u_gf_imag_name(std::move(u_gf_imag_name)),
+    _v_gf_imag_name(std::move(v_gf_imag_name)),
+    _scaling_coef_name(std::move(scaling_coef_name)),
+    _complex_average(complex_average)
+    
 {
 }
 

--- a/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
+++ b/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
@@ -34,11 +34,11 @@ VectorGridFunctionDotProductCoefficient::Eval(mfem::ElementTransformation & T,
 VectorGridFunctionDotProductAux::VectorGridFunctionDotProductAux(
     const std::string & dot_product_gf_name,
     const std::string & dot_product_coef_name,
-    std::string  scaling_coef_name,
-    std::string  u_gf_real_name,
-    std::string  v_gf_real_name,
-    std::string  u_gf_imag_name,
-    std::string  v_gf_imag_name,
+    std::string scaling_coef_name,
+    std::string u_gf_real_name,
+    std::string v_gf_real_name,
+    std::string u_gf_imag_name,
+    std::string v_gf_imag_name,
     const bool complex_average)
   : CoefficientAux(dot_product_gf_name, dot_product_coef_name),
     _u_gf_real_name(std::move(u_gf_real_name)),
@@ -47,7 +47,7 @@ VectorGridFunctionDotProductAux::VectorGridFunctionDotProductAux(
     _v_gf_imag_name(std::move(v_gf_imag_name)),
     _scaling_coef_name(std::move(scaling_coef_name)),
     _complex_average(complex_average)
-    
+
 {
 }
 

--- a/src/auxsolvers/vector_gridfunction_dot_product_aux.hpp
+++ b/src/auxsolvers/vector_gridfunction_dot_product_aux.hpp
@@ -52,11 +52,11 @@ private:
 public:
   VectorGridFunctionDotProductAux(const std::string & dot_product_gf_name,
                                   const std::string & dot_product_coef_name,
-                                  std::string  scaling_coef_name,
-                                  std::string  u_gf_real_name,
-                                  std::string  v_gf_real_name,
-                                  std::string  u_gf_imag_name = "",
-                                  std::string  v_gf_imag_name = "",
+                                  std::string scaling_coef_name,
+                                  std::string u_gf_real_name,
+                                  std::string v_gf_real_name,
+                                  std::string u_gf_imag_name = "",
+                                  std::string v_gf_imag_name = "",
                                   const bool complex_average = false);
 
   ~VectorGridFunctionDotProductAux() override = default;

--- a/src/auxsolvers/vector_gridfunction_dot_product_aux.hpp
+++ b/src/auxsolvers/vector_gridfunction_dot_product_aux.hpp
@@ -26,9 +26,9 @@ public:
   {
   }
 
-  ~VectorGridFunctionDotProductCoefficient() override {}
+  ~VectorGridFunctionDotProductCoefficient() override = default;
 
-  virtual double Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip);
+  double Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip) override;
 };
 
 // Auxsolver to project the dot product of two vector gridfunctions onto a third
@@ -52,14 +52,14 @@ private:
 public:
   VectorGridFunctionDotProductAux(const std::string & dot_product_gf_name,
                                   const std::string & dot_product_coef_name,
-                                  const std::string & scaling_coef_name,
-                                  const std::string & u_gf_real_name,
-                                  const std::string & v_gf_real_name,
-                                  const std::string & u_gf_imag_name = "",
-                                  const std::string & v_gf_imag_name = "",
+                                  std::string  scaling_coef_name,
+                                  std::string  u_gf_real_name,
+                                  std::string  v_gf_real_name,
+                                  std::string  u_gf_imag_name = "",
+                                  std::string  v_gf_imag_name = "",
                                   const bool complex_average = false);
 
-  ~VectorGridFunctionDotProductAux() override {}
+  ~VectorGridFunctionDotProductAux() override = default;
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;

--- a/src/boundary_conditions/Essential/function_dirichlet_bc.hpp
+++ b/src/boundary_conditions/Essential/function_dirichlet_bc.hpp
@@ -13,7 +13,7 @@ public:
                     mfem::Coefficient * coeff_,
                     mfem::Coefficient * coeff_im_ = nullptr);
 
-  virtual void applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_) override;
+  void applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_) override;
 
   mfem::Coefficient * coeff;
   mfem::Coefficient * coeff_im;

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
@@ -23,9 +23,9 @@ public:
                     mfem::VectorCoefficient * vec_coeff_im_ = nullptr,
                     APPLY_TYPE boundary_apply_type = TANGENTIAL);
 
-  virtual void applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_) override;
+  void applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_) override;
 
-  virtual void applyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh * mesh_) override;
+  void applyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh * mesh_) override;
 
   mfem::VectorCoefficient * vec_coeff;
   mfem::VectorCoefficient * vec_coeff_im;

--- a/src/boundary_conditions/Integrated/integrated_bc_base.hpp
+++ b/src/boundary_conditions/Integrated/integrated_bc_base.hpp
@@ -17,9 +17,9 @@ public:
   std::unique_ptr<mfem::LinearFormIntegrator> lfi_re;
   std::unique_ptr<mfem::LinearFormIntegrator> lfi_im;
 
-  virtual void applyBC(mfem::LinearForm & b) override;
-  virtual void applyBC(mfem::ComplexLinearForm & b) override;
-  virtual void applyBC(mfem::ParComplexLinearForm & b) override;
+  void applyBC(mfem::LinearForm & b) override;
+  void applyBC(mfem::ComplexLinearForm & b) override;
+  void applyBC(mfem::ParComplexLinearForm & b) override;
 };
 
 } // namespace hephaestus

--- a/src/boundary_conditions/boundary_condition_base.cpp
+++ b/src/boundary_conditions/boundary_condition_base.cpp
@@ -1,10 +1,12 @@
 #include "boundary_condition_base.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
-BoundaryCondition::BoundaryCondition(const std::string & name_, mfem::Array<int> bdr_attributes_)
-  : name(name_), bdr_attributes(bdr_attributes_)
+BoundaryCondition::BoundaryCondition(std::string  name_, mfem::Array<int> bdr_attributes_)
+  : name(std::move(name_)), bdr_attributes(std::move(bdr_attributes_))
 {
 }
 

--- a/src/boundary_conditions/boundary_condition_base.cpp
+++ b/src/boundary_conditions/boundary_condition_base.cpp
@@ -5,7 +5,7 @@
 namespace hephaestus
 {
 
-BoundaryCondition::BoundaryCondition(std::string  name_, mfem::Array<int> bdr_attributes_)
+BoundaryCondition::BoundaryCondition(std::string name_, mfem::Array<int> bdr_attributes_)
   : name(std::move(name_)), bdr_attributes(std::move(bdr_attributes_))
 {
 }

--- a/src/boundary_conditions/boundary_condition_base.hpp
+++ b/src/boundary_conditions/boundary_condition_base.hpp
@@ -11,7 +11,7 @@ namespace hephaestus
 class BoundaryCondition
 {
 public:
-  BoundaryCondition(const std::string & name_, mfem::Array<int> bdr_attributes_);
+  BoundaryCondition(std::string  name_, mfem::Array<int> bdr_attributes_);
   mfem::Array<int> getMarkers(mfem::Mesh & mesh);
 
   std::string name;

--- a/src/boundary_conditions/boundary_condition_base.hpp
+++ b/src/boundary_conditions/boundary_condition_base.hpp
@@ -11,7 +11,7 @@ namespace hephaestus
 class BoundaryCondition
 {
 public:
-  BoundaryCondition(std::string  name_, mfem::Array<int> bdr_attributes_);
+  BoundaryCondition(std::string name_, mfem::Array<int> bdr_attributes_);
   mfem::Array<int> getMarkers(mfem::Mesh & mesh);
 
   std::string name;

--- a/src/boundary_conditions/boundary_conditions.cpp
+++ b/src/boundary_conditions/boundary_conditions.cpp
@@ -40,7 +40,7 @@ BCMap::applyEssentialBCs(const std::string & name_,
   {
     if (bc_->name == name_)
     {
-      hephaestus::EssentialBC * bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
+      auto * bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
       if (bc != nullptr)
       {
         bc->applyBC(gridfunc, mesh_);
@@ -62,7 +62,7 @@ BCMap::applyEssentialBCs(const std::string & name_,
   {
     if (bc_->name == name_)
     {
-      hephaestus::EssentialBC * bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
+      auto * bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
       if (bc != nullptr)
       {
         bc->applyBC(gridfunc, mesh_);
@@ -81,7 +81,7 @@ BCMap::applyIntegratedBCs(const std::string & name_, mfem::LinearForm & lf, mfem
   {
     if (bc_->name == name_)
     {
-      hephaestus::IntegratedBC * bc = dynamic_cast<hephaestus::IntegratedBC *>(bc_);
+      auto * bc = dynamic_cast<hephaestus::IntegratedBC *>(bc_);
       if (bc != nullptr)
       {
         bc->getMarkers(*mesh_);
@@ -101,7 +101,7 @@ BCMap::applyIntegratedBCs(const std::string & name_,
   {
     if (bc_->name == name_)
     {
-      hephaestus::IntegratedBC * bc = dynamic_cast<hephaestus::IntegratedBC *>(bc_);
+      auto * bc = dynamic_cast<hephaestus::IntegratedBC *>(bc_);
       if (bc != nullptr)
       {
         bc->getMarkers(*mesh_);
@@ -121,7 +121,7 @@ BCMap::applyIntegratedBCs(const std::string & name_,
   {
     if (bc_->name == name_)
     {
-      hephaestus::RobinBC * bc = dynamic_cast<hephaestus::RobinBC *>(bc_);
+      auto * bc = dynamic_cast<hephaestus::RobinBC *>(bc_);
       if (bc != nullptr)
       {
         bc->getMarkers(*mesh_);

--- a/src/coefficients/coefficients.cpp
+++ b/src/coefficients/coefficients.cpp
@@ -16,7 +16,7 @@ fracFunc(double a, double b)
   return a / b;
 }
 
-Subdomain::Subdomain(std::string  name_, int id_) : name(std::move(name_)), id(id_) {}
+Subdomain::Subdomain(std::string name_, int id_) : name(std::move(name_)), id(id_) {}
 
 Coefficients::Coefficients() { registerDefaultCoefficients(); }
 

--- a/src/coefficients/coefficients.cpp
+++ b/src/coefficients/coefficients.cpp
@@ -1,5 +1,7 @@
 #include "coefficients.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
@@ -14,11 +16,11 @@ fracFunc(double a, double b)
   return a / b;
 }
 
-Subdomain::Subdomain(const std::string & name_, int id_) : name(name_), id(id_) {}
+Subdomain::Subdomain(std::string  name_, int id_) : name(std::move(name_)), id(id_) {}
 
 Coefficients::Coefficients() { registerDefaultCoefficients(); }
 
-Coefficients::Coefficients(std::vector<Subdomain> subdomains_) : subdomains(subdomains_)
+Coefficients::Coefficients(std::vector<Subdomain> subdomains_) : subdomains(std::move(subdomains_))
 {
   AddGlobalCoefficientsFromSubdomains();
   registerDefaultCoefficients();
@@ -59,11 +61,11 @@ Coefficients::AddGlobalCoefficientsFromSubdomains()
   mfem::Array<int> subdomain_ids;
   std::unordered_set<std::string> scalar_property_names;
 
-  for (std::size_t i = 0; i < subdomains.size(); i++)
+  for (auto & subdomain : subdomains)
   {
-    subdomain_ids.Append(subdomains[i].id);
+    subdomain_ids.Append(subdomain.id);
     // accumulate property names on subdomains, ignoring duplicates
-    for (auto const & [name, coeff_] : subdomains[i].scalar_coefficients)
+    for (auto const & [name, coeff_] : subdomain.scalar_coefficients)
     {
       scalar_property_names.insert(name);
     }
@@ -74,9 +76,9 @@ Coefficients::AddGlobalCoefficientsFromSubdomains()
   for (auto & scalar_property_name : scalar_property_names)
   {
     mfem::Array<mfem::Coefficient *> subdomain_coefs;
-    for (std::size_t i = 0; i < subdomains.size(); i++)
+    for (auto & subdomain : subdomains)
     {
-      subdomain_coefs.Append(subdomains[i].scalar_coefficients.Get(scalar_property_name));
+      subdomain_coefs.Append(subdomain.scalar_coefficients.Get(scalar_property_name));
     }
     if (!scalars.Has(scalar_property_name))
     {

--- a/src/coefficients/coefficients.hpp
+++ b/src/coefficients/coefficients.hpp
@@ -15,7 +15,7 @@ double fracFunc(double a, double b);
 class Subdomain
 {
 public:
-  Subdomain(const std::string & name_, int id_);
+  Subdomain(std::string name_, int id_);
 
   std::string name;
   int id;
@@ -33,7 +33,7 @@ class Coefficients
   double t; // Time at which time-dependent coefficients are evaluated
 public:
   Coefficients();
-  ~Coefficients(){};
+  ~Coefficients() = default;
 
   Coefficients(std::vector<Subdomain> subdomains_);
   void SetTime(double t);

--- a/src/equation_systems/equation_system.cpp
+++ b/src/equation_systems/equation_system.cpp
@@ -3,11 +3,7 @@
 namespace hephaestus
 {
 
-EquationSystem::EquationSystem(const hephaestus::InputParameters & params)
-  
-    
-{
-}
+EquationSystem::EquationSystem(const hephaestus::InputParameters & params) {}
 
 EquationSystem::~EquationSystem() { hBlocks.DeleteAll(); }
 
@@ -336,8 +332,7 @@ EquationSystem::buildMixedBilinearForms()
   for (int i = 0; i < test_var_names.size(); i++)
   {
     auto test_var_name = test_var_names.at(i);
-    auto * test_mblfs =
-        new hephaestus::NamedFieldsMap<mfem::ParMixedBilinearForm>;
+    auto * test_mblfs = new hephaestus::NamedFieldsMap<mfem::ParMixedBilinearForm>;
     for (int j = 0; j < test_var_names.size(); j++)
     {
       auto trial_var_name = test_var_names.at(j);
@@ -348,8 +343,7 @@ EquationSystem::buildMixedBilinearForms()
           mblf_kernels_map_map.Get(test_var_name)->Has(trial_var_name))
       {
         auto mblf_kernels = mblf_kernels_map_map.Get(test_var_name)->Get(trial_var_name);
-        auto * mblf =
-            new mfem::ParMixedBilinearForm(test_pfespaces.at(j), test_pfespaces.at(i));
+        auto * mblf = new mfem::ParMixedBilinearForm(test_pfespaces.at(j), test_pfespaces.at(i));
         // Apply all mixed kernels with this test/trial pair
         for (auto & mblf_kernel : *mblf_kernels)
         {
@@ -377,7 +371,7 @@ EquationSystem::buildEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sour
 }
 
 TimeDependentEquationSystem::TimeDependentEquationSystem(const hephaestus::InputParameters & params)
-  : EquationSystem(params),  dtCoef(1.0)
+  : EquationSystem(params), dtCoef(1.0)
 {
 }
 

--- a/src/equation_systems/equation_system.cpp
+++ b/src/equation_systems/equation_system.cpp
@@ -4,15 +4,8 @@ namespace hephaestus
 {
 
 EquationSystem::EquationSystem(const hephaestus::InputParameters & params)
-  : var_names(),
-    test_var_names(),
-    test_pfespaces(),
-    blfs(),
-    lfs(),
-    nlfs(),
-    mblfs(),
-    ess_tdof_lists(),
-    xs()
+  
+    
 {
 }
 
@@ -240,25 +233,25 @@ EquationSystem::Init(hephaestus::GridFunctions & gridfunctions,
 
   for (const auto & [test_var_name, blf_kernels] : blf_kernels_map.GetMap())
   {
-    for (int i = 0; i < blf_kernels->size(); i++)
+    for (auto & i : *blf_kernels)
     {
-      (*blf_kernels)[i]->Init(gridfunctions, fespaces, bc_map, coefficients);
+      i->Init(gridfunctions, fespaces, bc_map, coefficients);
     }
   }
   // Initialise linear form kernels
   for (const auto & [test_var_name, lf_kernels] : lf_kernels_map.GetMap())
   {
-    for (int i = 0; i < lf_kernels->size(); i++)
+    for (auto & i : *lf_kernels)
     {
-      (*lf_kernels)[i]->Init(gridfunctions, fespaces, bc_map, coefficients);
+      i->Init(gridfunctions, fespaces, bc_map, coefficients);
     }
   }
   // Initialise nonlinear form kernels
   for (const auto & [test_var_name, nlf_kernels] : nlf_kernels_map.GetMap())
   {
-    for (int i = 0; i < nlf_kernels->size(); i++)
+    for (auto & i : *nlf_kernels)
     {
-      (*nlf_kernels)[i]->Init(gridfunctions, fespaces, bc_map, coefficients);
+      i->Init(gridfunctions, fespaces, bc_map, coefficients);
     }
   }
   // Initialise mixed bilinear form kernels
@@ -266,9 +259,9 @@ EquationSystem::Init(hephaestus::GridFunctions & gridfunctions,
   {
     for (const auto & [trial_var_name, mblf_kernels] : mblf_kernels_map->GetMap())
     {
-      for (int i = 0; i < mblf_kernels->size(); i++)
+      for (auto & i : *mblf_kernels)
       {
-        (*mblf_kernels)[i]->Init(gridfunctions, fespaces, bc_map, coefficients);
+        i->Init(gridfunctions, fespaces, bc_map, coefficients);
       }
     }
   }
@@ -343,7 +336,7 @@ EquationSystem::buildMixedBilinearForms()
   for (int i = 0; i < test_var_names.size(); i++)
   {
     auto test_var_name = test_var_names.at(i);
-    hephaestus::NamedFieldsMap<mfem::ParMixedBilinearForm> * test_mblfs =
+    auto * test_mblfs =
         new hephaestus::NamedFieldsMap<mfem::ParMixedBilinearForm>;
     for (int j = 0; j < test_var_names.size(); j++)
     {
@@ -355,7 +348,7 @@ EquationSystem::buildMixedBilinearForms()
           mblf_kernels_map_map.Get(test_var_name)->Has(trial_var_name))
       {
         auto mblf_kernels = mblf_kernels_map_map.Get(test_var_name)->Get(trial_var_name);
-        mfem::ParMixedBilinearForm * mblf =
+        auto * mblf =
             new mfem::ParMixedBilinearForm(test_pfespaces.at(j), test_pfespaces.at(i));
         // Apply all mixed kernels with this test/trial pair
         for (auto & mblf_kernel : *mblf_kernels)
@@ -384,7 +377,7 @@ EquationSystem::buildEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sour
 }
 
 TimeDependentEquationSystem::TimeDependentEquationSystem(const hephaestus::InputParameters & params)
-  : EquationSystem(params), var_time_derivative_names(), dtCoef(1.0)
+  : EquationSystem(params),  dtCoef(1.0)
 {
 }
 
@@ -407,9 +400,8 @@ TimeDependentEquationSystem::setTimeStep(double dt)
   if (fabs(dt - dtCoef.constant) > 1.0e-12 * dt)
   {
     dtCoef.constant = dt;
-    for (int i = 0; i < test_var_names.size(); i++)
+    for (auto test_var_name : test_var_names)
     {
-      auto test_var_name = test_var_names.at(i);
       auto blf = blfs.Get(test_var_name);
       blf->Update();
       blf->Assemble();

--- a/src/equation_systems/equation_system.hpp
+++ b/src/equation_systems/equation_system.hpp
@@ -15,12 +15,12 @@ mixed and nonlinear forms) and build methods
 class EquationSystem
 {
 public:
-  typedef hephaestus::Kernel<mfem::ParBilinearForm> ParBilinearFormKernel;
-  typedef hephaestus::Kernel<mfem::ParLinearForm> ParLinearFormKernel;
-  typedef hephaestus::Kernel<mfem::ParNonlinearForm> ParNonlinearFormKernel;
-  typedef hephaestus::Kernel<mfem::ParMixedBilinearForm> ParMixedBilinearFormKernel;
+  using ParBilinearFormKernel = hephaestus::Kernel<mfem::ParBilinearForm>;
+  using ParLinearFormKernel = hephaestus::Kernel<mfem::ParLinearForm>;
+  using ParNonlinearFormKernel = hephaestus::Kernel<mfem::ParNonlinearForm>;
+  using ParMixedBilinearFormKernel = hephaestus::Kernel<mfem::ParMixedBilinearForm>;
 
-  EquationSystem(){};
+  EquationSystem() = default;
   EquationSystem(const hephaestus::InputParameters & params);
 
   virtual ~EquationSystem();
@@ -111,13 +111,13 @@ class TimeDependentEquationSystem : public EquationSystem
 {
 public:
   TimeDependentEquationSystem(const hephaestus::InputParameters & params);
-  ~TimeDependentEquationSystem() override{};
+  ~TimeDependentEquationSystem() override = default;
 
   static std::string GetTimeDerivativeName(std::string name)
   {
     return std::string("d") + name + std::string("_dt");
   }
-  virtual void addVariableNameIfMissing(const std::string & var_name) override;
+  void addVariableNameIfMissing(const std::string & var_name) override;
 
   virtual void setTimeStep(double dt);
   virtual void updateEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sources & sources);

--- a/src/executioners/executioner_base.hpp
+++ b/src/executioners/executioner_base.hpp
@@ -10,7 +10,7 @@ public:
   Executioner() = default;
   explicit Executioner(const hephaestus::InputParameters & params){};
 
-  virtual ~Executioner() {}
+  virtual ~Executioner() = default;
 
   // Solve the current system of equations
   virtual void Solve() const = 0;

--- a/src/executioners/transient_executioner.hpp
+++ b/src/executioners/transient_executioner.hpp
@@ -21,7 +21,7 @@ public:
   TransientExecutioner() = default;
   explicit TransientExecutioner(const hephaestus::InputParameters & params);
 
-  ~TransientExecutioner() override {}
+  ~TransientExecutioner() override = default;
 
   void Step(double dt, int it) const;
 

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -158,7 +158,7 @@ Factory::createTimeDomainEMFormulation(std::string & formulation)
 mfem::ParFiniteElementSpace *
 Factory::createParFESpace(hephaestus::InputParameters params, mfem::ParMesh & pmesh)
 {
-  std::string FEType(params.GetParam<std::string>("FESpaceType"));
+  auto FEType(params.GetParam<std::string>("FESpaceType"));
   int order(params.GetParam<int>("order"));
   int components(params.GetParam<int>("components")); // spatial dimension of mesh. Use
                                                       // FiniteElementCollection::New instead

--- a/src/formulations/AV/av_formulation.cpp
+++ b/src/formulations/AV/av_formulation.cpp
@@ -33,13 +33,12 @@
 namespace hephaestus
 {
 
-AVFormulation::AVFormulation(std::string  alpha_coef_name,
-                             std::string  inv_alpha_coef_name,
-                             std::string  beta_coef_name,
-                             std::string  vector_potential_name,
-                             std::string  scalar_potential_name)
-  : 
-    _alpha_coef_name(std::move(alpha_coef_name)),
+AVFormulation::AVFormulation(std::string alpha_coef_name,
+                             std::string inv_alpha_coef_name,
+                             std::string beta_coef_name,
+                             std::string vector_potential_name,
+                             std::string scalar_potential_name)
+  : _alpha_coef_name(std::move(alpha_coef_name)),
     _inv_alpha_coef_name(std::move(inv_alpha_coef_name)),
     _beta_coef_name(std::move(beta_coef_name)),
     _vector_potential_name(std::move(vector_potential_name)),

--- a/src/formulations/AV/av_formulation.cpp
+++ b/src/formulations/AV/av_formulation.cpp
@@ -28,20 +28,22 @@
 
 #include "av_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
-AVFormulation::AVFormulation(const std::string & alpha_coef_name,
-                             const std::string & inv_alpha_coef_name,
-                             const std::string & beta_coef_name,
-                             const std::string & vector_potential_name,
-                             const std::string & scalar_potential_name)
-  : TimeDomainEMFormulation(),
-    _alpha_coef_name(alpha_coef_name),
-    _inv_alpha_coef_name(inv_alpha_coef_name),
-    _beta_coef_name(beta_coef_name),
-    _vector_potential_name(vector_potential_name),
-    _scalar_potential_name(scalar_potential_name)
+AVFormulation::AVFormulation(std::string  alpha_coef_name,
+                             std::string  inv_alpha_coef_name,
+                             std::string  beta_coef_name,
+                             std::string  vector_potential_name,
+                             std::string  scalar_potential_name)
+  : 
+    _alpha_coef_name(std::move(alpha_coef_name)),
+    _inv_alpha_coef_name(std::move(inv_alpha_coef_name)),
+    _beta_coef_name(std::move(beta_coef_name)),
+    _vector_potential_name(std::move(vector_potential_name)),
+    _scalar_potential_name(std::move(scalar_potential_name))
 {
 }
 

--- a/src/formulations/AV/av_formulation.hpp
+++ b/src/formulations/AV/av_formulation.hpp
@@ -10,11 +10,11 @@ namespace hephaestus
 class AVFormulation : public TimeDomainEMFormulation
 {
 public:
-  AVFormulation(std::string  alpha_coef_name,
-                std::string  inv_alpha_coef_name,
-                std::string  beta_coef_name,
-                std::string  vector_potential_name,
-                std::string  scalar_potential_name);
+  AVFormulation(std::string alpha_coef_name,
+                std::string inv_alpha_coef_name,
+                std::string beta_coef_name,
+                std::string vector_potential_name,
+                std::string scalar_potential_name);
 
   ~AVFormulation() override = default;
 
@@ -42,9 +42,9 @@ public:
   ~AVEquationSystem() override = default;
 
   void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
   void addKernels() override;
 
   std::string a_name, v_name, coupled_variable_name, alpha_coef_name, beta_coef_name,

--- a/src/formulations/AV/av_formulation.hpp
+++ b/src/formulations/AV/av_formulation.hpp
@@ -10,21 +10,21 @@ namespace hephaestus
 class AVFormulation : public TimeDomainEMFormulation
 {
 public:
-  AVFormulation(const std::string & alpha_coef_name,
-                const std::string & inv_alpha_coef_name,
-                const std::string & beta_coef_name,
-                const std::string & vector_potential_name,
-                const std::string & scalar_potential_name);
+  AVFormulation(std::string  alpha_coef_name,
+                std::string  inv_alpha_coef_name,
+                std::string  beta_coef_name,
+                std::string  vector_potential_name,
+                std::string  scalar_potential_name);
 
-  ~AVFormulation() override {}
+  ~AVFormulation() override = default;
 
-  virtual void ConstructEquationSystem() override;
+  void ConstructEquationSystem() override;
 
-  virtual void ConstructOperator() override;
+  void ConstructOperator() override;
 
-  virtual void RegisterGridFunctions() override;
+  void RegisterGridFunctions() override;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
 protected:
   const std::string _alpha_coef_name;
@@ -39,13 +39,13 @@ class AVEquationSystem : public TimeDependentEquationSystem
 public:
   AVEquationSystem(const hephaestus::InputParameters & params);
 
-  ~AVEquationSystem() override {}
+  ~AVEquationSystem() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
+  void Init(hephaestus::GridFunctions & gridfunctions,
                     const hephaestus::FESpaces & fespaces,
                     hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients);
-  virtual void addKernels() override;
+                    hephaestus::Coefficients & coefficients) override;
+  void addKernels() override;
 
   std::string a_name, v_name, coupled_variable_name, alpha_coef_name, beta_coef_name,
       dtalpha_coef_name, neg_beta_coef_name;
@@ -63,7 +63,7 @@ public:
              hephaestus::Sources & sources,
              hephaestus::InputParameters & solver_options);
 
-  ~AVOperator() override {}
+  ~AVOperator() override = default;
 
   void ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
 };

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
@@ -42,22 +42,22 @@ public:
   // Enable auxiliary calculation of J ∈ H(div)
   //* Induced electric current, Jind = σE = -iωσA
   void registerCurrentDensityAux(const std::string & j_field_real_name,
-                                         const std::string & j_field_imag_name) override;
+                                 const std::string & j_field_imag_name) override;
 
   //* Magnetic flux density B = curl A
   void registerMagneticFluxDensityAux(const std::string & b_field_real_name,
-                                              const std::string & b_field_imag_name) override;
+                                      const std::string & b_field_imag_name) override;
 
   //* Electric field E =-dA/dt=-iωA
   void registerElectricFieldAux(const std::string & e_field_real_name,
-                                        const std::string & e_field_imag_name) override;
+                                const std::string & e_field_imag_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
   // Time averaged Joule heating density E.J
   void registerJouleHeatingDensityAux(const std::string & p_field_name,
-                                              const std::string & e_field_real_name,
-                                              const std::string & e_field_imag_name,
-                                              const std::string & conductivity_coef_name) override;
+                                      const std::string & e_field_real_name,
+                                      const std::string & e_field_imag_name,
+                                      const std::string & conductivity_coef_name) override;
 
 protected:
   const std::string & _magnetic_reluctivity_name =

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
@@ -37,24 +37,24 @@ public:
                       const std::string & magnetic_vector_potential_real_name,
                       const std::string & magnetic_vector_potential_imag_name);
 
-  ~ComplexAFormulation() override {}
+  ~ComplexAFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
   //* Induced electric current, Jind = σE = -iωσA
-  virtual void registerCurrentDensityAux(const std::string & j_field_real_name,
+  void registerCurrentDensityAux(const std::string & j_field_real_name,
                                          const std::string & j_field_imag_name) override;
 
   //* Magnetic flux density B = curl A
-  virtual void registerMagneticFluxDensityAux(const std::string & b_field_real_name,
+  void registerMagneticFluxDensityAux(const std::string & b_field_real_name,
                                               const std::string & b_field_imag_name) override;
 
   //* Electric field E =-dA/dt=-iωA
-  virtual void registerElectricFieldAux(const std::string & e_field_real_name,
+  void registerElectricFieldAux(const std::string & e_field_real_name,
                                         const std::string & e_field_imag_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
   // Time averaged Joule heating density E.J
-  virtual void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void registerJouleHeatingDensityAux(const std::string & p_field_name,
                                               const std::string & e_field_real_name,
                                               const std::string & e_field_imag_name,
                                               const std::string & conductivity_coef_name) override;

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
@@ -36,25 +36,25 @@ public:
                       const std::string & e_field_real_name,
                       const std::string & e_field_imag_name);
 
-  ~ComplexEFormulation() override {}
+  ~ComplexEFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
   //* Induced electric current, Jind = σE
-  virtual void registerCurrentDensityAux(const std::string & j_field_real_name,
+  void registerCurrentDensityAux(const std::string & j_field_real_name,
                                          const std::string & j_field_imag_name) override;
 
   //* Magnetic flux density B = (i/ω) curl E
   //* (∇×E = -dB/dt = -iωB)
-  virtual void registerMagneticFluxDensityAux(const std::string & b_field_real_name,
+  void registerMagneticFluxDensityAux(const std::string & b_field_real_name,
                                               const std::string & b_field_imag_name) override;
 
   //* Electric field is already a state variable solved for
-  virtual void registerElectricFieldAux(const std::string & e_field_real_name,
+  void registerElectricFieldAux(const std::string & e_field_real_name,
                                         const std::string & e_field_imag_name) override{};
 
   // Enable auxiliary calculation of P ∈ L2
   // Time averaged Joule heating density E.J
-  virtual void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void registerJouleHeatingDensityAux(const std::string & p_field_name,
                                               const std::string & e_field_real_name,
                                               const std::string & e_field_imag_name,
                                               const std::string & conductivity_coef_name) override;

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
@@ -41,23 +41,23 @@ public:
   // Enable auxiliary calculation of J ∈ H(div)
   //* Induced electric current, Jind = σE
   void registerCurrentDensityAux(const std::string & j_field_real_name,
-                                         const std::string & j_field_imag_name) override;
+                                 const std::string & j_field_imag_name) override;
 
   //* Magnetic flux density B = (i/ω) curl E
   //* (∇×E = -dB/dt = -iωB)
   void registerMagneticFluxDensityAux(const std::string & b_field_real_name,
-                                              const std::string & b_field_imag_name) override;
+                                      const std::string & b_field_imag_name) override;
 
   //* Electric field is already a state variable solved for
   void registerElectricFieldAux(const std::string & e_field_real_name,
-                                        const std::string & e_field_imag_name) override{};
+                                const std::string & e_field_imag_name) override{};
 
   // Enable auxiliary calculation of P ∈ L2
   // Time averaged Joule heating density E.J
   void registerJouleHeatingDensityAux(const std::string & p_field_name,
-                                              const std::string & e_field_real_name,
-                                              const std::string & e_field_imag_name,
-                                              const std::string & conductivity_coef_name) override;
+                                      const std::string & e_field_real_name,
+                                      const std::string & e_field_imag_name,
+                                      const std::string & conductivity_coef_name) override;
 
 protected:
   const std::string & _magnetic_reluctivity_name =

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
@@ -102,15 +102,14 @@ ComplexMaxwellOperator::Solve(mfem::Vector & X)
   *_gridfunctions.Get(state_var_names.at(1)) = u_->imag();
 }
 
-ComplexMaxwellFormulation::ComplexMaxwellFormulation(std::string  alpha_coef_name,
-                                                     std::string  beta_coef_name,
-                                                     std::string  zeta_coef_name,
-                                                     std::string  frequency_coef_name,
-                                                     std::string  h_curl_var_complex_name,
-                                                     std::string  h_curl_var_real_name,
-                                                     std::string  h_curl_var_imag_name)
-  : 
-    _alpha_coef_name(std::move(alpha_coef_name)),
+ComplexMaxwellFormulation::ComplexMaxwellFormulation(std::string alpha_coef_name,
+                                                     std::string beta_coef_name,
+                                                     std::string zeta_coef_name,
+                                                     std::string frequency_coef_name,
+                                                     std::string h_curl_var_complex_name,
+                                                     std::string h_curl_var_real_name,
+                                                     std::string h_curl_var_imag_name)
+  : _alpha_coef_name(std::move(alpha_coef_name)),
     _beta_coef_name(std::move(beta_coef_name)),
     _zeta_coef_name(std::move(zeta_coef_name)),
     _frequency_coef_name(std::move(frequency_coef_name)),

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
@@ -1,5 +1,7 @@
 #include "complex_maxwell_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
@@ -86,7 +88,7 @@ ComplexMaxwellOperator::Solve(mfem::Vector & X)
 
   a1_.FormLinearSystem(ess_bdr_tdofs_, *u_, b1_, A1, U, RHS);
 
-  mfem::ComplexHypreParMatrix * A1Z = A1.As<mfem::ComplexHypreParMatrix>();
+  auto * A1Z = A1.As<mfem::ComplexHypreParMatrix>();
   auto A1C = std::unique_ptr<mfem::HypreParMatrix>(A1Z->GetSystemMatrix());
 
   mfem::SuperLURowLocMatrix A_SuperLU(*A1C);
@@ -100,21 +102,21 @@ ComplexMaxwellOperator::Solve(mfem::Vector & X)
   *_gridfunctions.Get(state_var_names.at(1)) = u_->imag();
 }
 
-ComplexMaxwellFormulation::ComplexMaxwellFormulation(const std::string & alpha_coef_name,
-                                                     const std::string & beta_coef_name,
-                                                     const std::string & zeta_coef_name,
-                                                     const std::string & frequency_coef_name,
-                                                     const std::string & h_curl_var_complex_name,
-                                                     const std::string & h_curl_var_real_name,
-                                                     const std::string & h_curl_var_imag_name)
-  : FrequencyDomainEMFormulation(),
-    _alpha_coef_name(alpha_coef_name),
-    _beta_coef_name(beta_coef_name),
-    _zeta_coef_name(zeta_coef_name),
-    _frequency_coef_name(frequency_coef_name),
-    _h_curl_var_complex_name(h_curl_var_complex_name),
-    _h_curl_var_real_name(h_curl_var_real_name),
-    _h_curl_var_imag_name(h_curl_var_imag_name),
+ComplexMaxwellFormulation::ComplexMaxwellFormulation(std::string  alpha_coef_name,
+                                                     std::string  beta_coef_name,
+                                                     std::string  zeta_coef_name,
+                                                     std::string  frequency_coef_name,
+                                                     std::string  h_curl_var_complex_name,
+                                                     std::string  h_curl_var_real_name,
+                                                     std::string  h_curl_var_imag_name)
+  : 
+    _alpha_coef_name(std::move(alpha_coef_name)),
+    _beta_coef_name(std::move(beta_coef_name)),
+    _zeta_coef_name(std::move(zeta_coef_name)),
+    _frequency_coef_name(std::move(frequency_coef_name)),
+    _h_curl_var_complex_name(std::move(h_curl_var_complex_name)),
+    _h_curl_var_real_name(std::move(h_curl_var_real_name)),
+    _h_curl_var_imag_name(std::move(h_curl_var_imag_name)),
     _mass_coef_name(std::string("maxwell_mass")),
     _loss_coef_name(std::string("maxwell_loss"))
 {

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
@@ -36,11 +36,11 @@ public:
                          hephaestus::Sources & sources,
                          hephaestus::InputParameters & solver_options);
 
-  ~ComplexMaxwellOperator() override {}
+  ~ComplexMaxwellOperator() override = default;
 
-  virtual void SetGridFunctions() override;
-  virtual void Init(mfem::Vector & X) override;
-  virtual void Solve(mfem::Vector & X) override;
+  void SetGridFunctions() override;
+  void Init(mfem::Vector & X) override;
+  void Solve(mfem::Vector & X) override;
 
   std::string h_curl_var_complex_name, h_curl_var_real_name, h_curl_var_imag_name,
       stiffness_coef_name, mass_coef_name, loss_coef_name;
@@ -60,21 +60,21 @@ public:
 class ComplexMaxwellFormulation : public hephaestus::FrequencyDomainEMFormulation
 {
 public:
-  ComplexMaxwellFormulation(const std::string & frequency_coef_name,
-                            const std::string & alpha_coef_name,
-                            const std::string & beta_coef_name,
-                            const std::string & zeta_coef_name,
-                            const std::string & h_curl_var_complex_name,
-                            const std::string & h_curl_var_real_name,
-                            const std::string & h_curl_var_imag_name);
+  ComplexMaxwellFormulation(std::string frequency_coef_name,
+                            std::string alpha_coef_name,
+                            std::string beta_coef_name,
+                            std::string zeta_coef_name,
+                            std::string h_curl_var_complex_name,
+                            std::string h_curl_var_real_name,
+                            std::string h_curl_var_imag_name);
 
-  ~ComplexMaxwellFormulation() override{};
+  ~ComplexMaxwellFormulation() override = default;
 
-  virtual void ConstructOperator() override;
+  void ConstructOperator() override;
 
-  virtual void RegisterGridFunctions() override;
+  void RegisterGridFunctions() override;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
   // std::vector<mfem::ParGridFunction *> local_trial_vars, local_test_vars;
 protected:

--- a/src/formulations/Dual/dual_formulation.cpp
+++ b/src/formulations/Dual/dual_formulation.cpp
@@ -47,12 +47,11 @@
 namespace hephaestus
 {
 
-DualFormulation::DualFormulation(std::string  alpha_coef_name,
-                                 std::string  beta_coef_name,
-                                 std::string  h_curl_var_name,
-                                 std::string  h_div_var_name)
-  : 
-    _alpha_coef_name(std::move(alpha_coef_name)),
+DualFormulation::DualFormulation(std::string alpha_coef_name,
+                                 std::string beta_coef_name,
+                                 std::string h_curl_var_name,
+                                 std::string h_div_var_name)
+  : _alpha_coef_name(std::move(alpha_coef_name)),
     _beta_coef_name(std::move(beta_coef_name)),
     _h_curl_var_name(std::move(h_curl_var_name)),
     _h_div_var_name(std::move(h_div_var_name))
@@ -198,8 +197,7 @@ void
 DualOperator::Init(mfem::Vector & X)
 {
   TimeDomainEquationSystemOperator::Init(X);
-  auto * eqs =
-      dynamic_cast<hephaestus::WeakCurlEquationSystem *>(_equation_system);
+  auto * eqs = dynamic_cast<hephaestus::WeakCurlEquationSystem *>(_equation_system);
   _h_curl_var_name = eqs->_h_curl_var_name;
   _h_div_var_name = eqs->_h_div_var_name;
   u_ = _gridfunctions.Get(_h_curl_var_name);

--- a/src/formulations/Dual/dual_formulation.cpp
+++ b/src/formulations/Dual/dual_formulation.cpp
@@ -42,18 +42,20 @@
 
 #include "dual_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
-DualFormulation::DualFormulation(const std::string & alpha_coef_name,
-                                 const std::string & beta_coef_name,
-                                 const std::string & h_curl_var_name,
-                                 const std::string & h_div_var_name)
-  : TimeDomainEMFormulation(),
-    _alpha_coef_name(alpha_coef_name),
-    _beta_coef_name(beta_coef_name),
-    _h_curl_var_name(h_curl_var_name),
-    _h_div_var_name(h_div_var_name)
+DualFormulation::DualFormulation(std::string  alpha_coef_name,
+                                 std::string  beta_coef_name,
+                                 std::string  h_curl_var_name,
+                                 std::string  h_div_var_name)
+  : 
+    _alpha_coef_name(std::move(alpha_coef_name)),
+    _beta_coef_name(std::move(beta_coef_name)),
+    _h_curl_var_name(std::move(h_curl_var_name)),
+    _h_div_var_name(std::move(h_div_var_name))
 {
 }
 
@@ -196,7 +198,7 @@ void
 DualOperator::Init(mfem::Vector & X)
 {
   TimeDomainEquationSystemOperator::Init(X);
-  hephaestus::WeakCurlEquationSystem * eqs =
+  auto * eqs =
       dynamic_cast<hephaestus::WeakCurlEquationSystem *>(_equation_system);
   _h_curl_var_name = eqs->_h_curl_var_name;
   _h_div_var_name = eqs->_h_div_var_name;

--- a/src/formulations/Dual/dual_formulation.hpp
+++ b/src/formulations/Dual/dual_formulation.hpp
@@ -9,10 +9,10 @@ namespace hephaestus
 class DualFormulation : public TimeDomainEMFormulation
 {
 public:
-  DualFormulation(std::string  alpha_coef_name,
-                  std::string  beta_coef_name,
-                  std::string  h_curl_var_name,
-                  std::string  h_div_var_name);
+  DualFormulation(std::string alpha_coef_name,
+                  std::string beta_coef_name,
+                  std::string h_curl_var_name,
+                  std::string h_div_var_name);
 
   ~DualFormulation() override = default;
 
@@ -38,9 +38,9 @@ public:
   ~WeakCurlEquationSystem() override = default;
 
   void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
   void addKernels() override;
 
   std::string _h_curl_var_name, _h_div_var_name, _alpha_coef_name, _beta_coef_name,

--- a/src/formulations/Dual/dual_formulation.hpp
+++ b/src/formulations/Dual/dual_formulation.hpp
@@ -9,20 +9,20 @@ namespace hephaestus
 class DualFormulation : public TimeDomainEMFormulation
 {
 public:
-  DualFormulation(const std::string & alpha_coef_name,
-                  const std::string & beta_coef_name,
-                  const std::string & h_curl_var_name,
-                  const std::string & h_div_var_name);
+  DualFormulation(std::string  alpha_coef_name,
+                  std::string  beta_coef_name,
+                  std::string  h_curl_var_name,
+                  std::string  h_div_var_name);
 
-  ~DualFormulation() override {}
+  ~DualFormulation() override = default;
 
-  virtual void ConstructEquationSystem() override;
+  void ConstructEquationSystem() override;
 
-  virtual void ConstructOperator() override;
+  void ConstructOperator() override;
 
-  virtual void RegisterGridFunctions() override;
+  void RegisterGridFunctions() override;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
 protected:
   const std::string _alpha_coef_name;
@@ -35,13 +35,13 @@ class WeakCurlEquationSystem : public TimeDependentEquationSystem
 {
 public:
   WeakCurlEquationSystem(const hephaestus::InputParameters & params);
-  ~WeakCurlEquationSystem() override {}
+  ~WeakCurlEquationSystem() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
+  void Init(hephaestus::GridFunctions & gridfunctions,
                     const hephaestus::FESpaces & fespaces,
                     hephaestus::BCMap & bc_map,
                     hephaestus::Coefficients & coefficients) override;
-  virtual void addKernels() override;
+  void addKernels() override;
 
   std::string _h_curl_var_name, _h_div_var_name, _alpha_coef_name, _beta_coef_name,
       _dtalpha_coef_name;
@@ -58,12 +58,12 @@ public:
                hephaestus::Sources & sources,
                hephaestus::InputParameters & solver_options);
 
-  ~DualOperator() override {}
+  ~DualOperator() override = default;
 
   void Init(mfem::Vector & X) override;
 
   void ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
-  virtual void SetGridFunctions() override;
+  void SetGridFunctions() override;
   mfem::ParFiniteElementSpace * HCurlFESpace_;
   mfem::ParFiniteElementSpace * HDivFESpace_;
 

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -6,7 +6,7 @@ namespace hephaestus
 {
 
 EBDualFormulation::EBDualFormulation(const std::string & magnetic_reluctivity_name,
-                                     std::string  magnetic_permeability_name,
+                                     std::string magnetic_permeability_name,
                                      const std::string & electric_conductivity_name,
                                      const std::string & e_field_name,
                                      const std::string & b_field_name)

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -1,16 +1,18 @@
 #include "eb_dual_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
 EBDualFormulation::EBDualFormulation(const std::string & magnetic_reluctivity_name,
-                                     const std::string & magnetic_permeability_name,
+                                     std::string  magnetic_permeability_name,
                                      const std::string & electric_conductivity_name,
                                      const std::string & e_field_name,
                                      const std::string & b_field_name)
   : DualFormulation(
         magnetic_reluctivity_name, electric_conductivity_name, e_field_name, b_field_name),
-    _magnetic_permeability_name(magnetic_permeability_name)
+    _magnetic_permeability_name(std::move(magnetic_permeability_name))
 {
 }
 

--- a/src/formulations/Dual/eb_dual_formulation.hpp
+++ b/src/formulations/Dual/eb_dual_formulation.hpp
@@ -10,27 +10,27 @@ class EBDualFormulation : public hephaestus::DualFormulation
 {
 public:
   EBDualFormulation(const std::string & magnetic_reluctivity_name,
-                    const std::string & magnetic_permeability_name,
+                    std::string  magnetic_permeability_name,
                     const std::string & electric_conductivity_name,
                     const std::string & e_field_name,
                     const std::string & b_field_name);
 
-  ~EBDualFormulation() override {}
+  ~EBDualFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  virtual void registerCurrentDensityAux(const std::string & j_field_name) override;
+  void registerCurrentDensityAux(const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of F ∈ L2
-  virtual void registerLorentzForceDensityAux(const std::string & f_field_name,
+  void registerLorentzForceDensityAux(const std::string & f_field_name,
                                               const std::string & b_field_name,
                                               const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
-  virtual void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void registerJouleHeatingDensityAux(const std::string & p_field_name,
                                               const std::string & e_field_name,
                                               const std::string & conductivity_coef_name) override;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
 protected:
   const std::string _magnetic_permeability_name;

--- a/src/formulations/Dual/eb_dual_formulation.hpp
+++ b/src/formulations/Dual/eb_dual_formulation.hpp
@@ -10,7 +10,7 @@ class EBDualFormulation : public hephaestus::DualFormulation
 {
 public:
   EBDualFormulation(const std::string & magnetic_reluctivity_name,
-                    std::string  magnetic_permeability_name,
+                    std::string magnetic_permeability_name,
                     const std::string & electric_conductivity_name,
                     const std::string & e_field_name,
                     const std::string & b_field_name);
@@ -22,13 +22,13 @@ public:
 
   // Enable auxiliary calculation of F ∈ L2
   void registerLorentzForceDensityAux(const std::string & f_field_name,
-                                              const std::string & b_field_name,
-                                              const std::string & j_field_name) override;
+                                      const std::string & b_field_name,
+                                      const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
   void registerJouleHeatingDensityAux(const std::string & p_field_name,
-                                              const std::string & e_field_name,
-                                              const std::string & conductivity_coef_name) override;
+                                      const std::string & e_field_name,
+                                      const std::string & conductivity_coef_name) override;
 
   void RegisterCoefficients() override;
 

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -15,16 +15,18 @@
 
 #include "a_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
 AFormulation::AFormulation(const std::string & magnetic_reluctivity_name,
-                           const std::string & magnetic_permeability_name,
+                           std::string  magnetic_permeability_name,
                            const std::string & electric_conductivity_name,
                            const std::string & magnetic_vector_potential_name)
   : HCurlFormulation(
         magnetic_reluctivity_name, electric_conductivity_name, magnetic_vector_potential_name),
-    _magnetic_permeability_name(magnetic_permeability_name)
+    _magnetic_permeability_name(std::move(magnetic_permeability_name))
 {
 }
 

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -21,7 +21,7 @@ namespace hephaestus
 {
 
 AFormulation::AFormulation(const std::string & magnetic_reluctivity_name,
-                           std::string  magnetic_permeability_name,
+                           std::string magnetic_permeability_name,
                            const std::string & electric_conductivity_name,
                            const std::string & magnetic_vector_potential_name)
   : HCurlFormulation(

--- a/src/formulations/HCurl/a_formulation.hpp
+++ b/src/formulations/HCurl/a_formulation.hpp
@@ -10,7 +10,7 @@ class AFormulation : public hephaestus::HCurlFormulation
 {
 public:
   AFormulation(const std::string & magnetic_reluctivity_name,
-               std::string  magnetic_permeability_name,
+               std::string magnetic_permeability_name,
                const std::string & electric_conductivity_name,
                const std::string & magnetic_vector_potential_name);
 
@@ -30,13 +30,13 @@ public:
 
   // Enable auxiliary calculation of F ∈ L2
   void registerLorentzForceDensityAux(const std::string & f_field_name,
-                                              const std::string & b_field_name,
-                                              const std::string & j_field_name) override;
+                                      const std::string & b_field_name,
+                                      const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
   void registerJouleHeatingDensityAux(const std::string & p_field_name,
-                                              const std::string & e_field_name,
-                                              const std::string & conductivity_coef_name) override;
+                                      const std::string & e_field_name,
+                                      const std::string & conductivity_coef_name) override;
 
   void RegisterCoefficients() override;
 

--- a/src/formulations/HCurl/a_formulation.hpp
+++ b/src/formulations/HCurl/a_formulation.hpp
@@ -10,35 +10,35 @@ class AFormulation : public hephaestus::HCurlFormulation
 {
 public:
   AFormulation(const std::string & magnetic_reluctivity_name,
-               const std::string & magnetic_permeability_name,
+               std::string  magnetic_permeability_name,
                const std::string & electric_conductivity_name,
                const std::string & magnetic_vector_potential_name);
 
-  ~AFormulation() override {}
+  ~AFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  virtual void registerCurrentDensityAux(const std::string & j_field_name) override;
+  void registerCurrentDensityAux(const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of B ∈ H(div)
-  virtual void registerMagneticFluxDensityAux(const std::string & b_field_name) override;
+  void registerMagneticFluxDensityAux(const std::string & b_field_name) override;
 
   // Enable auxiliary calculation of E ∈ H(curl)
-  virtual void registerElectricFieldAux(const std::string & e_field_name) override;
+  void registerElectricFieldAux(const std::string & e_field_name) override;
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  virtual void registerMagneticFieldAux(const std::string & h_field_name) override;
+  void registerMagneticFieldAux(const std::string & h_field_name) override;
 
   // Enable auxiliary calculation of F ∈ L2
-  virtual void registerLorentzForceDensityAux(const std::string & f_field_name,
+  void registerLorentzForceDensityAux(const std::string & f_field_name,
                                               const std::string & b_field_name,
                                               const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
-  virtual void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void registerJouleHeatingDensityAux(const std::string & p_field_name,
                                               const std::string & e_field_name,
                                               const std::string & conductivity_coef_name) override;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
 protected:
   const std::string _magnetic_permeability_name;

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -14,15 +14,17 @@
 
 #include "e_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
 EFormulation::EFormulation(const std::string & magnetic_reluctivity_name,
-                           const std::string & magnetic_permeability_name,
+                           std::string  magnetic_permeability_name,
                            const std::string & electric_conductivity_name,
                            const std::string & e_field_name)
   : HCurlFormulation(magnetic_reluctivity_name, electric_conductivity_name, e_field_name),
-    _magnetic_permeability_name(magnetic_permeability_name)
+    _magnetic_permeability_name(std::move(magnetic_permeability_name))
 {
 }
 

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -20,7 +20,7 @@ namespace hephaestus
 {
 
 EFormulation::EFormulation(const std::string & magnetic_reluctivity_name,
-                           std::string  magnetic_permeability_name,
+                           std::string magnetic_permeability_name,
                            const std::string & electric_conductivity_name,
                            const std::string & e_field_name)
   : HCurlFormulation(magnetic_reluctivity_name, electric_conductivity_name, e_field_name),

--- a/src/formulations/HCurl/e_formulation.hpp
+++ b/src/formulations/HCurl/e_formulation.hpp
@@ -10,21 +10,21 @@ class EFormulation : public hephaestus::HCurlFormulation
 {
 public:
   EFormulation(const std::string & magnetic_reluctivity_name,
-               const std::string & magnetic_permeability_name,
+               std::string magnetic_permeability_name,
                const std::string & electric_conductivity_name,
                const std::string & e_field_name);
 
-  ~EFormulation(){};
+  ~EFormulation() override = default;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  virtual void registerCurrentDensityAux(const std::string & j_field_name) override;
+  void registerCurrentDensityAux(const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
-  virtual void registerJouleHeatingDensityAux(const std::string & p_field_name,
-                                              const std::string & e_field_name,
-                                              const std::string & conductivity_coef_name) override;
+  void registerJouleHeatingDensityAux(const std::string & p_field_name,
+                                      const std::string & e_field_name,
+                                      const std::string & conductivity_coef_name) override;
 
 protected:
   const std::string _magnetic_permeability_name;

--- a/src/formulations/HCurl/h_formulation.cpp
+++ b/src/formulations/HCurl/h_formulation.cpp
@@ -19,7 +19,7 @@ namespace hephaestus
 {
 
 HFormulation::HFormulation(const std::string & electric_resistivity_name,
-                           std::string  electric_conductivity_name,
+                           std::string electric_conductivity_name,
                            const std::string & magnetic_permeability_name,
                            const std::string & h_field_name)
   : HCurlFormulation(electric_resistivity_name, magnetic_permeability_name, h_field_name),

--- a/src/formulations/HCurl/h_formulation.cpp
+++ b/src/formulations/HCurl/h_formulation.cpp
@@ -13,15 +13,17 @@
 
 #include "h_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
 HFormulation::HFormulation(const std::string & electric_resistivity_name,
-                           const std::string & electric_conductivity_name,
+                           std::string  electric_conductivity_name,
                            const std::string & magnetic_permeability_name,
                            const std::string & h_field_name)
   : HCurlFormulation(electric_resistivity_name, magnetic_permeability_name, h_field_name),
-    _electric_conductivity_name(electric_conductivity_name)
+    _electric_conductivity_name(std::move(electric_conductivity_name))
 {
 }
 

--- a/src/formulations/HCurl/h_formulation.hpp
+++ b/src/formulations/HCurl/h_formulation.hpp
@@ -10,7 +10,7 @@ class HFormulation : public hephaestus::HCurlFormulation
 {
 public:
   HFormulation(const std::string & electric_resistivity_name,
-               std::string  electric_conductivity_name,
+               std::string electric_conductivity_name,
                const std::string & magnetic_permeability_name,
                const std::string & h_field_name);
 
@@ -30,13 +30,13 @@ public:
 
   // Enable auxiliary calculation of F ∈ L2
   void registerLorentzForceDensityAux(const std::string & f_field_name,
-                                              const std::string & b_field_name,
-                                              const std::string & j_field_name) override;
+                                      const std::string & b_field_name,
+                                      const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
   void registerJouleHeatingDensityAux(const std::string & p_field_name,
-                                              const std::string & e_field_name,
-                                              const std::string & conductivity_coef_name) override;
+                                      const std::string & e_field_name,
+                                      const std::string & conductivity_coef_name) override;
 
   void RegisterCoefficients() override;
 

--- a/src/formulations/HCurl/h_formulation.hpp
+++ b/src/formulations/HCurl/h_formulation.hpp
@@ -10,35 +10,35 @@ class HFormulation : public hephaestus::HCurlFormulation
 {
 public:
   HFormulation(const std::string & electric_resistivity_name,
-               const std::string & electric_conductivity_name,
+               std::string  electric_conductivity_name,
                const std::string & magnetic_permeability_name,
                const std::string & h_field_name);
 
-  ~HFormulation() override {}
+  ~HFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  virtual void registerCurrentDensityAux(const std::string & j_field_name) override;
+  void registerCurrentDensityAux(const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of B ∈ H(div)
-  virtual void registerMagneticFluxDensityAux(const std::string & b_field_name) override;
+  void registerMagneticFluxDensityAux(const std::string & b_field_name) override;
 
   // Enable auxiliary calculation of E ∈ H(curl)
-  virtual void registerElectricFieldAux(const std::string & e_field_name) override;
+  void registerElectricFieldAux(const std::string & e_field_name) override;
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  virtual void registerMagneticFieldAux(const std::string & h_field_name) override;
+  void registerMagneticFieldAux(const std::string & h_field_name) override;
 
   // Enable auxiliary calculation of F ∈ L2
-  virtual void registerLorentzForceDensityAux(const std::string & f_field_name,
+  void registerLorentzForceDensityAux(const std::string & f_field_name,
                                               const std::string & b_field_name,
                                               const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
-  virtual void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void registerJouleHeatingDensityAux(const std::string & p_field_name,
                                               const std::string & e_field_name,
                                               const std::string & conductivity_coef_name) override;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
 protected:
   const std::string _electric_conductivity_name;

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -38,16 +38,18 @@
 // b1(u') = (s0_{n+1}, u') - (α∇×u_{n}, ∇×u') + <(α∇×u_{n+1}) × n, u'>
 #include "hcurl_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
-HCurlFormulation::HCurlFormulation(const std::string & alpha_coef_name,
-                                   const std::string & beta_coef_name,
-                                   const std::string & h_curl_var_name)
-  : TimeDomainEMFormulation(),
-    _alpha_coef_name(alpha_coef_name),
-    _beta_coef_name(beta_coef_name),
-    _h_curl_var_name(h_curl_var_name)
+HCurlFormulation::HCurlFormulation(std::string  alpha_coef_name,
+                                   std::string  beta_coef_name,
+                                   std::string  h_curl_var_name)
+  : 
+    _alpha_coef_name(std::move(alpha_coef_name)),
+    _beta_coef_name(std::move(beta_coef_name)),
+    _h_curl_var_name(std::move(h_curl_var_name))
 {
 }
 

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -43,11 +43,10 @@
 namespace hephaestus
 {
 
-HCurlFormulation::HCurlFormulation(std::string  alpha_coef_name,
-                                   std::string  beta_coef_name,
-                                   std::string  h_curl_var_name)
-  : 
-    _alpha_coef_name(std::move(alpha_coef_name)),
+HCurlFormulation::HCurlFormulation(std::string alpha_coef_name,
+                                   std::string beta_coef_name,
+                                   std::string h_curl_var_name)
+  : _alpha_coef_name(std::move(alpha_coef_name)),
     _beta_coef_name(std::move(beta_coef_name)),
     _h_curl_var_name(std::move(h_curl_var_name))
 {

--- a/src/formulations/HCurl/hcurl_formulation.hpp
+++ b/src/formulations/HCurl/hcurl_formulation.hpp
@@ -10,9 +10,9 @@ namespace hephaestus
 class HCurlFormulation : public TimeDomainEMFormulation
 {
 public:
-  HCurlFormulation(std::string  alpha_coef_name,
-                   std::string  beta_coef_name,
-                   std::string  h_curl_var_name);
+  HCurlFormulation(std::string alpha_coef_name,
+                   std::string beta_coef_name,
+                   std::string h_curl_var_name);
 
   ~HCurlFormulation() override = default;
 
@@ -36,9 +36,9 @@ public:
   CurlCurlEquationSystem(const hephaestus::InputParameters & params);
 
   void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
   void addKernels() override;
 
   std::string h_curl_var_name, alpha_coef_name, beta_coef_name, dtalpha_coef_name;

--- a/src/formulations/HCurl/hcurl_formulation.hpp
+++ b/src/formulations/HCurl/hcurl_formulation.hpp
@@ -10,19 +10,19 @@ namespace hephaestus
 class HCurlFormulation : public TimeDomainEMFormulation
 {
 public:
-  HCurlFormulation(const std::string & alpha_coef_name,
-                   const std::string & beta_coef_name,
-                   const std::string & h_curl_var_name);
+  HCurlFormulation(std::string  alpha_coef_name,
+                   std::string  beta_coef_name,
+                   std::string  h_curl_var_name);
 
-  ~HCurlFormulation() override {}
+  ~HCurlFormulation() override = default;
 
-  virtual void ConstructEquationSystem() override;
+  void ConstructEquationSystem() override;
 
-  virtual void ConstructOperator() override;
+  void ConstructOperator() override;
 
-  virtual void RegisterGridFunctions() override;
+  void RegisterGridFunctions() override;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
 protected:
   const std::string _alpha_coef_name;
@@ -35,11 +35,11 @@ class CurlCurlEquationSystem : public TimeDependentEquationSystem
 public:
   CurlCurlEquationSystem(const hephaestus::InputParameters & params);
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
+  void Init(hephaestus::GridFunctions & gridfunctions,
                     const hephaestus::FESpaces & fespaces,
                     hephaestus::BCMap & bc_map,
                     hephaestus::Coefficients & coefficients) override;
-  virtual void addKernels() override;
+  void addKernels() override;
 
   std::string h_curl_var_name, alpha_coef_name, beta_coef_name, dtalpha_coef_name;
 };
@@ -55,7 +55,7 @@ public:
                 hephaestus::Sources & sources,
                 hephaestus::InputParameters & solver_options);
 
-  ~HCurlOperator() override {}
+  ~HCurlOperator() override = default;
 
   void ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
 };

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
@@ -21,7 +21,7 @@ namespace hephaestus
 
 MagnetostaticFormulation::MagnetostaticFormulation(
     const std::string & magnetic_reluctivity_name,
-    std::string  magnetic_permeability_name,
+    std::string magnetic_permeability_name,
     const std::string & magnetic_vector_potential_name)
   : StaticsFormulation(magnetic_reluctivity_name, magnetic_vector_potential_name),
     _magnetic_permeability_name(std::move(magnetic_permeability_name))

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
@@ -14,15 +14,17 @@
 
 #include "magnetostatic_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
 MagnetostaticFormulation::MagnetostaticFormulation(
     const std::string & magnetic_reluctivity_name,
-    const std::string & magnetic_permeability_name,
+    std::string  magnetic_permeability_name,
     const std::string & magnetic_vector_potential_name)
   : StaticsFormulation(magnetic_reluctivity_name, magnetic_vector_potential_name),
-    _magnetic_permeability_name(magnetic_permeability_name)
+    _magnetic_permeability_name(std::move(magnetic_permeability_name))
 {
 }
 

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
@@ -10,7 +10,7 @@ class MagnetostaticFormulation : public hephaestus::StaticsFormulation
 {
 public:
   MagnetostaticFormulation(const std::string & magnetic_reluctivity_name,
-                           std::string  magnetic_permeability_name,
+                           std::string magnetic_permeability_name,
                            const std::string & magnetic_vector_potential_name);
 
   ~MagnetostaticFormulation() override = default;
@@ -23,8 +23,8 @@ public:
 
   // Enable auxiliary calculation of F ∈ L2
   void registerLorentzForceDensityAux(const std::string & f_field_name,
-                                              const std::string & b_field_name,
-                                              const std::string & j_field_name) override;
+                                      const std::string & b_field_name,
+                                      const std::string & j_field_name) override;
 
   void RegisterCoefficients() override;
 

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
@@ -10,23 +10,23 @@ class MagnetostaticFormulation : public hephaestus::StaticsFormulation
 {
 public:
   MagnetostaticFormulation(const std::string & magnetic_reluctivity_name,
-                           const std::string & magnetic_permeability_name,
+                           std::string  magnetic_permeability_name,
                            const std::string & magnetic_vector_potential_name);
 
-  ~MagnetostaticFormulation() override {}
+  ~MagnetostaticFormulation() override = default;
 
   // Enable auxiliary calculation of B ∈ H(div)
-  virtual void registerMagneticFluxDensityAux(const std::string & b_field_name) override;
+  void registerMagneticFluxDensityAux(const std::string & b_field_name) override;
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  virtual void registerMagneticFieldAux(const std::string & h_field_name) override;
+  void registerMagneticFieldAux(const std::string & h_field_name) override;
 
   // Enable auxiliary calculation of F ∈ L2
-  virtual void registerLorentzForceDensityAux(const std::string & f_field_name,
+  void registerLorentzForceDensityAux(const std::string & f_field_name,
                                               const std::string & b_field_name,
                                               const std::string & j_field_name) override;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
 protected:
   const std::string _magnetic_permeability_name;

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -32,9 +32,8 @@
 namespace hephaestus
 {
 
-StaticsFormulation::StaticsFormulation(std::string  alpha_coef_name,
-                                       std::string  h_curl_var_name)
-  :  _alpha_coef_name(std::move(alpha_coef_name)), _h_curl_var_name(std::move(h_curl_var_name))
+StaticsFormulation::StaticsFormulation(std::string alpha_coef_name, std::string h_curl_var_name)
+  : _alpha_coef_name(std::move(alpha_coef_name)), _h_curl_var_name(std::move(h_curl_var_name))
 {
 }
 

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -27,12 +27,14 @@
 // b1(u') = (s0, u') + <(α∇×u) × n, u'>
 #include "statics_formulation.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
-StaticsFormulation::StaticsFormulation(const std::string & alpha_coef_name,
-                                       const std::string & h_curl_var_name)
-  : SteadyStateEMFormulation(), _alpha_coef_name(alpha_coef_name), _h_curl_var_name(h_curl_var_name)
+StaticsFormulation::StaticsFormulation(std::string  alpha_coef_name,
+                                       std::string  h_curl_var_name)
+  :  _alpha_coef_name(std::move(alpha_coef_name)), _h_curl_var_name(std::move(h_curl_var_name))
 {
 }
 

--- a/src/formulations/Magnetostatic/statics_formulation.hpp
+++ b/src/formulations/Magnetostatic/statics_formulation.hpp
@@ -10,15 +10,15 @@ namespace hephaestus
 class StaticsFormulation : public SteadyStateEMFormulation
 {
 public:
-  StaticsFormulation(const std::string & alpha_coef_name, const std::string & h_curl_var_name);
+  StaticsFormulation(std::string alpha_coef_name, std::string h_curl_var_name);
 
-  ~StaticsFormulation() override {}
+  ~StaticsFormulation() override = default;
 
-  virtual void ConstructOperator() override;
+  void ConstructOperator() override;
 
-  virtual void RegisterGridFunctions() override;
+  void RegisterGridFunctions() override;
 
-  virtual void RegisterCoefficients() override;
+  void RegisterCoefficients() override;
 
 protected:
   const std::string _alpha_coef_name;
@@ -36,11 +36,11 @@ public:
                   hephaestus::Sources & sources,
                   hephaestus::InputParameters & solver_options);
 
-  ~StaticsOperator(){};
+  ~StaticsOperator() override = default;
 
-  virtual void SetGridFunctions() override;
-  virtual void Init(mfem::Vector & X) override;
-  virtual void Solve(mfem::Vector & X) override;
+  void SetGridFunctions() override;
+  void Init(mfem::Vector & X) override;
+  void Solve(mfem::Vector & X) override;
 
 private:
   std::string h_curl_var_name, stiffness_coef_name;

--- a/src/formulations/complex_em_formulation_interface.hpp
+++ b/src/formulations/complex_em_formulation_interface.hpp
@@ -8,7 +8,7 @@ namespace hephaestus
 class ComplexEMFormulationInterface
 {
 public:
-  ComplexEMFormulationInterface(){};
+  ComplexEMFormulationInterface() = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
   virtual void registerCurrentDensityAux(const std::string & j_field_real_name,

--- a/src/formulations/em_formulation_interface.hpp
+++ b/src/formulations/em_formulation_interface.hpp
@@ -8,7 +8,7 @@ namespace hephaestus
 class EMFormulationInterface
 {
 public:
-  EMFormulationInterface(){};
+  EMFormulationInterface() = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
   virtual void registerCurrentDensityAux(const std::string & j_field_name)

--- a/src/formulations/equation_system_operator.hpp
+++ b/src/formulations/equation_system_operator.hpp
@@ -18,8 +18,7 @@ public:
                          hephaestus::Coefficients & coefficients,
                          hephaestus::Sources & sources,
                          hephaestus::InputParameters & solver_options)
-    : myid_(0),
-      num_procs_(1),
+    : 
       pmesh_(&pmesh),
       _fespaces(fespaces),
       _gridfunctions(gridfunctions),
@@ -28,7 +27,7 @@ public:
       _coefficients(coefficients),
       _solver_options(solver_options){};
 
-  ~EquationSystemOperator() override {}
+  ~EquationSystemOperator() override = default;
 
   virtual void SetGridFunctions();
   virtual void Init(mfem::Vector & X);
@@ -48,8 +47,8 @@ public:
 
   std::vector<mfem::ParGridFunction *> local_test_vars;
 
-  int myid_;
-  int num_procs_;
+  int myid_{0};
+  int num_procs_{1};
   mfem::ParMesh * pmesh_;
   hephaestus::FESpaces & _fespaces;
   hephaestus::GridFunctions & _gridfunctions;

--- a/src/formulations/equation_system_operator.hpp
+++ b/src/formulations/equation_system_operator.hpp
@@ -18,8 +18,7 @@ public:
                          hephaestus::Coefficients & coefficients,
                          hephaestus::Sources & sources,
                          hephaestus::InputParameters & solver_options)
-    : 
-      pmesh_(&pmesh),
+    : pmesh_(&pmesh),
       _fespaces(fespaces),
       _gridfunctions(gridfunctions),
       _bc_map(bc_map),

--- a/src/formulations/frequency_domain_em_formulation.cpp
+++ b/src/formulations/frequency_domain_em_formulation.cpp
@@ -3,6 +3,6 @@
 namespace hephaestus
 {
 
-FrequencyDomainEMFormulation::FrequencyDomainEMFormulation(){};
+FrequencyDomainEMFormulation::FrequencyDomainEMFormulation() = default;
 
 } // namespace hephaestus

--- a/src/formulations/frequency_domain_em_formulation.hpp
+++ b/src/formulations/frequency_domain_em_formulation.hpp
@@ -11,7 +11,7 @@ class FrequencyDomainEMFormulation : public hephaestus::SteadyStateProblemBuilde
 {
 public:
   FrequencyDomainEMFormulation();
-  ~FrequencyDomainEMFormulation() override{};
+  ~FrequencyDomainEMFormulation() override = default;
 
 protected:
   mfem::ConstantCoefficient * freqCoef{nullptr};

--- a/src/formulations/steady_state_em_formulation.cpp
+++ b/src/formulations/steady_state_em_formulation.cpp
@@ -3,6 +3,6 @@
 namespace hephaestus
 {
 
-SteadyStateEMFormulation::SteadyStateEMFormulation(){};
+SteadyStateEMFormulation::SteadyStateEMFormulation() = default;
 
 } // namespace hephaestus

--- a/src/formulations/steady_state_em_formulation.hpp
+++ b/src/formulations/steady_state_em_formulation.hpp
@@ -11,6 +11,6 @@ class SteadyStateEMFormulation : public hephaestus::SteadyStateProblemBuilder,
 {
 public:
   SteadyStateEMFormulation();
-  ~SteadyStateEMFormulation() override {}
+  ~SteadyStateEMFormulation() override = default;
 };
 } // namespace hephaestus

--- a/src/formulations/time_domain_em_formulation.cpp
+++ b/src/formulations/time_domain_em_formulation.cpp
@@ -52,6 +52,6 @@ namespace hephaestus
 //   }
 // }
 
-TimeDomainEMFormulation::TimeDomainEMFormulation() : TimeDomainProblemBuilder(){};
+TimeDomainEMFormulation::TimeDomainEMFormulation()  = default;;
 
 } // namespace hephaestus

--- a/src/formulations/time_domain_em_formulation.cpp
+++ b/src/formulations/time_domain_em_formulation.cpp
@@ -52,6 +52,7 @@ namespace hephaestus
 //   }
 // }
 
-TimeDomainEMFormulation::TimeDomainEMFormulation()  = default;;
+TimeDomainEMFormulation::TimeDomainEMFormulation() = default;
+;
 
 } // namespace hephaestus

--- a/src/formulations/time_domain_em_formulation.hpp
+++ b/src/formulations/time_domain_em_formulation.hpp
@@ -11,6 +11,6 @@ class TimeDomainEMFormulation : public hephaestus::TimeDomainProblemBuilder,
 {
 public:
   TimeDomainEMFormulation();
-  ~TimeDomainEMFormulation() override {}
+  ~TimeDomainEMFormulation() override = default;
 };
 } // namespace hephaestus

--- a/src/formulations/time_domain_equation_system_operator.hpp
+++ b/src/formulations/time_domain_equation_system_operator.hpp
@@ -24,8 +24,7 @@ public:
                                    hephaestus::Coefficients & coefficients,
                                    hephaestus::Sources & sources,
                                    hephaestus::InputParameters & solver_options)
-    : myid_(0),
-      num_procs_(1),
+    : 
       pmesh_(&pmesh),
       _fespaces(fespaces),
       _gridfunctions(gridfunctions),
@@ -34,11 +33,11 @@ public:
       _coefficients(coefficients),
       _solver_options(solver_options){};
 
-  ~TimeDomainEquationSystemOperator() override {}
+  ~TimeDomainEquationSystemOperator() override = default;
 
   virtual void SetGridFunctions();
   virtual void Init(mfem::Vector & X);
-  virtual void
+  void
   ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
   void SetEquationSystem(hephaestus::TimeDependentEquationSystem * equation_system);
 
@@ -57,8 +56,8 @@ public:
 
   hephaestus::TimeDependentEquationSystem * _equation_system;
 
-  int myid_;
-  int num_procs_;
+  int myid_{0};
+  int num_procs_{1};
   mfem::ParMesh * pmesh_;
   hephaestus::FESpaces & _fespaces;
   hephaestus::GridFunctions & _gridfunctions;

--- a/src/formulations/time_domain_equation_system_operator.hpp
+++ b/src/formulations/time_domain_equation_system_operator.hpp
@@ -24,8 +24,7 @@ public:
                                    hephaestus::Coefficients & coefficients,
                                    hephaestus::Sources & sources,
                                    hephaestus::InputParameters & solver_options)
-    : 
-      pmesh_(&pmesh),
+    : pmesh_(&pmesh),
       _fespaces(fespaces),
       _gridfunctions(gridfunctions),
       _bc_map(bc_map),
@@ -37,8 +36,7 @@ public:
 
   virtual void SetGridFunctions();
   virtual void Init(mfem::Vector & X);
-  void
-  ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
+  void ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
   void SetEquationSystem(hephaestus::TimeDependentEquationSystem * equation_system);
 
   mfem::Array<int> true_offsets, block_trueOffsets;

--- a/src/io/inputs.hpp
+++ b/src/io/inputs.hpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <utility>
 
 #include "boundary_conditions.hpp"
 #include "coefficients.hpp"
@@ -18,11 +19,11 @@ protected:
   std::map<std::string, std::any> params;
 
 public:
-  InputParameters(){};
-  InputParameters(std::map<std::string, std::any> _params) : params(_params){};
+  InputParameters() = default;
+  InputParameters(std::map<std::string, std::any> _params) : params(std::move(_params)){};
   void SetParam(std::string param_name, std::any value) { params[param_name] = value; };
   template <typename T>
-  T GetParam(std::string param_name) const
+  [[nodiscard]] [[nodiscard]] T GetParam(std::string param_name) const
   {
     T param;
     try
@@ -36,7 +37,8 @@ public:
     return param;
   };
   template <typename T>
-  T GetOptionalParam(std::string param_name, T value) const
+  [[nodiscard]] [[nodiscard]] [[nodiscard]] T GetOptionalParam(std::string param_name,
+                                                               T value) const
   {
     T param;
     try

--- a/src/io/outputs.hpp
+++ b/src/io/outputs.hpp
@@ -95,17 +95,17 @@ private:
   // Register fields (gridfunctions) to write to DataCollections
   void RegisterOutputFields()
   {
-    for (auto output = begin(); output != end(); ++output)
+    for (auto & output : *this)
     {
-      auto const & dc_(output->second);
+      auto const & dc_(output.second);
       mfem::ParMesh * pmesh_(_gridfunctions->begin()->second->ParFESpace()->GetParMesh());
       dc_->SetMesh(pmesh_);
 
       if (_output_field_names.empty())
       {
-        for (auto var = _gridfunctions->begin(); var != _gridfunctions->end(); ++var)
+        for (auto & _gridfunction : *_gridfunctions)
         {
-          dc_->RegisterField(var->first, var->second);
+          dc_->RegisterField(_gridfunction.first, _gridfunction.second);
         }
       }
       else
@@ -122,9 +122,9 @@ private:
   void WriteOutputFields(double t)
   {
     // Write fields to disk
-    for (auto output = begin(); output != end(); ++output)
+    for (auto & output : *this)
     {
-      auto const & dc_(output->second);
+      auto const & dc_(output.second);
       dc_->SetCycle(_cycle);
       dc_->SetTime(t);
       dc_->Save();
@@ -150,10 +150,10 @@ private:
       std::cout << "Opening GLVis sockets." << std::endl;
     }
 
-    for (auto var = _gridfunctions->begin(); var != _gridfunctions->end(); ++var)
+    for (auto & _gridfunction : *_gridfunctions)
     {
-      socks_[var->first] = new mfem::socketstream;
-      socks_[var->first]->precision(8);
+      socks_[_gridfunction.first] = new mfem::socketstream;
+      socks_[_gridfunction.first]->precision(8);
     }
 
     if (_my_rank == 0)
@@ -172,13 +172,13 @@ private:
     int Ww = 350, Wh = 350;             // window size
     int offx = Ww + 10, offy = Wh + 45; // window offsets
 
-    for (auto var = _gridfunctions->begin(); var != _gridfunctions->end(); ++var)
+    for (auto & _gridfunction : *_gridfunctions)
     {
-      mfem::common::VisualizeField(*socks_[var->first],
+      mfem::common::VisualizeField(*socks_[_gridfunction.first],
                                    vishost,
                                    visport,
-                                   *(var->second),
-                                   (var->first).c_str(),
+                                   *(_gridfunction.second),
+                                   (_gridfunction.first).c_str(),
                                    Wx,
                                    Wy,
                                    Ww,

--- a/src/kernels/curl_curl_kernel.hpp
+++ b/src/kernels/curl_curl_kernel.hpp
@@ -12,13 +12,13 @@ class CurlCurlKernel : public Kernel<mfem::ParBilinearForm>
 public:
   CurlCurlKernel(const hephaestus::InputParameters & params);
 
-  ~CurlCurlKernel() override{};
+  ~CurlCurlKernel() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
-  virtual void Apply(mfem::ParBilinearForm * blf) override;
+  void Init(hephaestus::GridFunctions & gridfunctions,
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
+  void Apply(mfem::ParBilinearForm * blf) override;
   std::string coef_name;
   mfem::Coefficient * coef;
 };

--- a/src/kernels/diffusion_kernel.hpp
+++ b/src/kernels/diffusion_kernel.hpp
@@ -15,9 +15,9 @@ public:
   ~DiffusionKernel() override = default;
 
   void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParBilinearForm * blf) override;
 
   std::string coef_name;

--- a/src/kernels/diffusion_kernel.hpp
+++ b/src/kernels/diffusion_kernel.hpp
@@ -12,13 +12,13 @@ class DiffusionKernel : public Kernel<mfem::ParBilinearForm>
 public:
   DiffusionKernel(const hephaestus::InputParameters & params);
 
-  ~DiffusionKernel() override {}
+  ~DiffusionKernel() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
+  void Init(hephaestus::GridFunctions & gridfunctions,
                     const hephaestus::FESpaces & fespaces,
                     hephaestus::BCMap & bc_map,
                     hephaestus::Coefficients & coefficients) override;
-  virtual void Apply(mfem::ParBilinearForm * blf) override;
+  void Apply(mfem::ParBilinearForm * blf) override;
 
   std::string coef_name;
   mfem::Coefficient * coef{nullptr};

--- a/src/kernels/kernel_base.hpp
+++ b/src/kernels/kernel_base.hpp
@@ -11,8 +11,8 @@ template <typename T>
 class Kernel
 {
 public:
-  Kernel() {}
-  virtual ~Kernel(){};
+  Kernel() = default;
+  virtual ~Kernel() = default;
 
   Kernel(const hephaestus::InputParameters & params){};
   virtual void Init(hephaestus::GridFunctions & gridfunctions,

--- a/src/kernels/mixed_vector_gradient_kernel.hpp
+++ b/src/kernels/mixed_vector_gradient_kernel.hpp
@@ -12,13 +12,13 @@ class MixedVectorGradientKernel : public Kernel<mfem::ParMixedBilinearForm>
 public:
   MixedVectorGradientKernel(const hephaestus::InputParameters & params);
 
-  ~MixedVectorGradientKernel() override{};
+  ~MixedVectorGradientKernel() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
-  virtual void Apply(mfem::ParMixedBilinearForm * mblf) override;
+  void Init(hephaestus::GridFunctions & gridfunctions,
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
+  void Apply(mfem::ParMixedBilinearForm * mblf) override;
   std::string coef_name;
   mfem::Coefficient * coef;
 };

--- a/src/kernels/vector_fe_mass_kernel.hpp
+++ b/src/kernels/vector_fe_mass_kernel.hpp
@@ -12,13 +12,13 @@ class VectorFEMassKernel : public Kernel<mfem::ParBilinearForm>
 public:
   VectorFEMassKernel(const hephaestus::InputParameters & params);
 
-  ~VectorFEMassKernel() override{};
+  ~VectorFEMassKernel() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
-  virtual void Apply(mfem::ParBilinearForm * blf) override;
+  void Init(hephaestus::GridFunctions & gridfunctions,
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
+  void Apply(mfem::ParBilinearForm * blf) override;
   std::string coef_name;
   mfem::Coefficient * coef;
 };

--- a/src/kernels/vector_fe_weak_divergence_kernel.hpp
+++ b/src/kernels/vector_fe_weak_divergence_kernel.hpp
@@ -12,13 +12,13 @@ class VectorFEWeakDivergenceKernel : public Kernel<mfem::ParMixedBilinearForm>
 public:
   VectorFEWeakDivergenceKernel(const hephaestus::InputParameters & params);
 
-  ~VectorFEWeakDivergenceKernel() override{};
+  ~VectorFEWeakDivergenceKernel() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
-  virtual void Apply(mfem::ParMixedBilinearForm * mblf) override;
+  void Init(hephaestus::GridFunctions & gridfunctions,
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
+  void Apply(mfem::ParMixedBilinearForm * mblf) override;
   std::string coef_name;
   mfem::Coefficient * coef;
 };

--- a/src/kernels/weak_curl_curl_kernel.hpp
+++ b/src/kernels/weak_curl_curl_kernel.hpp
@@ -12,13 +12,13 @@ class WeakCurlCurlKernel : public Kernel<mfem::ParLinearForm>
 public:
   WeakCurlCurlKernel(const hephaestus::InputParameters & params);
 
-  ~WeakCurlCurlKernel() override{};
+  ~WeakCurlCurlKernel() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
-  virtual void Apply(mfem::ParLinearForm * lf) override;
+  void Init(hephaestus::GridFunctions & gridfunctions,
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
+  void Apply(mfem::ParLinearForm * lf) override;
 
   std::string coupled_gf_name;
   std::string coef_name;

--- a/src/kernels/weak_curl_kernel.hpp
+++ b/src/kernels/weak_curl_kernel.hpp
@@ -12,13 +12,13 @@ class WeakCurlKernel : public Kernel<mfem::ParLinearForm>
 public:
   WeakCurlKernel(const hephaestus::InputParameters & params);
 
-  ~WeakCurlKernel() override{};
+  ~WeakCurlKernel() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients) override;
-  virtual void Apply(mfem::ParLinearForm * lf) override;
+  void Init(hephaestus::GridFunctions & gridfunctions,
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override;
+  void Apply(mfem::ParLinearForm * lf) override;
 
   std::string hcurl_gf_name, hdiv_gf_name;
   std::string coef_name;

--- a/src/named_fields_map/named_fields_map.hpp
+++ b/src/named_fields_map/named_fields_map.hpp
@@ -58,7 +58,10 @@ public:
   }
 
   /// Predicate to check if a field is associated with name @a field_name.
-  [[nodiscard]] inline bool Has(const std::string & field_name) const { return find(field_name) != end(); }
+  [[nodiscard]] inline bool Has(const std::string & field_name) const
+  {
+    return find(field_name) != end();
+  }
 
   /// Get a pointer to the field associated with name @a field_name.
   [[nodiscard]] inline T * Get(const std::string & field_name) const

--- a/src/named_fields_map/named_fields_map.hpp
+++ b/src/named_fields_map/named_fields_map.hpp
@@ -2,6 +2,9 @@
 #include <map>
 #include <set>
 #include <string>
+#include <memory>
+#include <vector>
+#include <mfem.hpp>
 
 namespace hephaestus
 {
@@ -74,7 +77,10 @@ public:
       if (Has(key))
         values.push_back(Get(key));
       else
-        MFEM_ABORT("Key " << key << " not found in NamedFieldsMap.");
+      {
+        std::string key_not_found_msg("Key " + key + " not found in NamedFieldsMap.");
+        MFEM_ABORT(key_not_found_msg);
+      }
     }
 
     values.shrink_to_fit();

--- a/src/named_fields_map/named_fields_map.hpp
+++ b/src/named_fields_map/named_fields_map.hpp
@@ -14,9 +14,9 @@ template <typename T>
 class NamedFieldsMap
 {
 public:
-  typedef std::map<std::string, T *> MapType;
-  typedef typename MapType::iterator iterator;
-  typedef typename MapType::const_iterator const_iterator;
+  using MapType = std::map<std::string, T *>;
+  using iterator = typename MapType::iterator;
+  using const_iterator = typename MapType::const_iterator;
 
   /// Default initializer.
   NamedFieldsMap() = default;
@@ -58,12 +58,12 @@ public:
   }
 
   /// Predicate to check if a field is associated with name @a field_name.
-  inline bool Has(const std::string & field_name) const { return find(field_name) != end(); }
+  [[nodiscard]] inline bool Has(const std::string & field_name) const { return find(field_name) != end(); }
 
   /// Get a pointer to the field associated with name @a field_name.
-  inline T * Get(const std::string & field_name) const
+  [[nodiscard]] inline T * Get(const std::string & field_name) const
   {
-    const_iterator it = find(field_name);
+    auto it = find(field_name);
     return it != _field_map.end() ? it->second : nullptr;
   }
 
@@ -91,31 +91,31 @@ public:
   inline MapType & GetMap() { return _field_map; }
 
   /// Returns const-reference to field map.
-  inline const MapType & GetMap() const { return _field_map; }
+  [[nodiscard]] inline const MapType & GetMap() const { return _field_map; }
 
   /// Returns a begin iterator to the registered fields.
   inline iterator begin() { return _field_map.begin(); }
 
   /// Returns a begin const iterator to the registered fields.
-  inline const_iterator begin() const { return _field_map.begin(); }
+  [[nodiscard]] inline const_iterator begin() const { return _field_map.begin(); }
 
   /// Returns an end iterator to the registered fields.
   inline iterator end() { return _field_map.end(); }
 
   /// Returns an end const iterator to the registered fields.
-  inline const_iterator end() const { return _field_map.end(); }
+  [[nodiscard]] inline const_iterator end() const { return _field_map.end(); }
 
   /// Returns an iterator to the field @a field_name.
   inline iterator find(const std::string & field_name) { return _field_map.find(field_name); }
 
   /// Returns a const iterator to the field @a field_name.
-  inline const_iterator find(const std::string & field_name) const
+  [[nodiscard]] inline const_iterator find(const std::string & field_name) const
   {
     return _field_map.find(field_name);
   }
 
   /// Returns the number of registered fields.
-  inline int NumFields() const { return _field_map.size(); }
+  [[nodiscard]] inline int NumFields() const { return _field_map.size(); }
 
 protected:
   /// Check for double-registration of a field. A double-registered field may

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -93,7 +93,7 @@ ProblemBuilder::AddFESpace(std::string fespace_name, std::string fec_name, int v
     {
       MFEM_ABORT("ParMesh not found when trying to add " << fespace_name << " to fespaces.");
     }
-    mfem::ParFiniteElementSpace * pfes = new mfem::ParFiniteElementSpace(
+    auto * pfes = new mfem::ParFiniteElementSpace(
         GetProblem()->pmesh.get(), GetProblem()->fecs.Get(fec_name), vdim, ordering);
 
     GetProblem()->fespaces.Register(fespace_name, pfes, true);
@@ -117,7 +117,7 @@ ProblemBuilder::AddGridFunction(std::string gridfunction_name, std::string fespa
                           << " associated with it into gridfunctions. Please add " << fespace_name
                           << " to fespaces before adding this gridfunction.");
   }
-  mfem::ParGridFunction * gridfunc = new mfem::ParGridFunction(fespace);
+  auto * gridfunc = new mfem::ParGridFunction(fespace);
   *gridfunc = 0.0;
 
   GetProblem()->gridfunctions.Register(gridfunction_name, gridfunc, true);

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -46,10 +46,10 @@ private:
   virtual hephaestus::Problem * GetProblem() = 0;
 
 public:
-  ProblemBuilder(){};
+  ProblemBuilder() = default;
 
   // Virtual destructor required to prevent leaks.
-  virtual ~ProblemBuilder() {}
+  virtual ~ProblemBuilder() = default;
 
   void SetMesh(std::shared_ptr<mfem::ParMesh> pmesh);
   void SetFESpaces(hephaestus::FESpaces & fespaces);

--- a/src/problem_builders/steady_state_problem_builder.hpp
+++ b/src/problem_builders/steady_state_problem_builder.hpp
@@ -11,10 +11,10 @@ public:
   std::unique_ptr<hephaestus::EquationSystemOperator> eq_sys_operator{nullptr};
 
   SteadyStateProblem() = default;
-  ~SteadyStateProblem() override {}
+  ~SteadyStateProblem() override = default;
 
-  virtual hephaestus::EquationSystem * GetEquationSystem() { return eq_sys.get(); };
-  virtual hephaestus::EquationSystemOperator * GetOperator() { return eq_sys_operator.get(); };
+  hephaestus::EquationSystem * GetEquationSystem() override { return eq_sys.get(); };
+  hephaestus::EquationSystemOperator * GetOperator() override { return eq_sys_operator.get(); };
 };
 
 // Builder class of a frequency-domain problem.
@@ -23,36 +23,36 @@ class SteadyStateProblemBuilder : public hephaestus::ProblemBuilder
 public:
   SteadyStateProblemBuilder() : problem(std::make_unique<hephaestus::SteadyStateProblem>()){};
 
-  ~SteadyStateProblemBuilder() override {}
+  ~SteadyStateProblemBuilder() override = default;
 
   virtual std::unique_ptr<hephaestus::SteadyStateProblem> ReturnProblem()
   {
     return std::move(problem);
   };
 
-  virtual void RegisterFESpaces() override{};
+  void RegisterFESpaces() override{};
 
-  virtual void RegisterGridFunctions() override{};
+  void RegisterGridFunctions() override{};
 
-  virtual void RegisterAuxSolvers() override{};
+  void RegisterAuxSolvers() override{};
 
-  virtual void RegisterCoefficients() override{};
+  void RegisterCoefficients() override{};
 
-  virtual void InitializeKernels() override;
+  void InitializeKernels() override;
 
-  virtual void ConstructEquationSystem() override{};
+  void ConstructEquationSystem() override{};
 
-  virtual void ConstructOperator() override;
+  void ConstructOperator() override;
 
-  virtual void ConstructState() override;
+  void ConstructState() override;
 
-  virtual void ConstructSolver() override{};
+  void ConstructSolver() override{};
 
 protected:
   std::unique_ptr<hephaestus::SteadyStateProblem> problem{nullptr};
   mfem::ConstantCoefficient oneCoef{1.0};
 
-  virtual hephaestus::SteadyStateProblem * GetProblem() override { return problem.get(); };
+  hephaestus::SteadyStateProblem * GetProblem() override { return problem.get(); };
 };
 
 } // namespace hephaestus

--- a/src/problem_builders/time_domain_problem_builder.hpp
+++ b/src/problem_builders/time_domain_problem_builder.hpp
@@ -15,11 +15,11 @@ public:
   TimeDomainProblem() = default;
   ~TimeDomainProblem() override;
 
-  virtual hephaestus::TimeDependentEquationSystem * GetEquationSystem()
+  hephaestus::TimeDependentEquationSystem * GetEquationSystem() override
   {
     return td_equation_system.get();
   };
-  virtual hephaestus::TimeDomainEquationSystemOperator * GetOperator()
+  hephaestus::TimeDomainEquationSystemOperator * GetOperator() override
   {
     return td_operator.get();
   };
@@ -31,7 +31,7 @@ class TimeDomainProblemBuilder : public hephaestus::ProblemBuilder
 public:
   TimeDomainProblemBuilder() : problem(std::make_unique<hephaestus::TimeDomainProblem>()){};
 
-  ~TimeDomainProblemBuilder() override {}
+  ~TimeDomainProblemBuilder() override = default;
 
   virtual std::unique_ptr<hephaestus::TimeDomainProblem> ReturnProblem()
   {
@@ -42,29 +42,29 @@ public:
   RegisterTimeDerivatives(std::vector<std::string> gridfunction_names,
                           hephaestus::GridFunctions & gridfunctions);
 
-  virtual void RegisterFESpaces() override{};
+  void RegisterFESpaces() override{};
 
-  virtual void RegisterGridFunctions() override;
+  void RegisterGridFunctions() override;
 
-  virtual void RegisterAuxSolvers() override{};
+  void RegisterAuxSolvers() override{};
 
-  virtual void RegisterCoefficients() override{};
+  void RegisterCoefficients() override{};
 
-  virtual void ConstructEquationSystem() override;
+  void ConstructEquationSystem() override;
 
-  virtual void InitializeKernels() override;
+  void InitializeKernels() override;
 
-  virtual void ConstructOperator() override;
+  void ConstructOperator() override;
 
-  virtual void ConstructState() override;
+  void ConstructState() override;
 
-  virtual void ConstructSolver() override;
+  void ConstructSolver() override;
 
 protected:
   std::unique_ptr<hephaestus::TimeDomainProblem> problem{nullptr};
   mfem::ConstantCoefficient oneCoef{1.0};
 
-  virtual hephaestus::TimeDomainProblem * GetProblem() override { return problem.get(); };
+  hephaestus::TimeDomainProblem * GetProblem() override { return problem.get(); };
 };
 
 } // namespace hephaestus

--- a/src/sources/closed_coil.cpp
+++ b/src/sources/closed_coil.cpp
@@ -27,7 +27,7 @@ pushIfUnique(std::vector<T> & vec, const T el)
 // Base class methods
 
 ClosedCoilSolver::ClosedCoilSolver(const hephaestus::InputParameters & params,
-                                   mfem::Array<int>  coil_dom,
+                                   mfem::Array<int> coil_dom,
                                    const int electrode_face)
   : hcurl_fespace_name_(params.GetParam<std::string>("HCurlFESpaceName")),
     h1_fespace_name_(params.GetParam<std::string>("H1FESpaceName")),
@@ -558,7 +558,7 @@ ClosedCoilSolver::elementCentre(int el, mfem::ParMesh * pm)
 
 // 3D Plane constructor and methods
 
-Plane3D::Plane3D()  
+Plane3D::Plane3D()
 {
   u = std::make_unique<mfem::Vector>(3);
   *u = 0.0;

--- a/src/sources/closed_coil.cpp
+++ b/src/sources/closed_coil.cpp
@@ -1,5 +1,7 @@
 #include "closed_coil.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
@@ -25,7 +27,7 @@ pushIfUnique(std::vector<T> & vec, const T el)
 // Base class methods
 
 ClosedCoilSolver::ClosedCoilSolver(const hephaestus::InputParameters & params,
-                                   const mfem::Array<int> & coil_dom,
+                                   mfem::Array<int>  coil_dom,
                                    const int electrode_face)
   : hcurl_fespace_name_(params.GetParam<std::string>("HCurlFESpaceName")),
     h1_fespace_name_(params.GetParam<std::string>("H1FESpaceName")),
@@ -33,7 +35,7 @@ ClosedCoilSolver::ClosedCoilSolver(const hephaestus::InputParameters & params,
     I_coef_name_(params.GetParam<std::string>("IFuncCoefName")),
     cond_coef_name_(params.GetParam<std::string>("ConductivityCoefName")),
     grad_phi_transfer_(params.GetOptionalParam<bool>("GradPhiTransfer", false)),
-    coil_domains_(coil_dom)
+    coil_domains_(std::move(coil_dom))
 {
   hephaestus::InputParameters default_pars;
   default_pars.SetParam("Tolerance", float(1e-18));
@@ -556,7 +558,7 @@ ClosedCoilSolver::elementCentre(int el, mfem::ParMesh * pm)
 
 // 3D Plane constructor and methods
 
-Plane3D::Plane3D() : d(0)
+Plane3D::Plane3D()  
 {
   u = std::make_unique<mfem::Vector>(3);
   *u = 0.0;

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -15,7 +15,7 @@ class ClosedCoilSolver : public hephaestus::Source
 
 public:
   ClosedCoilSolver(const hephaestus::InputParameters & params,
-                   const mfem::Array<int> & coil_dom,
+                   mfem::Array<int>  coil_dom,
                    const int electrode_face);
 
   // Override virtual Source destructor to avoid leaks.
@@ -131,7 +131,7 @@ public:
 
 private:
   std::unique_ptr<mfem::Vector> u{nullptr};
-  double d;
+  double d{0};
 };
 
 } // namespace hephaestus

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -15,7 +15,7 @@ class ClosedCoilSolver : public hephaestus::Source
 
 public:
   ClosedCoilSolver(const hephaestus::InputParameters & params,
-                   mfem::Array<int>  coil_dom,
+                   mfem::Array<int> coil_dom,
                    const int electrode_face);
 
   // Override virtual Source destructor to avoid leaks.

--- a/src/sources/div_free_source.hpp
+++ b/src/sources/div_free_source.hpp
@@ -10,7 +10,7 @@ public:
   DivFreeSource(const hephaestus::InputParameters & params);
 
   // Override virtual Source destructor to avoid leaks.
-  ~DivFreeSource() override{};
+  ~DivFreeSource() override = default;
 
   void Init(hephaestus::GridFunctions & gridfunctions,
             const hephaestus::FESpaces & fespaces,

--- a/src/sources/open_coil.cpp
+++ b/src/sources/open_coil.cpp
@@ -176,7 +176,7 @@ cleanDivergence(hephaestus::GridFunctions & gfs,
 /////////////////////////////////////////////////////////////////////
 
 OpenCoilSolver::OpenCoilSolver(const hephaestus::InputParameters & params,
-                               mfem::Array<int>  coil_dom,
+                               mfem::Array<int> coil_dom,
                                const std::pair<int, int> electrodes)
   : grad_phi_name_(params.GetParam<std::string>("GradPotentialName")),
     V_gf_name_(params.GetParam<std::string>("PotentialName")),

--- a/src/sources/open_coil.cpp
+++ b/src/sources/open_coil.cpp
@@ -1,5 +1,7 @@
 #include "open_coil.hpp"
 
+#include <utility>
+
 namespace hephaestus
 {
 
@@ -174,14 +176,14 @@ cleanDivergence(hephaestus::GridFunctions & gfs,
 /////////////////////////////////////////////////////////////////////
 
 OpenCoilSolver::OpenCoilSolver(const hephaestus::InputParameters & params,
-                               const mfem::Array<int> & coil_dom,
+                               mfem::Array<int>  coil_dom,
                                const std::pair<int, int> electrodes)
   : grad_phi_name_(params.GetParam<std::string>("GradPotentialName")),
     V_gf_name_(params.GetParam<std::string>("PotentialName")),
     I_coef_name_(params.GetParam<std::string>("IFuncCoefName")),
     cond_coef_name_(params.GetParam<std::string>("ConductivityCoefName")),
     grad_phi_transfer_(params.GetOptionalParam<bool>("GradPhiTransfer", true)),
-    coil_domains_(coil_dom),
+    coil_domains_(std::move(coil_dom)),
     elec_attrs_(electrodes),
     high_src_(highV),
     low_src_(lowV),

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -33,7 +33,7 @@ class OpenCoilSolver : public hephaestus::Source
 
 public:
   OpenCoilSolver(const hephaestus::InputParameters & params,
-                 mfem::Array<int>  coil_dom,
+                 mfem::Array<int> coil_dom,
                  const std::pair<int, int> electrodes);
 
   ~OpenCoilSolver() override;

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -33,10 +33,10 @@ class OpenCoilSolver : public hephaestus::Source
 
 public:
   OpenCoilSolver(const hephaestus::InputParameters & params,
-                 const mfem::Array<int> & coil_dom,
+                 mfem::Array<int>  coil_dom,
                  const std::pair<int, int> electrodes);
 
-  ~OpenCoilSolver();
+  ~OpenCoilSolver() override;
 
   void Init(hephaestus::GridFunctions & gridfunctions,
             const hephaestus::FESpaces & fespaces,

--- a/src/sources/scalar_potential_source.cpp
+++ b/src/sources/scalar_potential_source.cpp
@@ -77,7 +77,7 @@ ScalarPotentialSource::Init(hephaestus::GridFunctions & gridfunctions,
   B0 = std::make_unique<mfem::Vector>();
 }
 
-ScalarPotentialSource::~ScalarPotentialSource() {}
+ScalarPotentialSource::~ScalarPotentialSource() = default;
 
 void
 ScalarPotentialSource::buildM1(mfem::Coefficient * Sigma)

--- a/src/sources/source_base.hpp
+++ b/src/sources/source_base.hpp
@@ -11,17 +11,17 @@ namespace hephaestus
 class Source : public hephaestus::Kernel<mfem::ParLinearForm>
 {
 public:
-  Source(){};
+  Source() = default;
 
   // NB: must be virtual to avoid leaks (ensure correct subclass destructor!)
-  virtual ~Source(){};
+  ~Source() override = default;
 
-  virtual void Init(hephaestus::GridFunctions & gridfunctions,
-                    const hephaestus::FESpaces & fespaces,
-                    hephaestus::BCMap & bc_map,
-                    hephaestus::Coefficients & coefficients){};
+  void Init(hephaestus::GridFunctions & gridfunctions,
+            const hephaestus::FESpaces & fespaces,
+            hephaestus::BCMap & bc_map,
+            hephaestus::Coefficients & coefficients) override{};
 
-  virtual void Apply(mfem::ParLinearForm * lf) override = 0;
+  void Apply(mfem::ParLinearForm * lf) override = 0;
   virtual void SubtractSource(mfem::ParGridFunction * gf) = 0;
 };
 

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -70,8 +70,7 @@ protected:
                     true);
     coefficients.vectors.Register("surface_tangential_dAdt", adotVecCoef, true);
 
-    auto * A_exact =
-        new mfem::VectorFunctionCoefficient(3, A_exact_expr);
+    auto * A_exact = new mfem::VectorFunctionCoefficient(3, A_exact_expr);
     coefficients.vectors.Register("a_exact_coeff", A_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
@@ -93,8 +92,7 @@ protected:
     postprocessors.Register("VectorCoefficientAux", vec_coef_aux, true);
 
     hephaestus::Sources sources;
-    auto * JSrcCoef =
-        new mfem::VectorFunctionCoefficient(3, source_field);
+    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, source_field);
     coefficients.vectors.Register("source", JSrcCoef, true);
     hephaestus::InputParameters div_free_source_params;
     div_free_source_params.SetParam("SourceName", std::string("source"));
@@ -147,14 +145,12 @@ TEST_CASE_METHOD(TestAFormSource, "TestAForm", "[CheckRun]")
                                                                       "magnetic_vector_potential");
 
     auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-    auto coefficients(
-        params.GetParam<hephaestus::Coefficients>("Coefficients"));
+    auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
     //   hephaestus::FESpaces fespaces(
     //       params.GetParam<hephaestus::FESpaces>("FESpaces"));
     //   hephaestus::GridFunctions gridfunctions(
     //       params.GetParam<hephaestus::GridFunctions>("GridFunctions"));
-    auto postprocessors(
-        params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+    auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
     auto sources(params.GetParam<hephaestus::Sources>("Sources"));
     auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
     auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -62,7 +62,7 @@ protected:
         "magnetic_permeability", new mfem::FunctionCoefficient(mu_expr), true);
 
     hephaestus::BCMap bc_map;
-    mfem::VectorFunctionCoefficient * adotVecCoef = new mfem::VectorFunctionCoefficient(3, adot_bc);
+    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, adot_bc);
     bc_map.Register("tangential_dAdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_vector_potential_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -70,7 +70,7 @@ protected:
                     true);
     coefficients.vectors.Register("surface_tangential_dAdt", adotVecCoef, true);
 
-    mfem::VectorFunctionCoefficient * A_exact =
+    auto * A_exact =
         new mfem::VectorFunctionCoefficient(3, A_exact_expr);
     coefficients.vectors.Register("a_exact_coeff", A_exact, true);
 
@@ -87,13 +87,13 @@ protected:
                             new hephaestus::L2ErrorVectorPostprocessor(l2errpostprocparams),
                             true);
 
-    hephaestus::VectorCoefficientAux * vec_coef_aux =
+    auto * vec_coef_aux =
         new hephaestus::VectorCoefficientAux("analytic_vector_potential", "a_exact_coeff");
     vec_coef_aux->SetPriority(-1);
     postprocessors.Register("VectorCoefficientAux", vec_coef_aux, true);
 
     hephaestus::Sources sources;
-    mfem::VectorFunctionCoefficient * JSrcCoef =
+    auto * JSrcCoef =
         new mfem::VectorFunctionCoefficient(3, source_field);
     coefficients.vectors.Register("source", JSrcCoef, true);
     hephaestus::InputParameters div_free_source_params;
@@ -129,7 +129,7 @@ protected:
 TEST_CASE_METHOD(TestAFormSource, "TestAForm", "[CheckRun]")
 {
   hephaestus::InputParameters params(test_params());
-  mfem::ParMesh unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
+  auto unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
 
   int num_conv_refinements = 3;
   for (int par_ref_levels = 0; par_ref_levels < num_conv_refinements; ++par_ref_levels)
@@ -146,18 +146,18 @@ TEST_CASE_METHOD(TestAFormSource, "TestAForm", "[CheckRun]")
                                                                       "electrical_conductivity",
                                                                       "magnetic_vector_potential");
 
-    hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-    hephaestus::Coefficients coefficients(
+    auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+    auto coefficients(
         params.GetParam<hephaestus::Coefficients>("Coefficients"));
     //   hephaestus::FESpaces fespaces(
     //       params.GetParam<hephaestus::FESpaces>("FESpaces"));
     //   hephaestus::GridFunctions gridfunctions(
     //       params.GetParam<hephaestus::GridFunctions>("GridFunctions"));
-    hephaestus::AuxSolvers postprocessors(
+    auto postprocessors(
         params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-    hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-    hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-    hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+    auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+    auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+    auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
         "SolverOptions", hephaestus::InputParameters()));
 
     problem_builder->SetMesh(pmesh);

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -39,7 +39,7 @@ protected:
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
     hephaestus::BCMap bc_map;
-    mfem::VectorFunctionCoefficient * adotVecCoef = new mfem::VectorFunctionCoefficient(3, adot_bc);
+    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, adot_bc);
     bc_map.Register("tangential_dAdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_vector_potential_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -65,7 +65,7 @@ protected:
                                           new mfem::FunctionCoefficient(potential_ground)),
         true);
 
-    mfem::VectorFunctionCoefficient * JSrcCoef =
+    auto * JSrcCoef =
         new mfem::VectorFunctionCoefficient(3, source_current);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(), 1, 1);
@@ -108,13 +108,13 @@ TEST_CASE_METHOD(TestAVFormRod, "TestAVFormRod", "[CheckRun]")
                                                                      "magnetic_vector_potential",
                                                                      "electric_potential");
 
-  hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-  hephaestus::Coefficients coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
-  hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-  hephaestus::AuxSolvers postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-  hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-  hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-  hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+  auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+  auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
+  auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+  auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+  auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+  auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+  auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
       "SolverOptions", hephaestus::InputParameters()));
 
   problem_builder->SetMesh(pmesh);

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -65,8 +65,7 @@ protected:
                                           new mfem::FunctionCoefficient(potential_ground)),
         true);
 
-    auto * JSrcCoef =
-        new mfem::VectorFunctionCoefficient(3, source_current);
+    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, source_current);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(), 1, 1);
 

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -59,7 +59,7 @@ protected:
         "magnetic_permeability", new mfem::FunctionCoefficient(mu_expr), true);
 
     hephaestus::BCMap bc_map;
-    mfem::VectorFunctionCoefficient * adotVecCoef = new mfem::VectorFunctionCoefficient(3, adot_bc);
+    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, adot_bc);
     bc_map.Register("tangential_dAdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_vector_potential_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -71,7 +71,7 @@ protected:
 
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 1;
-    mfem::FunctionCoefficient * ground_coeff = new mfem::FunctionCoefficient(potential_ground);
+    auto * ground_coeff = new mfem::FunctionCoefficient(potential_ground);
     bc_map.Register("ground_potential",
                     new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -79,7 +79,7 @@ protected:
                     true);
     coefficients.scalars.Register("ground_potential", ground_coeff, true);
 
-    mfem::VectorFunctionCoefficient * A_exact =
+    auto * A_exact =
         new mfem::VectorFunctionCoefficient(3, A_exact_expr);
     coefficients.vectors.Register("a_exact_coeff", A_exact, true);
 
@@ -96,7 +96,7 @@ protected:
                             new hephaestus::L2ErrorVectorPostprocessor(l2errpostprocparams),
                             true);
 
-    hephaestus::VectorCoefficientAux * vec_coef_aux =
+    auto * vec_coef_aux =
         new hephaestus::VectorCoefficientAux("analytic_vector_potential", "a_exact_coeff");
     vec_coef_aux->SetPriority(-1);
     postprocessors.Register("VectorCoefficientAux", vec_coef_aux, true);
@@ -104,7 +104,7 @@ protected:
     hephaestus::AuxSolvers preprocessors;
 
     hephaestus::Sources sources;
-    mfem::VectorFunctionCoefficient * JSrcCoef =
+    auto * JSrcCoef =
         new mfem::VectorFunctionCoefficient(3, source_field);
     coefficients.vectors.Register("source", JSrcCoef, true);
     hephaestus::InputParameters div_free_source_params;
@@ -136,7 +136,7 @@ protected:
 TEST_CASE_METHOD(TestAVFormSource, "TestAVFormSource", "[CheckRun]")
 {
   hephaestus::InputParameters params(test_params());
-  mfem::ParMesh unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
+  auto unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
 
   int num_conv_refinements = 3;
   for (int par_ref_levels = 0; par_ref_levels < num_conv_refinements; ++par_ref_levels)
@@ -155,19 +155,19 @@ TEST_CASE_METHOD(TestAVFormSource, "TestAVFormSource", "[CheckRun]")
                                                                        "magnetic_vector_potential",
                                                                        "electric_potential");
 
-    hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-    hephaestus::Coefficients coefficients(
+    auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+    auto coefficients(
         params.GetParam<hephaestus::Coefficients>("Coefficients"));
     //   hephaestus::FESpaces fespaces(
     //       params.GetParam<hephaestus::FESpaces>("FESpaces"));
     //   hephaestus::GridFunctions gridfunctions(
     //       params.GetParam<hephaestus::GridFunctions>("GridFunctions"));
-    hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-    hephaestus::AuxSolvers postprocessors(
+    auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+    auto postprocessors(
         params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-    hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-    hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-    hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+    auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+    auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+    auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
         "SolverOptions", hephaestus::InputParameters()));
 
     problem_builder->SetMesh(pmesh);

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -79,8 +79,7 @@ protected:
                     true);
     coefficients.scalars.Register("ground_potential", ground_coeff, true);
 
-    auto * A_exact =
-        new mfem::VectorFunctionCoefficient(3, A_exact_expr);
+    auto * A_exact = new mfem::VectorFunctionCoefficient(3, A_exact_expr);
     coefficients.vectors.Register("a_exact_coeff", A_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
@@ -104,8 +103,7 @@ protected:
     hephaestus::AuxSolvers preprocessors;
 
     hephaestus::Sources sources;
-    auto * JSrcCoef =
-        new mfem::VectorFunctionCoefficient(3, source_field);
+    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, source_field);
     coefficients.vectors.Register("source", JSrcCoef, true);
     hephaestus::InputParameters div_free_source_params;
     div_free_source_params.SetParam("SourceName", std::string("source"));
@@ -156,15 +154,13 @@ TEST_CASE_METHOD(TestAVFormSource, "TestAVFormSource", "[CheckRun]")
                                                                        "electric_potential");
 
     auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-    auto coefficients(
-        params.GetParam<hephaestus::Coefficients>("Coefficients"));
+    auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
     //   hephaestus::FESpaces fespaces(
     //       params.GetParam<hephaestus::FESpaces>("FESpaces"));
     //   hephaestus::GridFunctions gridfunctions(
     //       params.GetParam<hephaestus::GridFunctions>("GridFunctions"));
     auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-    auto postprocessors(
-        params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+    auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
     auto sources(params.GetParam<hephaestus::Sources>("Sources"));
     auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
     auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -60,7 +60,7 @@ protected:
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
-    mfem::FunctionCoefficient * potential_src = new mfem::FunctionCoefficient(potential_high);
+    auto * potential_src = new mfem::FunctionCoefficient(potential_high);
     bc_map.Register("high_potential",
                     new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal, potential_src),
@@ -138,13 +138,13 @@ TEST_CASE_METHOD(TestComplexAFormRod, "TestComplexAFormRod", "[CheckRun]")
                                                         "magnetic_vector_potential_real",
                                                         "magnetic_vector_potential_imag");
 
-  hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-  hephaestus::Coefficients coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
-  hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-  hephaestus::AuxSolvers postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-  hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-  hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-  hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+  auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+  auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
+  auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+  auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+  auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+  auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+  auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
       "SolverOptions", hephaestus::InputParameters()));
 
   problem_builder->SetMesh(pmesh);

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -144,13 +144,13 @@ TEST_CASE_METHOD(TestComplexERMESMouse, "TestComplexERMESMouse", "[CheckRun]")
                                                         "electric_field_real",
                                                         "electric_field_imag");
 
-  hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-  hephaestus::Coefficients coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
-  hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-  hephaestus::AuxSolvers postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-  hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-  hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-  hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+  auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+  auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
+  auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+  auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+  auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+  auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+  auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
       "SolverOptions", hephaestus::InputParameters()));
 
   problem_builder->SetMesh(pmesh);

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -135,13 +135,13 @@ TEST_CASE_METHOD(TestComplexIrisWaveguide, "TestComplexIrisWaveguide", "[CheckRu
                                                         "electric_field_real",
                                                         "electric_field_imag");
 
-  hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-  hephaestus::Coefficients coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
-  hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-  hephaestus::AuxSolvers postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-  hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-  hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-  hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+  auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+  auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
+  auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+  auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+  auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+  auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+  auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
       "SolverOptions", hephaestus::InputParameters()));
 
   problem_builder->SetMesh(pmesh);

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -109,7 +109,7 @@ protected:
     hephaestus::AuxSolvers preprocessors;
 
     hephaestus::Sources sources;
-    mfem::VectorFunctionCoefficient * JSrcCoef =
+    auto * JSrcCoef =
         new mfem::VectorFunctionCoefficient(3, source_current);
     mfem::Array<mfem::VectorCoefficient *> sourcecoefs(4);
     sourcecoefs[0] = JSrcCoef;
@@ -121,7 +121,7 @@ protected:
     coilsegments[1] = 4;
     coilsegments[2] = 5;
     coilsegments[3] = 6;
-    mfem::PWVectorCoefficient * JSrcRestricted =
+    auto * JSrcRestricted =
         new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
     coefficients.vectors.Register("source", JSrcRestricted, true);
 
@@ -164,13 +164,13 @@ TEST_CASE_METHOD(TestComplexTeam7, "TestComplexTeam7", "[CheckRun]")
   hephaestus::InputParameters params(test_params());
   auto pmesh = std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
-  hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-  hephaestus::Coefficients coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
-  hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-  hephaestus::AuxSolvers postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-  hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-  hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-  hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+  auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+  auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
+  auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+  auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+  auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+  auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+  auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
       "SolverOptions", hephaestus::InputParameters()));
 
   auto problem_builder =

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -109,8 +109,7 @@ protected:
     hephaestus::AuxSolvers preprocessors;
 
     hephaestus::Sources sources;
-    auto * JSrcCoef =
-        new mfem::VectorFunctionCoefficient(3, source_current);
+    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, source_current);
     mfem::Array<mfem::VectorCoefficient *> sourcecoefs(4);
     sourcecoefs[0] = JSrcCoef;
     sourcecoefs[1] = JSrcCoef;
@@ -121,8 +120,7 @@ protected:
     coilsegments[1] = 4;
     coilsegments[2] = 5;
     coilsegments[3] = 6;
-    auto * JSrcRestricted =
-        new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
+    auto * JSrcRestricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
     coefficients.vectors.Register("source", JSrcRestricted, true);
 
     hephaestus::InputParameters div_free_source_params;

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -8,7 +8,7 @@ class CopperConductivityCoefficient : public hephaestus::CoupledCoefficient
 public:
   CopperConductivityCoefficient(const hephaestus::InputParameters & params)
     : hephaestus::CoupledCoefficient(params){};
-  virtual double Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip)
+  double Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip) override
   {
     return 2.0 * M_PI * 10 + 0.001 * (gf->GetValue(T, ip));
   }
@@ -70,7 +70,7 @@ protected:
     preprocessors.Register("CoupledCoefficient", wireConductivity, false);
 
     hephaestus::BCMap bc_map;
-    mfem::VectorFunctionCoefficient * edotVecCoef = new mfem::VectorFunctionCoefficient(3, edot_bc);
+    auto * edotVecCoef = new mfem::VectorFunctionCoefficient(3, edot_bc);
     bc_map.Register("tangential_dEdt",
                     new hephaestus::VectorDirichletBC(
                         std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edotVecCoef),
@@ -81,7 +81,7 @@ protected:
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
-    mfem::FunctionCoefficient * potential_src = new mfem::FunctionCoefficient(potential_high);
+    auto * potential_src = new mfem::FunctionCoefficient(potential_high);
     bc_map.Register("high_potential",
                     new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal, potential_src),
@@ -161,13 +161,13 @@ TEST_CASE_METHOD(TestEBFormCoupled, "TestEBFormCoupled", "[CheckRun]")
                                                                          "electric_field",
                                                                          "magnetic_flux_density");
 
-  hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-  hephaestus::Coefficients coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
-  hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-  hephaestus::AuxSolvers postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-  hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-  hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-  hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+  auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+  auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
+  auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+  auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+  auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+  auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+  auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
       "SolverOptions", hephaestus::InputParameters()));
 
   std::shared_ptr<mfem::ParMesh> pmesh =

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -46,7 +46,7 @@ protected:
     //     true);
 
     hephaestus::BCMap bc_map;
-    mfem::VectorFunctionCoefficient * edotVecCoef = new mfem::VectorFunctionCoefficient(3, edot_bc);
+    auto * edotVecCoef = new mfem::VectorFunctionCoefficient(3, edot_bc);
     bc_map.Register("tangential_dEdt",
                     new hephaestus::VectorDirichletBC(
                         std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edotVecCoef),
@@ -57,7 +57,7 @@ protected:
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
-    mfem::FunctionCoefficient * potential_src = new mfem::FunctionCoefficient(potential_high);
+    auto * potential_src = new mfem::FunctionCoefficient(potential_high);
     bc_map.Register("high_potential",
                     new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal, potential_src),
@@ -129,13 +129,13 @@ TEST_CASE_METHOD(TestEBFormRod, "TestEBFormRod", "[CheckRun]")
                                                                          "electric_field",
                                                                          "magnetic_flux_density");
 
-  hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-  hephaestus::Coefficients coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
-  hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-  hephaestus::AuxSolvers postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-  hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-  hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-  hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+  auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+  auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
+  auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+  auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+  auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+  auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+  auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
       "SolverOptions", hephaestus::InputParameters()));
 
   std::shared_ptr<mfem::ParMesh> pmesh =

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -46,7 +46,7 @@ protected:
     //     true);
 
     hephaestus::BCMap bc_map;
-    mfem::VectorFunctionCoefficient * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, hdot_bc);
+    auto * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, hdot_bc);
     bc_map.Register("tangential_dHdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_field_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -131,13 +131,13 @@ TEST_CASE_METHOD(TestHFormRod, "TestHFormRod", "[CheckRun]")
                                                                     "magnetic_permeability",
                                                                     "magnetic_field");
 
-  hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-  hephaestus::Coefficients coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
-  hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-  hephaestus::AuxSolvers postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-  hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-  hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-  hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+  auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+  auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
+  auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+  auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+  auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+  auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+  auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
       "SolverOptions", hephaestus::InputParameters()));
 
   problem_builder->SetMesh(pmesh);

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -74,12 +74,10 @@ protected:
     coefficients.scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
-    auto * dBdtSrcCoef =
-        new mfem::VectorFunctionCoefficient(3, source_field);
+    auto * dBdtSrcCoef = new mfem::VectorFunctionCoefficient(3, source_field);
     coefficients.vectors.Register("source", dBdtSrcCoef, true);
 
-    auto * H_exact =
-        new mfem::VectorFunctionCoefficient(3, H_exact_expr);
+    auto * H_exact = new mfem::VectorFunctionCoefficient(3, H_exact_expr);
     coefficients.vectors.Register("h_exact_coeff", H_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
@@ -165,15 +163,13 @@ TEST_CASE_METHOD(TestHFormSource, "TestHFormSource", "[CheckRun]")
                                                                       "magnetic_field");
 
     auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-    auto coefficients(
-        params.GetParam<hephaestus::Coefficients>("Coefficients"));
+    auto coefficients(params.GetParam<hephaestus::Coefficients>("Coefficients"));
     //   hephaestus::FESpaces fespaces(
     //       params.GetParam<hephaestus::FESpaces>("FESpaces"));
     //   hephaestus::GridFunctions gridfunctions(
     //       params.GetParam<hephaestus::GridFunctions>("GridFunctions"));
     auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-    auto postprocessors(
-        params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
+    auto postprocessors(params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
     auto sources(params.GetParam<hephaestus::Sources>("Sources"));
     auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
     auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -64,7 +64,7 @@ protected:
         "electrical_conductivity", new mfem::FunctionCoefficient(sigma_expr), true);
 
     hephaestus::BCMap bc_map;
-    mfem::VectorFunctionCoefficient * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, hdot_bc);
+    auto * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, hdot_bc);
     bc_map.Register("tangential_dHdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_field_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -74,11 +74,11 @@ protected:
     coefficients.scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
-    mfem::VectorFunctionCoefficient * dBdtSrcCoef =
+    auto * dBdtSrcCoef =
         new mfem::VectorFunctionCoefficient(3, source_field);
     coefficients.vectors.Register("source", dBdtSrcCoef, true);
 
-    mfem::VectorFunctionCoefficient * H_exact =
+    auto * H_exact =
         new mfem::VectorFunctionCoefficient(3, H_exact_expr);
     coefficients.vectors.Register("h_exact_coeff", H_exact, true);
 
@@ -146,7 +146,7 @@ protected:
 TEST_CASE_METHOD(TestHFormSource, "TestHFormSource", "[CheckRun]")
 {
   hephaestus::InputParameters params(test_params());
-  mfem::ParMesh unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
+  auto unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
 
   int num_conv_refinements = 3;
   for (int par_ref_levels = 0; par_ref_levels < num_conv_refinements; ++par_ref_levels)
@@ -164,19 +164,19 @@ TEST_CASE_METHOD(TestHFormSource, "TestHFormSource", "[CheckRun]")
                                                                       "magnetic_permeability",
                                                                       "magnetic_field");
 
-    hephaestus::BCMap bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
-    hephaestus::Coefficients coefficients(
+    auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));
+    auto coefficients(
         params.GetParam<hephaestus::Coefficients>("Coefficients"));
     //   hephaestus::FESpaces fespaces(
     //       params.GetParam<hephaestus::FESpaces>("FESpaces"));
     //   hephaestus::GridFunctions gridfunctions(
     //       params.GetParam<hephaestus::GridFunctions>("GridFunctions"));
-    hephaestus::AuxSolvers preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
-    hephaestus::AuxSolvers postprocessors(
+    auto preprocessors(params.GetParam<hephaestus::AuxSolvers>("PreProcessors"));
+    auto postprocessors(
         params.GetParam<hephaestus::AuxSolvers>("PostProcessors"));
-    hephaestus::Sources sources(params.GetParam<hephaestus::Sources>("Sources"));
-    hephaestus::Outputs outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
-    hephaestus::InputParameters solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+    auto sources(params.GetParam<hephaestus::Sources>("Sources"));
+    auto outputs(params.GetParam<hephaestus::Outputs>("Outputs"));
+    auto solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
         "SolverOptions", hephaestus::InputParameters()));
 
     problem_builder->SetMesh(pmesh);

--- a/test/unit/test_auxsolvers.cpp
+++ b/test/unit/test_auxsolvers.cpp
@@ -29,22 +29,22 @@ TEST_CASE("AuxSolverTest", "[CheckQueue]")
 
   hephaestus::AuxSolvers auxsolvers;
 
-  DummyAuxSolver * auxsolver1 = new DummyAuxSolver(string_arg1, string_base);
+  auto * auxsolver1 = new DummyAuxSolver(string_arg1, string_base);
   auxsolver1->SetPriority(-1);
   auxsolvers.Register("OneAuxSolver", auxsolver1, true);
 
-  DummyAuxSolver * auxsolver2 = new DummyAuxSolver(string_arg2, string_base);
+  auto * auxsolver2 = new DummyAuxSolver(string_arg2, string_base);
   auxsolvers.Register("AnotherAuxSolver", auxsolver2, true);
 
-  DummyAuxSolver * auxsolver3 = new DummyAuxSolver(string_arg3, string_base);
+  auto * auxsolver3 = new DummyAuxSolver(string_arg3, string_base);
   auxsolver3->SetPriority(3);
   auxsolvers.Register("AThirdAuxSolver", auxsolver3, true);
 
-  DummyAuxSolver * auxsolver4 = new DummyAuxSolver(string_arg4, string_base);
+  auto * auxsolver4 = new DummyAuxSolver(string_arg4, string_base);
   auxsolver4->SetPriority(4);
   auxsolvers.Register("YetAnotherAuxSolver", auxsolver4, true);
 
-  DummyAuxSolver * auxsolver5 = new DummyAuxSolver(string_arg5, string_base);
+  auto * auxsolver5 = new DummyAuxSolver(string_arg5, string_base);
   auxsolver5->SetPriority(4);
   auxsolvers.Register("AFinalAuxSolver", auxsolver5, true);
 

--- a/test/unit/test_inputs.cpp
+++ b/test/unit/test_inputs.cpp
@@ -19,7 +19,7 @@ TEST_CASE("InputParametersTest", "[CheckData]")
 
   REQUIRE(params.GetParam<std::string>("StringParam") == example_string);
 
-  mfem::Array<int> stored_array = params.GetParam<mfem::Array<int>>("ArrayParam");
+  auto stored_array = params.GetParam<mfem::Array<int>>("ArrayParam");
 
   for (int i = 0; i < example_array.Size(); ++i)
     REQUIRE(example_array[i] == stored_array[i]);

--- a/test/unit/test_nlintegrators.cpp
+++ b/test/unit/test_nlintegrators.cpp
@@ -19,9 +19,9 @@ public:
   VectorPowerLawNLFIntegrator(mfem::Coefficient & q) : Q(&q) {}
 
   void AssembleElementGrad(const mfem::FiniteElement & el,
-                                   mfem::ElementTransformation & Ttr,
-                                   const mfem::Vector & elfun,
-                                   mfem::DenseMatrix & elmat) override
+                           mfem::ElementTransformation & Ttr,
+                           const mfem::Vector & elfun,
+                           mfem::DenseMatrix & elmat) override
   {
 
     int nd = el.GetDof();
@@ -61,9 +61,9 @@ public:
   };
 
   void AssembleElementVector(const mfem::FiniteElement & el,
-                                     mfem::ElementTransformation & Ttr,
-                                     const mfem::Vector & elfun,
-                                     mfem::Vector & elvect) override
+                             mfem::ElementTransformation & Ttr,
+                             const mfem::Vector & elfun,
+                             mfem::Vector & elvect) override
   {
     int nd = el.GetDof(), dim = el.GetDim();
 
@@ -133,7 +133,7 @@ public:
     : Operator(blf_->ParFESpace()->TrueVSize()),
       blf(blf_),
       nlf(nlf_),
-      
+
       x1(height),
       ess_tdof_list(ess_tdof_list_){};
 


### PR DESCRIPTION
Adds modernize and readability clang-tidy checks as a pre-commit hook, to enforce consistent code style for future commits.

Clang-tidy checks configured by the `hephaestus/.clang-tidy` configuration file. The full list of available clang-tidy checks is listed [here](https://clang.llvm.org/extra/clang-tidy/checks/list.html) along with reasons for their inclusion. 

Currently, all modernize-* checks with the exception of `modernize-use-trailing-return-type` and `modernize-avoid-c-arrays` will be checked by pre-commit hooks and by the CI. Naming convention checks shall be added to checks in a future PR.