### PR TITLE
Establish and enforce naming conventions with clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,8 +5,8 @@ CheckOptions:
     value:           true
   - key:             readability-identifier-naming.ClassCase
     value:           'CamelCase'
-  # - key:             readability-identifier-naming.MethodCase
-  #   value:           'CamelCase'    
+  - key:             readability-identifier-naming.MethodCase
+    value:           'CamelCase'    
   # - key:             readability-identifier-naming.MemberCase
   #   value:           'lower_case'
   # - key:             readability-identifier-naming.MemberPrefix

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,5 +11,5 @@ CheckOptions:
   #   value:           'lower_case'
   # - key:             readability-identifier-naming.MemberPrefix
   #   value:           '_'
-  # - key:             readability-identifier-naming.LocalVariableCase
-  #   value:           'lower_case'
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           'lower_case'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,9 +7,9 @@ CheckOptions:
     value:           'CamelCase'
   - key:             readability-identifier-naming.MethodCase
     value:           'CamelCase'    
-  # - key:             readability-identifier-naming.MemberCase
-  #   value:           'lower_case'
-  # - key:             readability-identifier-naming.MemberPrefix
-  #   value:           '_'
+  - key:             readability-identifier-naming.MemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.MemberPrefix
+    value:           '_'
   - key:             readability-identifier-naming.LocalVariableCase
     value:           'lower_case'

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -7,13 +7,13 @@ defineCoefficients()
 {
   hephaestus::Coefficients coefficients;
 
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       "magnetic_permeability", new mfem::ConstantCoefficient(M_PI * 4.0e-7), true);
 
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
 
-  coefficients.scalars.Register("I", new mfem::ConstantCoefficient(2742), true);
+  coefficients._scalars.Register("I", new mfem::ConstantCoefficient(2742), true);
 
   return coefficients;
 }

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -87,7 +87,7 @@ main(int argc, char * argv[])
   problem_builder->AddGridFunction(std::string("magnetic_vector_potential"), std::string("HCurl"));
   problem_builder->AddGridFunction(std::string("source_grad_phi"), std::string("HCurl"));
   problem_builder->AddGridFunction(std::string("magnetic_flux_density"), std::string("HDiv"));
-  problem_builder->registerMagneticFluxDensityAux("magnetic_flux_density");
+  problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density");
 
   hephaestus::Coefficients coefficients = defineCoefficients();
   problem_builder->SetCoefficients(coefficients);

--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -8,15 +8,15 @@ source_current(const mfem::Vector & xv, double t, mfem::Vector & J)
   double x0(194e-3);  // Coil centre x coordinate
   double y0(100e-3);  // Coil centre y coordinate
   double a(50e-3);    // Coil thickness
-  double I0(2742);    // Coil current in Ampere-turns
-  double S(2.5e-3);   // Coil cross sectional area
+  double i0(2742);    // Coil current in Ampere-turns
+  double s(2.5e-3);   // Coil cross sectional area
   double freq(200.0); // Frequency in Hz
 
   double x = xv(0);
   double y = xv(1);
 
   // Current density magnitude
-  double Jmag = (I0 / S);
+  double jmag = (i0 / s);
 
   // Calculate x component of current density unit vector
   if (abs(x - x0) < a)
@@ -52,7 +52,7 @@ source_current(const mfem::Vector & xv, double t, mfem::Vector & J)
   J(2) = 0.0;
 
   // Scale by current density magnitude
-  J *= Jmag;
+  J *= jmag;
 }
 
 hephaestus::Coefficients
@@ -84,13 +84,13 @@ defineCoefficients()
   coefficients.scalars.Register(
       "dielectric_permittivity", new mfem::ConstantCoefficient(8.854e-12), true);
 
-  auto JSrcCoef = std::make_unique<mfem::VectorFunctionCoefficient>(3, source_current);
+  auto j_src_coef = std::make_unique<mfem::VectorFunctionCoefficient>(3, source_current);
 
   mfem::Array<mfem::VectorCoefficient *> sourcecoefs(4);
-  sourcecoefs[0] = JSrcCoef.get();
-  sourcecoefs[1] = JSrcCoef.get();
-  sourcecoefs[2] = JSrcCoef.get();
-  sourcecoefs[3] = JSrcCoef.get();
+  sourcecoefs[0] = j_src_coef.get();
+  sourcecoefs[1] = j_src_coef.get();
+  sourcecoefs[2] = j_src_coef.get();
+  sourcecoefs[3] = j_src_coef.get();
 
   mfem::Array<int> coilsegments(4);
   coilsegments[0] = 3;
@@ -98,8 +98,8 @@ defineCoefficients()
   coilsegments[2] = 5;
   coilsegments[3] = 6;
 
-  auto JSrcRestricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
-  coefficients.vectors.Register("source", JSrcRestricted, true);
+  auto j_src_restricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
+  coefficients.vectors.Register("source", j_src_restricted, true);
 
   return coefficients;
 }
@@ -164,19 +164,19 @@ main(int argc, char * argv[])
 
   problem_builder->AddGridFunction("electric_field_real", "HCurl");
   problem_builder->AddGridFunction("electric_field_imag", "HCurl");
-  problem_builder->registerElectricFieldAux("electric_field_real", "electric_field_imag");
+  problem_builder->RegisterElectricFieldAux("electric_field_real", "electric_field_imag");
 
   problem_builder->AddGridFunction("magnetic_flux_density_real", "HDiv");
   problem_builder->AddGridFunction("magnetic_flux_density_imag", "HDiv");
-  problem_builder->registerMagneticFluxDensityAux("magnetic_flux_density_real",
+  problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density_real",
                                                   "magnetic_flux_density_imag");
 
   problem_builder->AddGridFunction("current_density_real", "HDiv");
   problem_builder->AddGridFunction("current_density_imag", "HDiv");
-  problem_builder->registerCurrentDensityAux("current_density_real", "current_density_imag");
+  problem_builder->RegisterCurrentDensityAux("current_density_real", "current_density_imag");
 
   problem_builder->AddGridFunction("joule_heating_density", "L2");
-  problem_builder->registerJouleHeatingDensityAux("joule_heating_density",
+  problem_builder->RegisterJouleHeatingDensityAux("joule_heating_density",
                                                   "electric_field_real",
                                                   "electric_field_imag",
                                                   "electrical_conductivity");

--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -59,29 +59,29 @@ hephaestus::Coefficients
 defineCoefficients()
 {
   hephaestus::Subdomain air("air", 1);
-  air.scalar_coefficients.Register(
+  air._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain plate("plate", 2);
-  plate.scalar_coefficients.Register(
+  plate._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(3.526e7), true);
   hephaestus::Subdomain coil1("coil1", 3);
-  coil1.scalar_coefficients.Register(
+  coil1._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain coil2("coil2", 4);
-  coil2.scalar_coefficients.Register(
+  coil2._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain coil3("coil3", 5);
-  coil3.scalar_coefficients.Register(
+  coil3._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain coil4("coil4", 6);
-  coil4.scalar_coefficients.Register(
+  coil4._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Coefficients coefficients(
       std::vector<hephaestus::Subdomain>({air, plate, coil1, coil2, coil3, coil4}));
-  coefficients.scalars.Register("frequency", new mfem::ConstantCoefficient(200.0), true);
-  coefficients.scalars.Register(
+  coefficients._scalars.Register("frequency", new mfem::ConstantCoefficient(200.0), true);
+  coefficients._scalars.Register(
       "magnetic_permeability", new mfem::ConstantCoefficient(M_PI * 4.0e-7), true);
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       "dielectric_permittivity", new mfem::ConstantCoefficient(8.854e-12), true);
 
   auto j_src_coef = std::make_unique<mfem::VectorFunctionCoefficient>(3, source_current);
@@ -99,7 +99,7 @@ defineCoefficients()
   coilsegments[3] = 6;
 
   auto j_src_restricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
-  coefficients.vectors.Register("source", j_src_restricted, true);
+  coefficients._vectors.Register("source", j_src_restricted, true);
 
   return coefficients;
 }

--- a/examples/magnetostatic/Main.cpp
+++ b/examples/magnetostatic/Main.cpp
@@ -8,14 +8,14 @@ source_current(const mfem::Vector & xv, double t, mfem::Vector & J)
   double x0(194e-3); // Coil centre x coordinate
   double y0(100e-3); // Coil centre y coordinate
   double a(50e-3);   // Coil thickness
-  double I0(2742);   // Coil current in Ampere-turns
-  double S(2.5e-3);  // Coil cross sectional area
+  double i0(2742);   // Coil current in Ampere-turns
+  double s(2.5e-3);  // Coil cross sectional area
 
   double x = xv(0);
   double y = xv(1);
 
   // Current density magnitude
-  double Jmag = (I0 / S);
+  double jmag = (i0 / s);
 
   // Calculate x component of current density unit vector
   if (abs(x - x0) < a)
@@ -51,7 +51,7 @@ source_current(const mfem::Vector & xv, double t, mfem::Vector & J)
   J(2) = 0.0;
 
   // Scale by current density magnitude
-  J *= Jmag;
+  J *= jmag;
 }
 
 hephaestus::Coefficients
@@ -80,13 +80,13 @@ defineCoefficients()
   coefficients.scalars.Register(
       "magnetic_permeability", new mfem::ConstantCoefficient(M_PI * 4.0e-7), true);
 
-  auto JSrcCoef = std::make_unique<mfem::VectorFunctionCoefficient>(3, source_current);
+  auto j_src_coef = std::make_unique<mfem::VectorFunctionCoefficient>(3, source_current);
 
   mfem::Array<mfem::VectorCoefficient *> sourcecoefs(4);
-  sourcecoefs[0] = JSrcCoef.get();
-  sourcecoefs[1] = JSrcCoef.get();
-  sourcecoefs[2] = JSrcCoef.get();
-  sourcecoefs[3] = JSrcCoef.get();
+  sourcecoefs[0] = j_src_coef.get();
+  sourcecoefs[1] = j_src_coef.get();
+  sourcecoefs[2] = j_src_coef.get();
+  sourcecoefs[3] = j_src_coef.get();
 
   mfem::Array<int> coilsegments(4);
   coilsegments[0] = 3;
@@ -94,8 +94,8 @@ defineCoefficients()
   coilsegments[2] = 5;
   coilsegments[3] = 6;
 
-  auto JSrcRestricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
-  coefficients.vectors.Register("source", JSrcRestricted, true);
+  auto j_src_restricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
+  coefficients.vectors.Register("source", j_src_restricted, true);
 
   return coefficients;
 }

--- a/examples/magnetostatic/Main.cpp
+++ b/examples/magnetostatic/Main.cpp
@@ -58,26 +58,26 @@ hephaestus::Coefficients
 defineCoefficients()
 {
   hephaestus::Subdomain air("air", 1);
-  air.scalar_coefficients.Register(
+  air._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain plate("plate", 2);
-  plate.scalar_coefficients.Register(
+  plate._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(3.526e7), true);
   hephaestus::Subdomain coil1("coil1", 3);
-  coil1.scalar_coefficients.Register(
+  coil1._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain coil2("coil2", 4);
-  coil2.scalar_coefficients.Register(
+  coil2._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain coil3("coil3", 5);
-  coil3.scalar_coefficients.Register(
+  coil3._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain coil4("coil4", 6);
-  coil4.scalar_coefficients.Register(
+  coil4._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Coefficients coefficients(
       std::vector<hephaestus::Subdomain>({air, plate, coil1, coil2, coil3, coil4}));
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       "magnetic_permeability", new mfem::ConstantCoefficient(M_PI * 4.0e-7), true);
 
   auto j_src_coef = std::make_unique<mfem::VectorFunctionCoefficient>(3, source_current);
@@ -95,7 +95,7 @@ defineCoefficients()
   coilsegments[3] = 6;
 
   auto j_src_restricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
-  coefficients.vectors.Register("source", j_src_restricted, true);
+  coefficients._vectors.Register("source", j_src_restricted, true);
 
   return coefficients;
 }

--- a/examples/open_coil/Main.cpp
+++ b/examples/open_coil/Main.cpp
@@ -60,7 +60,7 @@ main(int argc, char * argv[])
 
   // Total electrical current going around the coil. Must be nonzero, can be
   // changed later.
-  double Itotal = 10;
+  double itotal = 10;
 
   // Attribute that defines the internal faces over which we apply the potential
   // difference
@@ -79,7 +79,7 @@ main(int argc, char * argv[])
       &DATA_DIR, "-dataDir", "--data_directory", "Directory storing input data for tests.");
   args.AddOption(&par_ref_lvl, "-ref", "--parallel-refinement", "Parallel refinement level.");
   args.AddOption(&order, "-o", "--order", "Base functions order");
-  args.AddOption(&Itotal, "-I", "--Itotal", "Total electrical current.");
+  args.AddOption(&itotal, "-I", "--Itotal", "Total electrical current.");
   args.AddOption(&mesh_filename, "-f", "--mesh-filename", "Mesh file name");
   args.AddOption(&coil_attr,
                  "-cd",
@@ -138,17 +138,17 @@ main(int argc, char * argv[])
   problem_builder->AddGridFunction(std::string("magnetic_vector_potential"), std::string("HCurl"));
   problem_builder->AddGridFunction(std::string("grad_phi"), std::string("HCurl"));
   problem_builder->AddGridFunction(std::string("magnetic_flux_density"), std::string("HDiv"));
-  problem_builder->registerMagneticFluxDensityAux("magnetic_flux_density");
-  hephaestus::Coefficients coefficients = defineCoefficients(Itotal);
+  problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density");
+  hephaestus::Coefficients coefficients = defineCoefficients(itotal);
 
-  mfem::Array<int> A_DBC_bdr(3);
-  A_DBC_bdr[0] = 1;
-  A_DBC_bdr[1] = 2;
-  A_DBC_bdr[2] = 4;
-  hephaestus::VectorDirichletBC A_DBC(
-      "magnetic_vector_potential", A_DBC_bdr, new mfem::VectorFunctionCoefficient(3, constVec));
+  mfem::Array<int> a_dbc_bdr(3);
+  a_dbc_bdr[0] = 1;
+  a_dbc_bdr[1] = 2;
+  a_dbc_bdr[2] = 4;
+  hephaestus::VectorDirichletBC a_dbc(
+      "magnetic_vector_potential", a_dbc_bdr, new mfem::VectorFunctionCoefficient(3, constVec));
 
-  problem_builder->AddBoundaryCondition("A_DBC", &A_DBC, false);
+  problem_builder->AddBoundaryCondition("A_DBC", &a_dbc, false);
 
   problem_builder->SetCoefficients(coefficients);
 

--- a/examples/open_coil/Main.cpp
+++ b/examples/open_coil/Main.cpp
@@ -13,15 +13,15 @@ defineCoefficients(double Itotal)
 {
 
   hephaestus::Coefficients coefficients;
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       "magnetic_permeability", new mfem::ConstantCoefficient(M_PI * 4.0e-7), true);
 
   // Electrical conductivity
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
 
   // Time-dependent current
-  coefficients.scalars.Register("I", new mfem::ConstantCoefficient(Itotal), true);
+  coefficients._scalars.Register("I", new mfem::ConstantCoefficient(Itotal), true);
 
   return coefficients;
 }

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -59,26 +59,26 @@ hephaestus::Coefficients
 defineCoefficients()
 {
   hephaestus::Subdomain air("air", 1);
-  air.scalar_coefficients.Register(
+  air._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain plate("plate", 2);
-  plate.scalar_coefficients.Register(
+  plate._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(3.526e7), true);
   hephaestus::Subdomain coil1("coil1", 3);
-  coil1.scalar_coefficients.Register(
+  coil1._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain coil2("coil2", 4);
-  coil2.scalar_coefficients.Register(
+  coil2._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain coil3("coil3", 5);
-  coil3.scalar_coefficients.Register(
+  coil3._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Subdomain coil4("coil4", 6);
-  coil4.scalar_coefficients.Register(
+  coil4._scalar_coefficients.Register(
       "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
   hephaestus::Coefficients coefficients(
       std::vector<hephaestus::Subdomain>({air, plate, coil1, coil2, coil3, coil4}));
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       "magnetic_permeability", new mfem::ConstantCoefficient(M_PI * 4.0e-7), true);
 
   auto j_src_coef = std::make_unique<mfem::VectorFunctionCoefficient>(3, source_current);
@@ -96,7 +96,7 @@ defineCoefficients()
   coilsegments[3] = 6;
 
   auto j_src_restricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
-  coefficients.vectors.Register("source", j_src_restricted, true);
+  coefficients._vectors.Register("source", j_src_restricted, true);
 
   return coefficients;
 }

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -8,15 +8,15 @@ source_current(const mfem::Vector & xv, double t, mfem::Vector & J)
   double x0(194e-3);  // Coil centre x coordinate
   double y0(100e-3);  // Coil centre y coordinate
   double a(50e-3);    // Coil thickness
-  double I0(2742);    // Coil current in Ampere-turns
-  double S(2.5e-3);   // Coil cross sectional area
+  double i0(2742);    // Coil current in Ampere-turns
+  double s(2.5e-3);   // Coil cross sectional area
   double freq(200.0); // Frequency in Hz
 
   double x = xv(0);
   double y = xv(1);
 
   // Current density magnitude
-  double Jmag = (I0 / S) * sin(2 * M_PI * freq * t);
+  double jmag = (i0 / s) * sin(2 * M_PI * freq * t);
 
   // Calculate x component of current density unit vector
   if (abs(x - x0) < a)
@@ -52,7 +52,7 @@ source_current(const mfem::Vector & xv, double t, mfem::Vector & J)
   J(2) = 0.0;
 
   // Scale by current density magnitude
-  J *= Jmag;
+  J *= jmag;
 }
 
 hephaestus::Coefficients
@@ -81,13 +81,13 @@ defineCoefficients()
   coefficients.scalars.Register(
       "magnetic_permeability", new mfem::ConstantCoefficient(M_PI * 4.0e-7), true);
 
-  auto JSrcCoef = std::make_unique<mfem::VectorFunctionCoefficient>(3, source_current);
+  auto j_src_coef = std::make_unique<mfem::VectorFunctionCoefficient>(3, source_current);
 
   mfem::Array<mfem::VectorCoefficient *> sourcecoefs(4);
-  sourcecoefs[0] = JSrcCoef.get();
-  sourcecoefs[1] = JSrcCoef.get();
-  sourcecoefs[2] = JSrcCoef.get();
-  sourcecoefs[3] = JSrcCoef.get();
+  sourcecoefs[0] = j_src_coef.get();
+  sourcecoefs[1] = j_src_coef.get();
+  sourcecoefs[2] = j_src_coef.get();
+  sourcecoefs[3] = j_src_coef.get();
 
   mfem::Array<int> coilsegments(4);
   coilsegments[0] = 3;
@@ -95,8 +95,8 @@ defineCoefficients()
   coilsegments[2] = 5;
   coilsegments[3] = 6;
 
-  auto JSrcRestricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
-  coefficients.vectors.Register("source", JSrcRestricted, true);
+  auto j_src_restricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
+  coefficients.vectors.Register("source", j_src_restricted, true);
 
   return coefficients;
 }
@@ -157,20 +157,20 @@ main(int argc, char * argv[])
   problem_builder->AddGridFunction("magnetic_vector_potential", "HCurl");
 
   problem_builder->AddGridFunction("magnetic_flux_density", "HDiv");
-  problem_builder->registerMagneticFluxDensityAux("magnetic_flux_density");
+  problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density");
 
   problem_builder->AddGridFunction("current_density", "HDiv");
-  problem_builder->registerCurrentDensityAux("current_density");
+  problem_builder->RegisterCurrentDensityAux("current_density");
 
   problem_builder->AddGridFunction("electric_field", "HCurl");
-  problem_builder->registerElectricFieldAux("electric_field");
+  problem_builder->RegisterElectricFieldAux("electric_field");
 
   problem_builder->AddGridFunction("lorentz_force_density", "Vector_L2");
-  problem_builder->registerLorentzForceDensityAux(
+  problem_builder->RegisterLorentzForceDensityAux(
       "lorentz_force_density", "magnetic_flux_density", "current_density");
 
   problem_builder->AddGridFunction("joule_heating_density", "Scalar_L2");
-  problem_builder->registerJouleHeatingDensityAux(
+  problem_builder->RegisterJouleHeatingDensityAux(
       "joule_heating_density", "electric_field", "current_density");
 
   hephaestus::Coefficients coefficients = defineCoefficients();

--- a/src/auxsolvers/auxsolvers.cpp
+++ b/src/auxsolvers/auxsolvers.cpp
@@ -11,16 +11,16 @@ AuxSolvers::Init(const hephaestus::GridFunctions & gridfunctions,
   for (const auto & [name, auxsolver] : GetMap())
   {
     auxsolver->Init(gridfunctions, coefficients);
-    aux_queue.push_back(auxsolver);
+    _aux_queue.push_back(auxsolver);
   }
 
-  std::sort(aux_queue.begin(), aux_queue.end(), AuxSolver::PriorityComparator);
+  std::sort(_aux_queue.begin(), _aux_queue.end(), AuxSolver::PriorityComparator);
 }
 
 void
 AuxSolvers::Solve(double t)
 {
-  for (auto & auxsolver : aux_queue)
+  for (auto & auxsolver : _aux_queue)
   {
     auxsolver->Solve(t);
   }

--- a/src/auxsolvers/auxsolvers.hpp
+++ b/src/auxsolvers/auxsolvers.hpp
@@ -19,7 +19,7 @@ class AuxSolvers : public hephaestus::NamedFieldsMap<hephaestus::AuxSolver>
 {
 private:
 public:
-  std::vector<hephaestus::AuxSolver *> aux_queue;
+  std::vector<hephaestus::AuxSolver *> _aux_queue;
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients);
   void Solve(double t = 0.0);

--- a/src/auxsolvers/coefficient_aux.cpp
+++ b/src/auxsolvers/coefficient_aux.cpp
@@ -19,7 +19,7 @@ CoefficientAux::Init(const hephaestus::GridFunctions & gridfunctions,
   {
     MFEM_ABORT("GridFunction " << _gf_name << " not found when initializing CoefficientAux");
   }
-  _coef = coefficients.scalars.Get(_coef_name);
+  _coef = coefficients._scalars.Get(_coef_name);
   if (_coef == nullptr)
   {
     MFEM_ABORT("Coefficient " << _coef_name << " not found when initializing CoefficientAux");

--- a/src/auxsolvers/coupled_coefficient_aux.cpp
+++ b/src/auxsolvers/coupled_coefficient_aux.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 CoupledCoefficient::CoupledCoefficient(const hephaestus::InputParameters & params)
-  : coupled_var_name(params.GetParam<std::string>("CoupledVariableName"))
+  : _coupled_var_name(params.GetParam<std::string>("CoupledVariableName"))
 {
 }
 
@@ -12,14 +12,14 @@ void
 CoupledCoefficient::Init(const hephaestus::GridFunctions & gridfunctions,
                          hephaestus::Coefficients & coefficients)
 {
-  if (gridfunctions.Has(coupled_var_name))
+  if (gridfunctions.Has(_coupled_var_name))
   {
-    gf = gridfunctions.Get(coupled_var_name);
+    _gf = gridfunctions.Get(_coupled_var_name);
   }
   else
   {
-    const std::string error_message = coupled_var_name + " not found in gridfunctions when "
-                                                         "creating CoupledCoefficient\n";
+    const std::string error_message = _coupled_var_name + " not found in gridfunctions when "
+                                                          "creating CoupledCoefficient\n";
     mfem::mfem_error(error_message.c_str());
   }
 }
@@ -27,7 +27,7 @@ CoupledCoefficient::Init(const hephaestus::GridFunctions & gridfunctions,
 double
 CoupledCoefficient::Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip)
 {
-  return gf->GetValue(T, ip);
+  return _gf->GetValue(T, ip);
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/coupled_coefficient_aux.hpp
+++ b/src/auxsolvers/coupled_coefficient_aux.hpp
@@ -13,8 +13,8 @@ class CoupledCoefficient : public mfem::Coefficient, public AuxSolver
 {
 protected:
   // pointer to coupled variable (could just be to vars?)
-  mfem::ParGridFunction * gf;
-  double scalar_val;
+  mfem::ParGridFunction * _gf;
+  double _scalar_val;
 
 public:
   CoupledCoefficient(const hephaestus::InputParameters & params);
@@ -28,7 +28,7 @@ public:
 
   void Solve(double t = 0.0) override{};
 
-  std::string coupled_var_name; // name of the variable
+  std::string _coupled_var_name; // name of the variable
 };
 
 } // namespace hephaestus

--- a/src/auxsolvers/curl_aux.cpp
+++ b/src/auxsolvers/curl_aux.cpp
@@ -14,25 +14,26 @@ void
 CurlAuxSolver::Init(const hephaestus::GridFunctions & gridfunctions,
                     hephaestus::Coefficients & coefficients)
 {
-  u_ = gridfunctions.Get(_input_gf_name);
-  if (u_ == nullptr)
+  _u = gridfunctions.Get(_input_gf_name);
+  if (_u == nullptr)
   {
     MFEM_ABORT("GridFunction " << _input_gf_name << " not found when initializing CurlAuxSolver");
   }
-  curl_u_ = gridfunctions.Get(_curl_gf_name);
-  if (curl_u_ == nullptr)
+  _curl_u = gridfunctions.Get(_curl_gf_name);
+  if (_curl_u == nullptr)
   {
     MFEM_ABORT("GridFunction " << _curl_gf_name << " not found when initializing CurlAuxSolver");
   }
-  curl = std::make_unique<mfem::ParDiscreteLinearOperator>(u_->ParFESpace(), curl_u_->ParFESpace());
-  curl->AddDomainInterpolator(new mfem::CurlInterpolator());
-  curl->Assemble();
+  _curl =
+      std::make_unique<mfem::ParDiscreteLinearOperator>(_u->ParFESpace(), _curl_u->ParFESpace());
+  _curl->AddDomainInterpolator(new mfem::CurlInterpolator());
+  _curl->Assemble();
 }
 
 void
 CurlAuxSolver::Solve(double t)
 {
-  curl->Mult(*u_, *curl_u_);
+  _curl->Mult(*_u, *_curl_u);
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/curl_aux.hpp
+++ b/src/auxsolvers/curl_aux.hpp
@@ -21,8 +21,8 @@ private:
   const std::string _input_gf_name; // name of the variable
   const std::string _curl_gf_name;  // Variable in which to store curl
 
-  mfem::ParGridFunction *u_, *curl_u_;
-  std::unique_ptr<mfem::ParDiscreteLinearOperator> curl;
+  mfem::ParGridFunction *_u, *_curl_u;
+  std::unique_ptr<mfem::ParDiscreteLinearOperator> _curl;
 };
 
 } // namespace hephaestus

--- a/src/auxsolvers/helmholtz_projector.cpp
+++ b/src/auxsolvers/helmholtz_projector.cpp
@@ -81,10 +81,10 @@ HelmholtzProjector::Project(hephaestus::GridFunctions & gridfunctions,
 
   bc_map_ = &bc_map;
 
-  setForms();
-  setGrad();
-  setBCs();
-  solveLinearSystem();
+  SetForms();
+  SetGrad();
+  SetBCs();
+  SolveLinearSystem();
 
   // Compute the irrotational component of g
   // P(g) = g - ∇Q
@@ -99,7 +99,7 @@ HelmholtzProjector::Project(hephaestus::GridFunctions & gridfunctions,
 }
 
 void
-HelmholtzProjector::setForms()
+HelmholtzProjector::SetForms()
 {
 
   if (gDiv_ == nullptr)
@@ -123,7 +123,7 @@ HelmholtzProjector::setForms()
 }
 
 void
-HelmholtzProjector::setGrad()
+HelmholtzProjector::SetGrad()
 {
 
   if (grad_ == nullptr)
@@ -136,7 +136,7 @@ HelmholtzProjector::setGrad()
 }
 
 void
-HelmholtzProjector::setBCs()
+HelmholtzProjector::SetBCs()
 {
 
   // Begin Divergence-free projection
@@ -144,8 +144,8 @@ HelmholtzProjector::setBCs()
   int myid = H1FESpace_->GetMyRank();
 
   // <P(g).n, q>
-  bc_map_->applyEssentialBCs(gf_name_, ess_bdr_tdofs_, *q_, (H1FESpace_->GetParMesh()));
-  bc_map_->applyIntegratedBCs(gf_name_, *gDiv_, (H1FESpace_->GetParMesh()));
+  bc_map_->ApplyEssentialBCs(gf_name_, ess_bdr_tdofs_, *q_, (H1FESpace_->GetParMesh()));
+  bc_map_->ApplyIntegratedBCs(gf_name_, *gDiv_, (H1FESpace_->GetParMesh()));
 
   // Apply essential BC. Necessary to ensure potential at least one point is
   // fixed.
@@ -161,7 +161,7 @@ HelmholtzProjector::setBCs()
 }
 
 void
-HelmholtzProjector::solveLinearSystem()
+HelmholtzProjector::SolveLinearSystem()
 {
 
   gDiv_->Assemble();

--- a/src/auxsolvers/helmholtz_projector.cpp
+++ b/src/auxsolvers/helmholtz_projector.cpp
@@ -4,17 +4,17 @@ namespace hephaestus
 {
 
 HelmholtzProjector::HelmholtzProjector(const hephaestus::InputParameters & params)
-  : h1_fespace_name_(params.GetOptionalParam<std::string>("H1FESpaceName", "H1FES_Name")),
-    hcurl_fespace_name_(params.GetOptionalParam<std::string>("HCurlFESpaceName", "HCurlFES_Name")),
-    gf_grad_name_(params.GetParam<std::string>("VectorGridFunctionName")),
-    gf_name_(params.GetOptionalParam<std::string>("ScalarGridFunctionName", "ScalarGF_Name")),
+  : _h1_fespace_name(params.GetOptionalParam<std::string>("H1FESpaceName", "H1FES_Name")),
+    _hcurl_fespace_name(params.GetOptionalParam<std::string>("HCurlFESpaceName", "HCurlFES_Name")),
+    _gf_grad_name(params.GetParam<std::string>("VectorGridFunctionName")),
+    _gf_name(params.GetOptionalParam<std::string>("ScalarGridFunctionName", "ScalarGF_Name")),
 
-    g(nullptr),
+    _g(nullptr),
 
-    gDiv_(nullptr),
-    weakDiv_(nullptr),
-    grad_(nullptr),
-    a0_(nullptr)
+    _g_div(nullptr),
+    _weak_div(nullptr),
+    _grad(nullptr),
+    _a0(nullptr)
 {
 
   hephaestus::InputParameters default_pars;
@@ -23,7 +23,7 @@ HelmholtzProjector::HelmholtzProjector(const hephaestus::InputParameters & param
   default_pars.SetParam("MaxIter", (unsigned int)1000);
   default_pars.SetParam("PrintLevel", 1);
 
-  solver_options_ =
+  _solver_options =
       params.GetOptionalParam<hephaestus::InputParameters>("SolverOptions", default_pars);
 }
 
@@ -34,52 +34,52 @@ HelmholtzProjector::Project(hephaestus::GridFunctions & gridfunctions,
 {
 
   // Retrieving vector GridFunction. This is the only mandatory one
-  div_free_src_gf_ = gridfunctions.Get(gf_grad_name_);
-  if (div_free_src_gf_ == nullptr)
+  _div_free_src_gf = gridfunctions.Get(_gf_grad_name);
+  if (_div_free_src_gf == nullptr)
   {
-    const std::string error_message = gf_grad_name_ + " not found in gridfunctions when "
+    const std::string error_message = _gf_grad_name + " not found in gridfunctions when "
                                                       "creating HelmholtzProjector\n";
     mfem::mfem_error(error_message.c_str());
   }
 
-  HCurlFESpace_ = fespaces.Get(hcurl_fespace_name_);
-  if (HCurlFESpace_ == nullptr)
+  _h_curl_fe_space = fespaces.Get(_hcurl_fespace_name);
+  if (_h_curl_fe_space == nullptr)
   {
-    std::cout << hcurl_fespace_name_ + " not found in fespaces when "
+    std::cout << _hcurl_fespace_name + " not found in fespaces when "
                                        "creating HelmholtzProjector. "
                                        "Obtaining from vector GridFunction.\n";
-    HCurlFESpace_ = div_free_src_gf_->ParFESpace();
+    _h_curl_fe_space = _div_free_src_gf->ParFESpace();
   }
 
-  H1FESpace_ = fespaces.Get(h1_fespace_name_);
-  if (H1FESpace_ == nullptr)
+  _h1_fe_space = fespaces.Get(_h1_fespace_name);
+  if (_h1_fe_space == nullptr)
   {
-    std::cout << h1_fespace_name_ + " not found in fespaces when "
+    std::cout << _h1_fespace_name + " not found in fespaces when "
                                     "creating HelmholtzProjector. "
                                     " Extracting from GridFunction\n";
 
     // Creates an H1 FES on the same mesh and with the same order as the HCurl
     // FES
-    H1FESpace_ = new mfem::ParFiniteElementSpace(
-        HCurlFESpace_->GetParMesh(),
-        new mfem::H1_FECollection(HCurlFESpace_->GetMaxElementOrder(),
-                                  HCurlFESpace_->GetParMesh()->Dimension()));
+    _h1_fe_space = new mfem::ParFiniteElementSpace(
+        _h_curl_fe_space->GetParMesh(),
+        new mfem::H1_FECollection(_h_curl_fe_space->GetMaxElementOrder(),
+                                  _h_curl_fe_space->GetParMesh()->Dimension()));
   }
 
-  q_ = gridfunctions.Get(gf_name_);
-  if (q_ == nullptr)
+  _q = gridfunctions.Get(_gf_name);
+  if (_q == nullptr)
   {
-    std::cout << gf_name_ + " not found in gridfunctions when "
+    std::cout << _gf_name + " not found in gridfunctions when "
                             "creating HelmholtzProjector. "
                             "Creating new GridFunction\n";
-    q_ = new mfem::ParGridFunction(H1FESpace_);
+    _q = new mfem::ParGridFunction(_h1_fe_space);
   }
 
-  g = std::make_unique<mfem::ParGridFunction>(HCurlFESpace_);
-  *g = *div_free_src_gf_;
-  *q_ = 0.0;
+  _g = std::make_unique<mfem::ParGridFunction>(_h_curl_fe_space);
+  *_g = *_div_free_src_gf;
+  *_q = 0.0;
 
-  bc_map_ = &bc_map;
+  _bc_map = &bc_map;
 
   SetForms();
   SetGrad();
@@ -88,37 +88,37 @@ HelmholtzProjector::Project(hephaestus::GridFunctions & gridfunctions,
 
   // Compute the irrotational component of g
   // P(g) = g - ∇Q
-  grad_->Mult(*q_, *div_free_src_gf_);
-  *div_free_src_gf_ -= *g;
-  *div_free_src_gf_ *= -1.0;
+  _grad->Mult(*_q, *_div_free_src_gf);
+  *_div_free_src_gf -= *_g;
+  *_div_free_src_gf *= -1.0;
 
-  if (!gridfunctions.Has(gf_name_))
-    delete q_;
-  if (!fespaces.Has(h1_fespace_name_))
-    delete H1FESpace_;
+  if (!gridfunctions.Has(_gf_name))
+    delete _q;
+  if (!fespaces.Has(_h1_fespace_name))
+    delete _h1_fe_space;
 }
 
 void
 HelmholtzProjector::SetForms()
 {
 
-  if (gDiv_ == nullptr)
-    gDiv_ = std::make_unique<mfem::ParLinearForm>(H1FESpace_);
+  if (_g_div == nullptr)
+    _g_div = std::make_unique<mfem::ParLinearForm>(_h1_fe_space);
 
-  if (weakDiv_ == nullptr)
+  if (_weak_div == nullptr)
   {
-    weakDiv_ = std::make_unique<mfem::ParMixedBilinearForm>(HCurlFESpace_, H1FESpace_);
-    weakDiv_->AddDomainIntegrator(new mfem::VectorFEWeakDivergenceIntegrator);
-    weakDiv_->Assemble();
-    weakDiv_->Finalize();
+    _weak_div = std::make_unique<mfem::ParMixedBilinearForm>(_h_curl_fe_space, _h1_fe_space);
+    _weak_div->AddDomainIntegrator(new mfem::VectorFEWeakDivergenceIntegrator);
+    _weak_div->Assemble();
+    _weak_div->Finalize();
   }
 
-  if (a0_ == nullptr)
+  if (_a0 == nullptr)
   {
-    a0_ = std::make_unique<mfem::ParBilinearForm>(H1FESpace_);
-    a0_->AddDomainIntegrator(new mfem::DiffusionIntegrator);
-    a0_->Assemble();
-    a0_->Finalize();
+    _a0 = std::make_unique<mfem::ParBilinearForm>(_h1_fe_space);
+    _a0->AddDomainIntegrator(new mfem::DiffusionIntegrator);
+    _a0->Assemble();
+    _a0->Finalize();
   }
 }
 
@@ -126,12 +126,12 @@ void
 HelmholtzProjector::SetGrad()
 {
 
-  if (grad_ == nullptr)
+  if (_grad == nullptr)
   {
-    grad_ = std::make_unique<mfem::ParDiscreteLinearOperator>(H1FESpace_, HCurlFESpace_);
-    grad_->AddDomainInterpolator(new mfem::GradientInterpolator());
-    grad_->Assemble();
-    grad_->Finalize();
+    _grad = std::make_unique<mfem::ParDiscreteLinearOperator>(_h1_fe_space, _h_curl_fe_space);
+    _grad->AddDomainInterpolator(new mfem::GradientInterpolator());
+    _grad->Assemble();
+    _grad->Finalize();
   }
 }
 
@@ -141,22 +141,22 @@ HelmholtzProjector::SetBCs()
 
   // Begin Divergence-free projection
   // (g, ∇q) - (∇Q, ∇q) - <P(g).n, q> = 0
-  int myid = H1FESpace_->GetMyRank();
+  int myid = _h1_fe_space->GetMyRank();
 
   // <P(g).n, q>
-  bc_map_->ApplyEssentialBCs(gf_name_, ess_bdr_tdofs_, *q_, (H1FESpace_->GetParMesh()));
-  bc_map_->ApplyIntegratedBCs(gf_name_, *gDiv_, (H1FESpace_->GetParMesh()));
+  _bc_map->ApplyEssentialBCs(_gf_name, _ess_bdr_tdofs, *_q, (_h1_fe_space->GetParMesh()));
+  _bc_map->ApplyIntegratedBCs(_gf_name, *_g_div, (_h1_fe_space->GetParMesh()));
 
   // Apply essential BC. Necessary to ensure potential at least one point is
   // fixed.
-  int localsize = ess_bdr_tdofs_.Size();
+  int localsize = _ess_bdr_tdofs.Size();
   int fullsize;
   MPI_Allreduce(&fullsize, &localsize, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
 
   if (fullsize == 0 && myid == 0)
   {
-    ess_bdr_tdofs_.SetSize(1);
-    ess_bdr_tdofs_[0] = 0;
+    _ess_bdr_tdofs.SetSize(1);
+    _ess_bdr_tdofs[0] = 0;
   }
 }
 
@@ -164,11 +164,11 @@ void
 HelmholtzProjector::SolveLinearSystem()
 {
 
-  gDiv_->Assemble();
+  _g_div->Assemble();
 
   // Compute the divergence of g
   // (g, ∇q)
-  weakDiv_->AddMult(*g, *gDiv_, -1.0);
+  _weak_div->AddMult(*_g, *_g_div, -1.0);
 
   // Form linear system
   // (g, ∇q) - (∇Q, ∇q) - <P(g).n, q> = 0
@@ -176,12 +176,12 @@ HelmholtzProjector::SolveLinearSystem()
   mfem::HypreParMatrix a0;
   mfem::Vector x0;
   mfem::Vector b0;
-  a0_->FormLinearSystem(ess_bdr_tdofs_, *q_, *gDiv_, a0, x0, b0);
+  _a0->FormLinearSystem(_ess_bdr_tdofs, *_q, *_g_div, a0, x0, b0);
 
-  hephaestus::DefaultGMRESSolver a0_solver(solver_options_, a0);
+  hephaestus::DefaultGMRESSolver a0_solver(_solver_options, a0);
 
   a0_solver.Mult(b0, x0);
-  a0_->RecoverFEMSolution(x0, *gDiv_, *q_);
+  _a0->RecoverFEMSolution(x0, *_g_div, *_q);
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/helmholtz_projector.cpp
+++ b/src/auxsolvers/helmholtz_projector.cpp
@@ -173,15 +173,15 @@ HelmholtzProjector::SolveLinearSystem()
   // Form linear system
   // (g, ∇q) - (∇Q, ∇q) - <P(g).n, q> = 0
   // (∇Q, ∇q) = (g, ∇q) - <P(g).n, q>
-  mfem::HypreParMatrix A0;
-  mfem::Vector X0;
-  mfem::Vector B0;
-  a0_->FormLinearSystem(ess_bdr_tdofs_, *q_, *gDiv_, A0, X0, B0);
+  mfem::HypreParMatrix a0;
+  mfem::Vector x0;
+  mfem::Vector b0;
+  a0_->FormLinearSystem(ess_bdr_tdofs_, *q_, *gDiv_, a0, x0, b0);
 
-  hephaestus::DefaultGMRESSolver a0_solver(solver_options_, A0);
+  hephaestus::DefaultGMRESSolver a0_solver(solver_options_, a0);
 
-  a0_solver.Mult(B0, X0);
-  a0_->RecoverFEMSolution(X0, *gDiv_, *q_);
+  a0_solver.Mult(b0, x0);
+  a0_->RecoverFEMSolution(x0, *gDiv_, *q_);
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/helmholtz_projector.hpp
+++ b/src/auxsolvers/helmholtz_projector.hpp
@@ -13,10 +13,10 @@ public:
                const hephaestus::FESpaces & fespaces,
                hephaestus::BCMap & bc_map);
 
-  void setForms();
-  void setGrad();
-  void setBCs();
-  void solveLinearSystem();
+  void SetForms();
+  void SetGrad();
+  void SetBCs();
+  void SolveLinearSystem();
 
 private:
   std::string hcurl_fespace_name_;

--- a/src/auxsolvers/helmholtz_projector.hpp
+++ b/src/auxsolvers/helmholtz_projector.hpp
@@ -19,28 +19,28 @@ public:
   void SolveLinearSystem();
 
 private:
-  std::string hcurl_fespace_name_;
-  std::string h1_fespace_name_;
-  std::string gf_grad_name_;
-  std::string gf_name_;
-  hephaestus::InputParameters solver_options_;
+  std::string _hcurl_fespace_name;
+  std::string _h1_fespace_name;
+  std::string _gf_grad_name;
+  std::string _gf_name;
+  hephaestus::InputParameters _solver_options;
 
-  mfem::ParFiniteElementSpace * H1FESpace_{nullptr};
-  mfem::ParFiniteElementSpace * HCurlFESpace_{nullptr};
-  mfem::ParGridFunction * q_{nullptr};
+  mfem::ParFiniteElementSpace * _h1_fe_space{nullptr};
+  mfem::ParFiniteElementSpace * _h_curl_fe_space{nullptr};
+  mfem::ParGridFunction * _q{nullptr};
 
   // H(Curl) projection of user specified source
-  std::unique_ptr<mfem::ParGridFunction> g;
+  std::unique_ptr<mfem::ParGridFunction> _g;
 
-  mfem::ParGridFunction * div_free_src_gf_{nullptr}; // Divergence free projected source
+  mfem::ParGridFunction * _div_free_src_gf{nullptr}; // Divergence free projected source
 
-  std::unique_ptr<mfem::ParLinearForm> gDiv_;
-  std::unique_ptr<mfem::ParBilinearForm> a0_;
-  std::unique_ptr<mfem::ParMixedBilinearForm> weakDiv_;
-  std::unique_ptr<mfem::ParDiscreteLinearOperator> grad_;
+  std::unique_ptr<mfem::ParLinearForm> _g_div;
+  std::unique_ptr<mfem::ParBilinearForm> _a0;
+  std::unique_ptr<mfem::ParMixedBilinearForm> _weak_div;
+  std::unique_ptr<mfem::ParDiscreteLinearOperator> _grad;
 
-  mfem::Array<int> ess_bdr_tdofs_;
-  hephaestus::BCMap * bc_map_;
+  mfem::Array<int> _ess_bdr_tdofs;
+  hephaestus::BCMap * _bc_map;
 };
 
 } // namespace hephaestus

--- a/src/auxsolvers/l2_error_vector_aux.cpp
+++ b/src/auxsolvers/l2_error_vector_aux.cpp
@@ -4,8 +4,8 @@ namespace hephaestus
 {
 
 L2ErrorVectorPostprocessor::L2ErrorVectorPostprocessor(const hephaestus::InputParameters & params)
-  : var_name(params.GetParam<std::string>("VariableName")),
-    vec_coef_name(params.GetParam<std::string>("VectorCoefficientName"))
+  : _var_name(params.GetParam<std::string>("VariableName")),
+    _vec_coef_name(params.GetParam<std::string>("VectorCoefficientName"))
 {
 }
 
@@ -13,19 +13,19 @@ void
 L2ErrorVectorPostprocessor::Init(const hephaestus::GridFunctions & gridfunctions,
                                  hephaestus::Coefficients & coefficients)
 {
-  gf = gridfunctions.Get(var_name);
-  vec_coeff = coefficients.vectors.Get(vec_coef_name);
+  _gf = gridfunctions.Get(_var_name);
+  _vec_coeff = coefficients._vectors.Get(_vec_coef_name);
 }
 
 void
 L2ErrorVectorPostprocessor::Solve(double t)
 {
-  double l2_err = gf->ComputeL2Error(*vec_coeff);
-  HYPRE_BigInt ndof = gf->ParFESpace()->GlobalTrueVSize();
+  double l2_err = _gf->ComputeL2Error(*_vec_coeff);
+  HYPRE_BigInt ndof = _gf->ParFESpace()->GlobalTrueVSize();
 
-  times.Append(t);
-  l2_errs.Append(l2_err);
-  ndofs.Append(ndof);
+  _times.Append(t);
+  _l2_errs.Append(l2_err);
+  _ndofs.Append(ndof);
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/l2_error_vector_aux.hpp
+++ b/src/auxsolvers/l2_error_vector_aux.hpp
@@ -21,15 +21,15 @@ public:
 
   void Solve(double t = 0.0) override;
 
-  std::string var_name;      // name of the variable
-  std::string vec_coef_name; // name of the vector coefficient
+  std::string _var_name;      // name of the variable
+  std::string _vec_coef_name; // name of the vector coefficient
 
-  mfem::Array<double> times;
-  mfem::Array<HYPRE_BigInt> ndofs;
-  mfem::Array<double> l2_errs;
+  mfem::Array<double> _times;
+  mfem::Array<HYPRE_BigInt> _ndofs;
+  mfem::Array<double> _l2_errs;
 
-  mfem::ParGridFunction * gf{nullptr};
-  mfem::VectorCoefficient * vec_coeff{nullptr};
+  mfem::ParGridFunction * _gf{nullptr};
+  mfem::VectorCoefficient * _vec_coeff{nullptr};
 };
 
 } // namespace hephaestus

--- a/src/auxsolvers/scaled_curl_vector_gridfunction_aux.cpp
+++ b/src/auxsolvers/scaled_curl_vector_gridfunction_aux.cpp
@@ -14,7 +14,7 @@ ScaledCurlVectorGridFunctionAux::ScaledCurlVectorGridFunctionAux(
 }
 
 void
-ScaledCurlVectorGridFunctionAux::buildMixedBilinearForm()
+ScaledCurlVectorGridFunctionAux::BuildMixedBilinearForm()
 {
   a_mixed = std::make_unique<mfem::ParMixedBilinearForm>(trial_fes, test_fes);
   a_mixed->AddDomainIntegrator(new mfem::MixedVectorCurlIntegrator(*coef));

--- a/src/auxsolvers/scaled_curl_vector_gridfunction_aux.cpp
+++ b/src/auxsolvers/scaled_curl_vector_gridfunction_aux.cpp
@@ -16,10 +16,10 @@ ScaledCurlVectorGridFunctionAux::ScaledCurlVectorGridFunctionAux(
 void
 ScaledCurlVectorGridFunctionAux::BuildMixedBilinearForm()
 {
-  a_mixed = std::make_unique<mfem::ParMixedBilinearForm>(trial_fes, test_fes);
-  a_mixed->AddDomainIntegrator(new mfem::MixedVectorCurlIntegrator(*coef));
-  a_mixed->Assemble();
-  a_mixed->Finalize();
+  _a_mixed = std::make_unique<mfem::ParMixedBilinearForm>(_trial_fes, _test_fes);
+  _a_mixed->AddDomainIntegrator(new mfem::MixedVectorCurlIntegrator(*_coef));
+  _a_mixed->Assemble();
+  _a_mixed->Finalize();
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/scaled_curl_vector_gridfunction_aux.hpp
+++ b/src/auxsolvers/scaled_curl_vector_gridfunction_aux.hpp
@@ -19,6 +19,6 @@ public:
 
   ~ScaledCurlVectorGridFunctionAux() override = default;
 
-  void buildMixedBilinearForm() override;
+  void BuildMixedBilinearForm() override;
 };
 } // namespace hephaestus

--- a/src/auxsolvers/scaled_vector_gridfunction_aux.cpp
+++ b/src/auxsolvers/scaled_vector_gridfunction_aux.cpp
@@ -49,15 +49,15 @@ ScaledVectorGridFunctionAux::Init(const hephaestus::GridFunctions & gridfunction
 
   test_fes = scaled_gf->ParFESpace();
   trial_fes = input_gf->ParFESpace();
-  buildBilinearForm();
-  buildMixedBilinearForm();
+  BuildBilinearForm();
+  BuildMixedBilinearForm();
   a_mat = std::unique_ptr<mfem::HypreParMatrix>(a->ParallelAssemble());
 
   solver = std::make_unique<hephaestus::DefaultJacobiPCGSolver>(_solver_options, *a_mat);
 }
 
 void
-ScaledVectorGridFunctionAux::buildBilinearForm()
+ScaledVectorGridFunctionAux::BuildBilinearForm()
 {
   a = std::make_unique<mfem::ParBilinearForm>(test_fes);
   a->AddDomainIntegrator(new mfem::VectorFEMassIntegrator());
@@ -66,7 +66,7 @@ ScaledVectorGridFunctionAux::buildBilinearForm()
 }
 
 void
-ScaledVectorGridFunctionAux::buildMixedBilinearForm()
+ScaledVectorGridFunctionAux::BuildMixedBilinearForm()
 {
   a_mixed = std::make_unique<mfem::ParMixedBilinearForm>(trial_fes, test_fes);
   a_mixed->AddDomainIntegrator(new mfem::MixedVectorMassIntegrator(*coef));

--- a/src/auxsolvers/scaled_vector_gridfunction_aux.cpp
+++ b/src/auxsolvers/scaled_vector_gridfunction_aux.cpp
@@ -77,11 +77,11 @@ ScaledVectorGridFunctionAux::BuildMixedBilinearForm()
 void
 ScaledVectorGridFunctionAux::Solve(double t)
 {
-  mfem::Vector B(test_fes->GetTrueVSize());  // Linear form true DOFs
-  mfem::Vector X(test_fes->GetTrueVSize());  // H(Div) gridfunction true DOFs
-  mfem::Vector P(trial_fes->GetTrueVSize()); // H(Curl) gridfunction true DOFs
-  B = 0.0;
-  input_gf->GetTrueDofs(P);
+  mfem::Vector b(test_fes->GetTrueVSize());  // Linear form true DOFs
+  mfem::Vector x(test_fes->GetTrueVSize());  // H(Div) gridfunction true DOFs
+  mfem::Vector p(trial_fes->GetTrueVSize()); // H(Curl) gridfunction true DOFs
+  b = 0.0;
+  input_gf->GetTrueDofs(p);
 
   // Reassemble in case coef has changed
   a_mixed->Update();
@@ -89,11 +89,11 @@ ScaledVectorGridFunctionAux::Solve(double t)
   a_mixed->Finalize();
 
   mixed_mat = std::unique_ptr<mfem::HypreParMatrix>(a_mixed->ParallelAssemble());
-  mixed_mat->AddMult(P, B, _aConst);
+  mixed_mat->AddMult(p, b, _aConst);
 
-  X = 0.0;
-  solver->Mult(B, X);
-  scaled_gf->SetFromTrueDofs(X);
+  x = 0.0;
+  solver->Mult(b, x);
+  scaled_gf->SetFromTrueDofs(x);
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
+++ b/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
@@ -27,35 +27,35 @@ public:
 
 protected:
   // Pointers to store trial and test FE spaces
-  mfem::ParFiniteElementSpace * trial_fes{nullptr};
-  mfem::ParFiniteElementSpace * test_fes{nullptr};
+  mfem::ParFiniteElementSpace * _trial_fes{nullptr};
+  mfem::ParFiniteElementSpace * _test_fes{nullptr};
 
   // Bilinear forms
-  std::unique_ptr<mfem::ParBilinearForm> a{nullptr};
-  std::unique_ptr<mfem::ParMixedBilinearForm> a_mixed{nullptr};
+  std::unique_ptr<mfem::ParBilinearForm> _a{nullptr};
+  std::unique_ptr<mfem::ParMixedBilinearForm> _a_mixed{nullptr};
 
   // Coefficient to scale input gridfunction by
-  mfem::Coefficient * coef{nullptr};
+  mfem::Coefficient * _coef{nullptr};
   // Optional constant to scale input gridfunction by
 
 private:
   const std::string _input_gf_name;
   const std::string _scaled_gf_name;
   const std::string _coef_name;
-  const double _aConst;
+  const double _a_const;
   const hephaestus::InputParameters _solver_options;
 
   // Input gridfunction to be scaled by a scalar coefficient
-  mfem::ParGridFunction * input_gf{nullptr};
+  mfem::ParGridFunction * _input_gf{nullptr};
 
   // Gridfunction in which to store result
-  mfem::ParGridFunction * scaled_gf{nullptr};
+  mfem::ParGridFunction * _scaled_gf{nullptr};
 
   // Operator matrices
-  std::unique_ptr<mfem::HypreParMatrix> a_mat{nullptr};
-  std::unique_ptr<mfem::HypreParMatrix> mixed_mat{nullptr};
+  std::unique_ptr<mfem::HypreParMatrix> _a_mat{nullptr};
+  std::unique_ptr<mfem::HypreParMatrix> _mixed_mat{nullptr};
 
   // Solver
-  std::unique_ptr<hephaestus::DefaultJacobiPCGSolver> solver{nullptr};
+  std::unique_ptr<hephaestus::DefaultJacobiPCGSolver> _solver{nullptr};
 };
 } // namespace hephaestus

--- a/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
+++ b/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
@@ -21,8 +21,8 @@ public:
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;
-  virtual void buildBilinearForm();
-  virtual void buildMixedBilinearForm();
+  virtual void BuildBilinearForm();
+  virtual void BuildMixedBilinearForm();
   void Solve(double t = 0.0) override;
 
 protected:

--- a/src/auxsolvers/vector_coefficient_aux.cpp
+++ b/src/auxsolvers/vector_coefficient_aux.cpp
@@ -14,13 +14,13 @@ void
 VectorCoefficientAux::Init(const hephaestus::GridFunctions & gridfunctions,
                            hephaestus::Coefficients & coefficients)
 {
-  gf = gridfunctions.Get(_gf_name);
-  if (gf == nullptr)
+  _gf = gridfunctions.Get(_gf_name);
+  if (_gf == nullptr)
   {
     MFEM_ABORT("GridFunction " << _gf_name << " not found when initializing VectorCoefficientAux");
   }
-  vec_coef = coefficients.vectors.Get(_vec_coef_name);
-  if (vec_coef == nullptr)
+  _vec_coef = coefficients._vectors.Get(_vec_coef_name);
+  if (_vec_coef == nullptr)
   {
     MFEM_ABORT("VectorCoefficient " << _vec_coef_name
                                     << " not found when initializing VectorCoefficientAux");
@@ -30,8 +30,8 @@ VectorCoefficientAux::Init(const hephaestus::GridFunctions & gridfunctions,
 void
 VectorCoefficientAux::Solve(double t)
 {
-  vec_coef->SetTime(t);
-  gf->ProjectCoefficient(*vec_coef);
+  _vec_coef->SetTime(t);
+  _gf->ProjectCoefficient(*_vec_coef);
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/vector_coefficient_aux.hpp
+++ b/src/auxsolvers/vector_coefficient_aux.hpp
@@ -21,8 +21,8 @@ protected:
   const std::string _gf_name;       // name of the variable
   const std::string _vec_coef_name; // name of the vector coefficient
 
-  mfem::ParGridFunction * gf{nullptr};
-  mfem::VectorCoefficient * vec_coef{nullptr};
+  mfem::ParGridFunction * _gf{nullptr};
+  mfem::VectorCoefficient * _vec_coef{nullptr};
 };
 
 } // namespace hephaestus

--- a/src/auxsolvers/vector_gridfunction_cross_product_aux.cpp
+++ b/src/auxsolvers/vector_gridfunction_cross_product_aux.cpp
@@ -54,7 +54,7 @@ VectorGridFunctionCrossProductAux::Init(const hephaestus::GridFunctions & gridfu
                                << " not found when initializing ScaledVectorGridFunctionAux");
   }
 
-  coefficients.vectors.Register(
+  coefficients._vectors.Register(
       _vec_coef_name,
       new hephaestus::VectorGridFunctionCrossProductCoefficient(*_u_gf, *_v_gf),
       true);

--- a/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
+++ b/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
@@ -9,8 +9,8 @@ double
 VectorGridFunctionDotProductCoefficient::Eval(mfem::ElementTransformation & T,
                                               const mfem::IntegrationPoint & ip)
 {
-  double coefValue;
-  coefValue = _coef.Eval(T, ip);
+  double coef_value;
+  coef_value = _coef.Eval(T, ip);
 
   mfem::Vector u_re;
   mfem::Vector u_im;
@@ -21,13 +21,13 @@ VectorGridFunctionDotProductCoefficient::Eval(mfem::ElementTransformation & T,
   _v_gf_re->GetVectorValue(T, ip, v_re);
   if (_u_gf_im == nullptr || _v_gf_im == nullptr)
   {
-    return coefValue * (u_re * v_re);
+    return coef_value * (u_re * v_re);
   }
   else
   {
     _u_gf_im->GetVectorValue(T, ip, u_im);
     _v_gf_im->GetVectorValue(T, ip, v_im);
-    return 0.5 * coefValue * (u_re * v_re + u_im * v_im);
+    return 0.5 * coef_value * (u_re * v_re + u_im * v_im);
   }
 }
 

--- a/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
+++ b/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
@@ -56,7 +56,7 @@ VectorGridFunctionDotProductAux::Init(const hephaestus::GridFunctions & gridfunc
                                       hephaestus::Coefficients & coefficients)
 {
 
-  _scaling_coef = coefficients.scalars.Get(_scaling_coef_name);
+  _scaling_coef = coefficients._scalars.Get(_scaling_coef_name);
   if (_scaling_coef == nullptr)
   {
     MFEM_ABORT("Conductivity coefficient not found for Joule heating");
@@ -105,10 +105,10 @@ VectorGridFunctionDotProductAux::Init(const hephaestus::GridFunctions & gridfunc
     }
   }
 
-  coefficients.scalars.Register(_coef_name,
-                                new VectorGridFunctionDotProductCoefficient(
-                                    *_scaling_coef, _u_gf_re, _v_gf_re, _u_gf_im, _v_gf_im),
-                                true);
+  coefficients._scalars.Register(_coef_name,
+                                 new VectorGridFunctionDotProductCoefficient(
+                                     *_scaling_coef, _u_gf_re, _v_gf_re, _u_gf_im, _v_gf_im),
+                                 true);
 
   CoefficientAux::Init(gridfunctions, coefficients);
 }

--- a/src/boundary_conditions/Essential/essential_bc_base.hpp
+++ b/src/boundary_conditions/Essential/essential_bc_base.hpp
@@ -9,8 +9,8 @@ class EssentialBC : public BoundaryCondition
 public:
   EssentialBC(const std::string & name_, mfem::Array<int> bdr_attributes_);
 
-  virtual void applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_){};
-  virtual void applyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh * mesh_){};
+  virtual void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_){};
+  virtual void ApplyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh * mesh_){};
 };
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Essential/function_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/function_dirichlet_bc.cpp
@@ -17,10 +17,10 @@ ScalarDirichletBC::ScalarDirichletBC(const std::string & name_,
 }
 
 void
-ScalarDirichletBC::applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_)
+ScalarDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_)
 {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
-  ess_bdrs = getMarkers(*mesh_);
+  ess_bdrs = GetMarkers(*mesh_);
   gridfunc.ProjectBdrCoefficient(*(coeff), ess_bdrs);
 }
 

--- a/src/boundary_conditions/Essential/function_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/function_dirichlet_bc.cpp
@@ -12,7 +12,7 @@ ScalarDirichletBC::ScalarDirichletBC(const std::string & name_,
                                      mfem::Array<int> bdr_attributes_,
                                      mfem::Coefficient * coeff_,
                                      mfem::Coefficient * coeff_im_)
-  : EssentialBC(name_, bdr_attributes_), coeff(coeff_), coeff_im(coeff_im_)
+  : EssentialBC(name_, bdr_attributes_), _coeff(coeff_), _coeff_im(coeff_im_)
 {
 }
 
@@ -21,7 +21,7 @@ ScalarDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_)
 {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
   ess_bdrs = GetMarkers(*mesh_);
-  gridfunc.ProjectBdrCoefficient(*(coeff), ess_bdrs);
+  gridfunc.ProjectBdrCoefficient(*(_coeff), ess_bdrs);
 }
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Essential/function_dirichlet_bc.hpp
+++ b/src/boundary_conditions/Essential/function_dirichlet_bc.hpp
@@ -13,7 +13,7 @@ public:
                     mfem::Coefficient * coeff_,
                     mfem::Coefficient * coeff_im_ = nullptr);
 
-  void applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_) override;
+  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_) override;
 
   mfem::Coefficient * coeff;
   mfem::Coefficient * coeff_im;

--- a/src/boundary_conditions/Essential/function_dirichlet_bc.hpp
+++ b/src/boundary_conditions/Essential/function_dirichlet_bc.hpp
@@ -15,8 +15,8 @@ public:
 
   void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_) override;
 
-  mfem::Coefficient * coeff;
-  mfem::Coefficient * coeff_im;
+  mfem::Coefficient * _coeff;
+  mfem::Coefficient * _coeff_im;
 };
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
@@ -14,9 +14,9 @@ VectorDirichletBC::VectorDirichletBC(const std::string & name_,
                                      mfem::VectorCoefficient * vec_coeff_im_,
                                      APPLY_TYPE boundary_apply_type_)
   : EssentialBC(name_, bdr_attributes_),
-    vec_coeff(vec_coeff_),
-    vec_coeff_im(vec_coeff_im_),
-    boundary_apply_type(boundary_apply_type_)
+    _vec_coeff(vec_coeff_),
+    _vec_coeff_im(vec_coeff_im_),
+    _boundary_apply_type(boundary_apply_type_)
 {
 }
 
@@ -25,22 +25,22 @@ VectorDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_)
 {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
   ess_bdrs = GetMarkers(*mesh_);
-  if (vec_coeff == nullptr)
+  if (_vec_coeff == nullptr)
   {
     MFEM_ABORT("Boundary condition does not store valid coefficients to specify the "
                "components of the vector at the Dirichlet boundary.");
   }
 
-  switch (boundary_apply_type)
+  switch (_boundary_apply_type)
   {
     case STANDARD:
-      gridfunc.ProjectBdrCoefficient(*(vec_coeff), ess_bdrs);
+      gridfunc.ProjectBdrCoefficient(*(_vec_coeff), ess_bdrs);
       break;
     case NORMAL:
-      gridfunc.ProjectBdrCoefficientNormal(*(vec_coeff), ess_bdrs);
+      gridfunc.ProjectBdrCoefficientNormal(*(_vec_coeff), ess_bdrs);
       break;
     case TANGENTIAL:
-      gridfunc.ProjectBdrCoefficientTangent(*(vec_coeff), ess_bdrs);
+      gridfunc.ProjectBdrCoefficientTangent(*(_vec_coeff), ess_bdrs);
   }
 }
 
@@ -49,13 +49,13 @@ VectorDirichletBC::ApplyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh *
 {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
   ess_bdrs = GetMarkers(*mesh_);
-  if (vec_coeff == nullptr || vec_coeff_im == nullptr)
+  if (_vec_coeff == nullptr || _vec_coeff_im == nullptr)
   {
     MFEM_ABORT("Boundary condition does not store valid coefficients to specify both "
                "the real and imaginary components of the vector at the Dirichlet "
                "boundary.");
   }
-  gridfunc.ProjectBdrCoefficientTangent(*(vec_coeff), *(vec_coeff_im), ess_bdrs);
+  gridfunc.ProjectBdrCoefficientTangent(*(_vec_coeff), *(_vec_coeff_im), ess_bdrs);
 }
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.cpp
@@ -21,10 +21,10 @@ VectorDirichletBC::VectorDirichletBC(const std::string & name_,
 }
 
 void
-VectorDirichletBC::applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_)
+VectorDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_)
 {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
-  ess_bdrs = getMarkers(*mesh_);
+  ess_bdrs = GetMarkers(*mesh_);
   if (vec_coeff == nullptr)
   {
     MFEM_ABORT("Boundary condition does not store valid coefficients to specify the "
@@ -45,10 +45,10 @@ VectorDirichletBC::applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_)
 }
 
 void
-VectorDirichletBC::applyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh * mesh_)
+VectorDirichletBC::ApplyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh * mesh_)
 {
   mfem::Array<int> ess_bdrs(mesh_->bdr_attributes.Max());
-  ess_bdrs = getMarkers(*mesh_);
+  ess_bdrs = GetMarkers(*mesh_);
   if (vec_coeff == nullptr || vec_coeff_im == nullptr)
   {
     MFEM_ABORT("Boundary condition does not store valid coefficients to specify both "

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
@@ -23,9 +23,9 @@ public:
                     mfem::VectorCoefficient * vec_coeff_im_ = nullptr,
                     APPLY_TYPE boundary_apply_type = TANGENTIAL);
 
-  void applyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_) override;
+  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh * mesh_) override;
 
-  void applyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh * mesh_) override;
+  void ApplyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh * mesh_) override;
 
   mfem::VectorCoefficient * vec_coeff;
   mfem::VectorCoefficient * vec_coeff_im;

--- a/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
+++ b/src/boundary_conditions/Essential/vector_dirichlet_bc.hpp
@@ -27,9 +27,9 @@ public:
 
   void ApplyBC(mfem::ParComplexGridFunction & gridfunc, mfem::Mesh * mesh_) override;
 
-  mfem::VectorCoefficient * vec_coeff;
-  mfem::VectorCoefficient * vec_coeff_im;
-  APPLY_TYPE boundary_apply_type;
+  mfem::VectorCoefficient * _vec_coeff;
+  mfem::VectorCoefficient * _vec_coeff_im;
+  APPLY_TYPE _boundary_apply_type;
 };
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Integrated/integrated_bc_base.cpp
+++ b/src/boundary_conditions/Integrated/integrated_bc_base.cpp
@@ -13,8 +13,8 @@ IntegratedBC::IntegratedBC(const std::string & name_,
                            mfem::LinearFormIntegrator * lfi_re_,
                            mfem::LinearFormIntegrator * lfi_im_)
   : BoundaryCondition(name_, bdr_attributes_),
-    lfi_re(std::unique_ptr<mfem::LinearFormIntegrator>(lfi_re_)),
-    lfi_im(std::unique_ptr<mfem::LinearFormIntegrator>(lfi_im_))
+    _lfi_re(std::unique_ptr<mfem::LinearFormIntegrator>(lfi_re_)),
+    _lfi_im(std::unique_ptr<mfem::LinearFormIntegrator>(lfi_im_))
 {
 }
 
@@ -22,19 +22,19 @@ void
 IntegratedBC::ApplyBC(mfem::LinearForm & b)
 {
   // NB: release ownership to prevent double-free. LinearForm assumes ownership.
-  b.AddBoundaryIntegrator(lfi_re.release(), markers);
+  b.AddBoundaryIntegrator(_lfi_re.release(), _markers);
 }
 
 void
 IntegratedBC::ApplyBC(mfem::ComplexLinearForm & b)
 {
-  b.AddBoundaryIntegrator(lfi_re.release(), lfi_im.release(), markers);
+  b.AddBoundaryIntegrator(_lfi_re.release(), _lfi_im.release(), _markers);
 }
 
 void
 IntegratedBC::ApplyBC(mfem::ParComplexLinearForm & b)
 {
-  b.AddBoundaryIntegrator(lfi_re.release(), lfi_im.release(), markers);
+  b.AddBoundaryIntegrator(_lfi_re.release(), _lfi_im.release(), _markers);
 }
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Integrated/integrated_bc_base.cpp
+++ b/src/boundary_conditions/Integrated/integrated_bc_base.cpp
@@ -19,20 +19,20 @@ IntegratedBC::IntegratedBC(const std::string & name_,
 }
 
 void
-IntegratedBC::applyBC(mfem::LinearForm & b)
+IntegratedBC::ApplyBC(mfem::LinearForm & b)
 {
   // NB: release ownership to prevent double-free. LinearForm assumes ownership.
   b.AddBoundaryIntegrator(lfi_re.release(), markers);
 }
 
 void
-IntegratedBC::applyBC(mfem::ComplexLinearForm & b)
+IntegratedBC::ApplyBC(mfem::ComplexLinearForm & b)
 {
   b.AddBoundaryIntegrator(lfi_re.release(), lfi_im.release(), markers);
 }
 
 void
-IntegratedBC::applyBC(mfem::ParComplexLinearForm & b)
+IntegratedBC::ApplyBC(mfem::ParComplexLinearForm & b)
 {
   b.AddBoundaryIntegrator(lfi_re.release(), lfi_im.release(), markers);
 }

--- a/src/boundary_conditions/Integrated/integrated_bc_base.hpp
+++ b/src/boundary_conditions/Integrated/integrated_bc_base.hpp
@@ -14,8 +14,8 @@ public:
                mfem::LinearFormIntegrator * lfi_im_ = nullptr);
 
   // NB: assume ownership of pointers.
-  std::unique_ptr<mfem::LinearFormIntegrator> lfi_re;
-  std::unique_ptr<mfem::LinearFormIntegrator> lfi_im;
+  std::unique_ptr<mfem::LinearFormIntegrator> _lfi_re;
+  std::unique_ptr<mfem::LinearFormIntegrator> _lfi_im;
 
   void ApplyBC(mfem::LinearForm & b) override;
   void ApplyBC(mfem::ComplexLinearForm & b) override;

--- a/src/boundary_conditions/Integrated/integrated_bc_base.hpp
+++ b/src/boundary_conditions/Integrated/integrated_bc_base.hpp
@@ -17,9 +17,9 @@ public:
   std::unique_ptr<mfem::LinearFormIntegrator> lfi_re;
   std::unique_ptr<mfem::LinearFormIntegrator> lfi_im;
 
-  void applyBC(mfem::LinearForm & b) override;
-  void applyBC(mfem::ComplexLinearForm & b) override;
-  void applyBC(mfem::ParComplexLinearForm & b) override;
+  void ApplyBC(mfem::LinearForm & b) override;
+  void ApplyBC(mfem::ComplexLinearForm & b) override;
+  void ApplyBC(mfem::ParComplexLinearForm & b) override;
 };
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Robin/robin_bc_base.cpp
+++ b/src/boundary_conditions/Robin/robin_bc_base.cpp
@@ -16,7 +16,7 @@ RobinBC::RobinBC(const std::string & name_,
 }
 
 void
-RobinBC::applyBC(mfem::ParBilinearForm & a)
+RobinBC::ApplyBC(mfem::ParBilinearForm & a)
 {
   // NB: ParBilinearForm assumes ownership of pointers. Release to
   // prevent double-free!
@@ -24,7 +24,7 @@ RobinBC::applyBC(mfem::ParBilinearForm & a)
 }
 
 void
-RobinBC::applyBC(mfem::ParSesquilinearForm & a)
+RobinBC::ApplyBC(mfem::ParSesquilinearForm & a)
 {
   a.AddBoundaryIntegrator(blfi_re.release(), blfi_im.release(), markers);
 }

--- a/src/boundary_conditions/Robin/robin_bc_base.cpp
+++ b/src/boundary_conditions/Robin/robin_bc_base.cpp
@@ -10,8 +10,8 @@ RobinBC::RobinBC(const std::string & name_,
                  mfem::BilinearFormIntegrator * blfi_im_,
                  mfem::LinearFormIntegrator * lfi_im_)
   : IntegratedBC(name_, bdr_attributes_, lfi_re_, lfi_im_),
-    blfi_re(std::unique_ptr<mfem::BilinearFormIntegrator>(blfi_re_)),
-    blfi_im(std::unique_ptr<mfem::BilinearFormIntegrator>(blfi_im_))
+    _blfi_re(std::unique_ptr<mfem::BilinearFormIntegrator>(blfi_re_)),
+    _blfi_im(std::unique_ptr<mfem::BilinearFormIntegrator>(blfi_im_))
 {
 }
 
@@ -20,13 +20,13 @@ RobinBC::ApplyBC(mfem::ParBilinearForm & a)
 {
   // NB: ParBilinearForm assumes ownership of pointers. Release to
   // prevent double-free!
-  a.AddBoundaryIntegrator(blfi_re.release(), markers);
+  a.AddBoundaryIntegrator(_blfi_re.release(), _markers);
 }
 
 void
 RobinBC::ApplyBC(mfem::ParSesquilinearForm & a)
 {
-  a.AddBoundaryIntegrator(blfi_re.release(), blfi_im.release(), markers);
+  a.AddBoundaryIntegrator(_blfi_re.release(), _blfi_im.release(), _markers);
 }
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Robin/robin_bc_base.hpp
+++ b/src/boundary_conditions/Robin/robin_bc_base.hpp
@@ -15,8 +15,8 @@ public:
           mfem::LinearFormIntegrator * lfi_im_ = nullptr);
 
   // NB: assume ownership of pointers.
-  std::unique_ptr<mfem::BilinearFormIntegrator> blfi_re{nullptr};
-  std::unique_ptr<mfem::BilinearFormIntegrator> blfi_im{nullptr};
+  std::unique_ptr<mfem::BilinearFormIntegrator> _blfi_re{nullptr};
+  std::unique_ptr<mfem::BilinearFormIntegrator> _blfi_im{nullptr};
 
   virtual void ApplyBC(mfem::ParBilinearForm & a);
   virtual void ApplyBC(mfem::ParSesquilinearForm & a);

--- a/src/boundary_conditions/Robin/robin_bc_base.hpp
+++ b/src/boundary_conditions/Robin/robin_bc_base.hpp
@@ -18,8 +18,8 @@ public:
   std::unique_ptr<mfem::BilinearFormIntegrator> blfi_re{nullptr};
   std::unique_ptr<mfem::BilinearFormIntegrator> blfi_im{nullptr};
 
-  virtual void applyBC(mfem::ParBilinearForm & a);
-  virtual void applyBC(mfem::ParSesquilinearForm & a);
+  virtual void ApplyBC(mfem::ParBilinearForm & a);
+  virtual void ApplyBC(mfem::ParSesquilinearForm & a);
 };
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Robin/rwte10_port_rbc.cpp
+++ b/src/boundary_conditions/Robin/rwte10_port_rbc.cpp
@@ -47,35 +47,35 @@ void
 RWTE10PortRBC::RWTE10(const mfem::Vector & x, std::vector<std::complex<double>> & E)
 {
 
-  mfem::Vector E_hat(CrossProduct(k_c, k_a));
-  E_hat *= 1.0 / E_hat.Norml2();
+  mfem::Vector e_hat(CrossProduct(k_c, k_a));
+  e_hat *= 1.0 / e_hat.Norml2();
 
-  double E0(sqrt(2 * omega_ * mu0_ / (a1Vec.Norml2() * a2Vec.Norml2() * k_.imag())));
-  std::complex<double> E_mag = E0 * sin(InnerProduct(k_a, x)) * exp(-zi * InnerProduct(k_c, x));
+  double e0(sqrt(2 * omega_ * mu0_ / (a1Vec.Norml2() * a2Vec.Norml2() * k_.imag())));
+  std::complex<double> e_mag = e0 * sin(InnerProduct(k_a, x)) * exp(-zi * InnerProduct(k_c, x));
 
-  E[0] = E_mag * E_hat(1);
-  E[1] = E_mag * E_hat(2);
-  E[2] = E_mag * E_hat(0);
+  E[0] = e_mag * e_hat(1);
+  E[1] = e_mag * e_hat(2);
+  E[2] = e_mag * e_hat(0);
 }
 
 void
 RWTE10PortRBC::RWTE10Real(const mfem::Vector & x, mfem::Vector & v)
 {
-  std::vector<std::complex<double>> Eval(x.Size());
-  RWTE10(x, Eval);
+  std::vector<std::complex<double>> eval(x.Size());
+  RWTE10(x, eval);
   for (int i = 0; i < x.Size(); ++i)
   {
-    v(i) = -2 * k_.imag() * Eval[i].imag() / mu0_;
+    v(i) = -2 * k_.imag() * eval[i].imag() / mu0_;
   }
 }
 void
 RWTE10PortRBC::RWTE10Imag(const mfem::Vector & x, mfem::Vector & v)
 {
-  std::vector<std::complex<double>> Eval(x.Size());
-  RWTE10(x, Eval);
+  std::vector<std::complex<double>> eval(x.Size());
+  RWTE10(x, eval);
   for (int i = 0; i < x.Size(); ++i)
   {
-    v(i) = 2 * k_.imag() * Eval[i].real() / mu0_;
+    v(i) = 2 * k_.imag() * eval[i].real() / mu0_;
   }
 }
 

--- a/src/boundary_conditions/Robin/rwte10_port_rbc.cpp
+++ b/src/boundary_conditions/Robin/rwte10_port_rbc.cpp
@@ -14,9 +14,9 @@ RWTE10PortRBC::RWTE10PortRBC(const std::string & name_,
     omega_(2 * M_PI * frequency_),
     a1Vec(port_length_vector_, 3),
     a2Vec(port_width_vector_, 3),
-    a3Vec(cross_product(a1Vec, a2Vec)),
-    a2xa3(cross_product(a2Vec, a3Vec)),
-    a3xa1(cross_product(a3Vec, a1Vec)),
+    a3Vec(CrossProduct(a1Vec, a2Vec)),
+    a2xa3(CrossProduct(a2Vec, a3Vec)),
+    a3xa1(CrossProduct(a3Vec, a1Vec)),
     V(mfem::InnerProduct(a1Vec, a2xa3)),
     kc(M_PI / a1Vec.Norml2()),
     k0(omega_ * sqrt(epsilon0_ * mu0_)),
@@ -33,10 +33,10 @@ RWTE10PortRBC::RWTE10PortRBC(const std::string & name_,
   if (input_port)
   {
     u_real = std::make_unique<mfem::VectorFunctionCoefficient>(
-        3, [this](const mfem::Vector & x, mfem::Vector & v) { return RWTE10_real(x, v); });
+        3, [this](const mfem::Vector & x, mfem::Vector & v) { return RWTE10Real(x, v); });
 
     u_imag = std::make_unique<mfem::VectorFunctionCoefficient>(
-        3, [this](const mfem::Vector & x, mfem::Vector & v) { return RWTE10_imag(x, v); });
+        3, [this](const mfem::Vector & x, mfem::Vector & v) { return RWTE10Imag(x, v); });
 
     lfi_re = std::make_unique<mfem::VectorFEBoundaryTangentLFIntegrator>(*u_real);
     lfi_im = std::make_unique<mfem::VectorFEBoundaryTangentLFIntegrator>(*u_imag);
@@ -47,7 +47,7 @@ void
 RWTE10PortRBC::RWTE10(const mfem::Vector & x, std::vector<std::complex<double>> & E)
 {
 
-  mfem::Vector E_hat(cross_product(k_c, k_a));
+  mfem::Vector E_hat(CrossProduct(k_c, k_a));
   E_hat *= 1.0 / E_hat.Norml2();
 
   double E0(sqrt(2 * omega_ * mu0_ / (a1Vec.Norml2() * a2Vec.Norml2() * k_.imag())));
@@ -59,7 +59,7 @@ RWTE10PortRBC::RWTE10(const mfem::Vector & x, std::vector<std::complex<double>> 
 }
 
 void
-RWTE10PortRBC::RWTE10_real(const mfem::Vector & x, mfem::Vector & v)
+RWTE10PortRBC::RWTE10Real(const mfem::Vector & x, mfem::Vector & v)
 {
   std::vector<std::complex<double>> Eval(x.Size());
   RWTE10(x, Eval);
@@ -69,7 +69,7 @@ RWTE10PortRBC::RWTE10_real(const mfem::Vector & x, mfem::Vector & v)
   }
 }
 void
-RWTE10PortRBC::RWTE10_imag(const mfem::Vector & x, mfem::Vector & v)
+RWTE10PortRBC::RWTE10Imag(const mfem::Vector & x, mfem::Vector & v)
 {
   std::vector<std::complex<double>> Eval(x.Size());
   RWTE10(x, Eval);

--- a/src/boundary_conditions/Robin/rwte10_port_rbc.hpp
+++ b/src/boundary_conditions/Robin/rwte10_port_rbc.hpp
@@ -19,7 +19,7 @@ public:
                 double port_width_vector[3],
                 bool input_port);
 
-  static mfem::Vector cross_product(mfem::Vector & va, mfem::Vector & vb)
+  static mfem::Vector CrossProduct(mfem::Vector & va, mfem::Vector & vb)
   {
     mfem::Vector Vec;
     Vec.SetSize(3);
@@ -29,8 +29,8 @@ public:
     return Vec;
   }
   void RWTE10(const mfem::Vector & x, std::vector<std::complex<double>> & E);
-  void RWTE10_real(const mfem::Vector & x, mfem::Vector & v);
-  void RWTE10_imag(const mfem::Vector & x, mfem::Vector & v);
+  void RWTE10Real(const mfem::Vector & x, mfem::Vector & v);
+  void RWTE10Imag(const mfem::Vector & x, mfem::Vector & v);
 
   bool input_port;
   double omega_;

--- a/src/boundary_conditions/Robin/rwte10_port_rbc.hpp
+++ b/src/boundary_conditions/Robin/rwte10_port_rbc.hpp
@@ -32,25 +32,25 @@ public:
   void RWTE10Real(const mfem::Vector & x, mfem::Vector & v);
   void RWTE10Imag(const mfem::Vector & x, mfem::Vector & v);
 
-  bool input_port;
-  double omega_;
-  mfem::Vector a1Vec;
-  mfem::Vector a2Vec;
-  mfem::Vector a3Vec;
-  mfem::Vector a2xa3;
-  mfem::Vector a3xa1;
+  bool _input_port;
+  double _omega;
+  mfem::Vector _a1_vec;
+  mfem::Vector _a2_vec;
+  mfem::Vector _a3_vec;
+  mfem::Vector _a2xa3;
+  mfem::Vector _a3xa1;
 
-  double V;
-  double kc;
-  double k0;
-  std::complex<double> k_;
+  double _v;
+  double _kc;
+  double _k0;
+  std::complex<double> _k;
 
-  mfem::Vector k_a;
-  mfem::Vector k_c;
+  mfem::Vector _k_a;
+  mfem::Vector _k_c;
 
-  std::unique_ptr<mfem::ConstantCoefficient> robin_coef_im;
-  std::unique_ptr<mfem::VectorFunctionCoefficient> u_real;
-  std::unique_ptr<mfem::VectorFunctionCoefficient> u_imag;
+  std::unique_ptr<mfem::ConstantCoefficient> _robin_coef_im;
+  std::unique_ptr<mfem::VectorFunctionCoefficient> _u_real;
+  std::unique_ptr<mfem::VectorFunctionCoefficient> _u_imag;
 };
 
 } // namespace hephaestus

--- a/src/boundary_conditions/Robin/rwte10_port_rbc.hpp
+++ b/src/boundary_conditions/Robin/rwte10_port_rbc.hpp
@@ -21,12 +21,12 @@ public:
 
   static mfem::Vector CrossProduct(mfem::Vector & va, mfem::Vector & vb)
   {
-    mfem::Vector Vec;
-    Vec.SetSize(3);
-    Vec[0] = va[1] * vb[2] - va[2] * vb[1];
-    Vec[1] = va[2] * vb[0] - va[0] * vb[2];
-    Vec[2] = va[0] * vb[1] - va[1] * vb[0];
-    return Vec;
+    mfem::Vector vec;
+    vec.SetSize(3);
+    vec[0] = va[1] * vb[2] - va[2] * vb[1];
+    vec[1] = va[2] * vb[0] - va[0] * vb[2];
+    vec[2] = va[0] * vb[1] - va[1] * vb[0];
+    return vec;
   }
   void RWTE10(const mfem::Vector & x, std::vector<std::complex<double>> & E);
   void RWTE10Real(const mfem::Vector & x, mfem::Vector & v);

--- a/src/boundary_conditions/boundary_condition_base.cpp
+++ b/src/boundary_conditions/boundary_condition_base.cpp
@@ -6,15 +6,15 @@ namespace hephaestus
 {
 
 BoundaryCondition::BoundaryCondition(std::string name_, mfem::Array<int> bdr_attributes_)
-  : name(std::move(name_)), bdr_attributes(std::move(bdr_attributes_))
+  : _name(std::move(name_)), _bdr_attributes(std::move(bdr_attributes_))
 {
 }
 
 mfem::Array<int>
 BoundaryCondition::GetMarkers(mfem::Mesh & mesh)
 {
-  mfem::common::AttrToMarker(mesh.bdr_attributes.Max(), bdr_attributes, markers);
-  return markers;
+  mfem::common::AttrToMarker(mesh.bdr_attributes.Max(), _bdr_attributes, _markers);
+  return _markers;
 }
 
 } // namespace hephaestus

--- a/src/boundary_conditions/boundary_condition_base.cpp
+++ b/src/boundary_conditions/boundary_condition_base.cpp
@@ -11,7 +11,7 @@ BoundaryCondition::BoundaryCondition(std::string name_, mfem::Array<int> bdr_att
 }
 
 mfem::Array<int>
-BoundaryCondition::getMarkers(mfem::Mesh & mesh)
+BoundaryCondition::GetMarkers(mfem::Mesh & mesh)
 {
   mfem::common::AttrToMarker(mesh.bdr_attributes.Max(), bdr_attributes, markers);
   return markers;

--- a/src/boundary_conditions/boundary_condition_base.hpp
+++ b/src/boundary_conditions/boundary_condition_base.hpp
@@ -14,9 +14,9 @@ public:
   BoundaryCondition(std::string name_, mfem::Array<int> bdr_attributes_);
   mfem::Array<int> GetMarkers(mfem::Mesh & mesh);
 
-  std::string name;
-  mfem::Array<int> bdr_attributes;
-  mfem::Array<int> markers;
+  std::string _name;
+  mfem::Array<int> _bdr_attributes;
+  mfem::Array<int> _markers;
 
   virtual void ApplyBC(mfem::LinearForm & b){};
   virtual void ApplyBC(mfem::ComplexLinearForm & b){};

--- a/src/boundary_conditions/boundary_condition_base.hpp
+++ b/src/boundary_conditions/boundary_condition_base.hpp
@@ -12,15 +12,15 @@ class BoundaryCondition
 {
 public:
   BoundaryCondition(std::string name_, mfem::Array<int> bdr_attributes_);
-  mfem::Array<int> getMarkers(mfem::Mesh & mesh);
+  mfem::Array<int> GetMarkers(mfem::Mesh & mesh);
 
   std::string name;
   mfem::Array<int> bdr_attributes;
   mfem::Array<int> markers;
 
-  virtual void applyBC(mfem::LinearForm & b){};
-  virtual void applyBC(mfem::ComplexLinearForm & b){};
-  virtual void applyBC(mfem::ParComplexLinearForm & b){};
+  virtual void ApplyBC(mfem::LinearForm & b){};
+  virtual void ApplyBC(mfem::ComplexLinearForm & b){};
+  virtual void ApplyBC(mfem::ParComplexLinearForm & b){};
 };
 
 } // namespace hephaestus

--- a/src/boundary_conditions/boundary_conditions.cpp
+++ b/src/boundary_conditions/boundary_conditions.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 mfem::Array<int>
-BCMap::getEssentialBdrMarkers(const std::string & name_, mfem::Mesh * mesh_)
+BCMap::GetEssentialBdrMarkers(const std::string & name_, mfem::Mesh * mesh_)
 {
   mfem::Array<int> global_ess_markers(mesh_->bdr_attributes.Max());
   global_ess_markers = 0;
@@ -18,7 +18,7 @@ BCMap::getEssentialBdrMarkers(const std::string & name_, mfem::Mesh * mesh_)
       bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
       if (bc != nullptr)
       {
-        ess_bdrs = bc->getMarkers(*mesh_);
+        ess_bdrs = bc->GetMarkers(*mesh_);
         for (auto it = 0; it != mesh_->bdr_attributes.Max(); ++it)
         {
           global_ess_markers[it] = std::max(global_ess_markers[it], ess_bdrs[it]);
@@ -30,7 +30,7 @@ BCMap::getEssentialBdrMarkers(const std::string & name_, mfem::Mesh * mesh_)
 }
 
 void
-BCMap::applyEssentialBCs(const std::string & name_,
+BCMap::ApplyEssentialBCs(const std::string & name_,
                          mfem::Array<int> & ess_tdof_list,
                          mfem::GridFunction & gridfunc,
                          mfem::Mesh * mesh_)
@@ -43,16 +43,16 @@ BCMap::applyEssentialBCs(const std::string & name_,
       auto * bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
       if (bc != nullptr)
       {
-        bc->applyBC(gridfunc, mesh_);
+        bc->ApplyBC(gridfunc, mesh_);
       }
     }
   }
-  mfem::Array<int> ess_bdr = getEssentialBdrMarkers(name_, mesh_);
+  mfem::Array<int> ess_bdr = GetEssentialBdrMarkers(name_, mesh_);
   gridfunc.FESpace()->GetEssentialTrueDofs(ess_bdr, ess_tdof_list);
 };
 
 void
-BCMap::applyEssentialBCs(const std::string & name_,
+BCMap::ApplyEssentialBCs(const std::string & name_,
                          mfem::Array<int> & ess_tdof_list,
                          mfem::ParComplexGridFunction & gridfunc,
                          mfem::Mesh * mesh_)
@@ -65,16 +65,16 @@ BCMap::applyEssentialBCs(const std::string & name_,
       auto * bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
       if (bc != nullptr)
       {
-        bc->applyBC(gridfunc, mesh_);
+        bc->ApplyBC(gridfunc, mesh_);
       }
     }
   }
-  mfem::Array<int> ess_bdr = getEssentialBdrMarkers(name_, mesh_);
+  mfem::Array<int> ess_bdr = GetEssentialBdrMarkers(name_, mesh_);
   gridfunc.FESpace()->GetEssentialTrueDofs(ess_bdr, ess_tdof_list);
 };
 
 void
-BCMap::applyIntegratedBCs(const std::string & name_, mfem::LinearForm & lf, mfem::Mesh * mesh_)
+BCMap::ApplyIntegratedBCs(const std::string & name_, mfem::LinearForm & lf, mfem::Mesh * mesh_)
 {
 
   for (auto const & [name, bc_] : *this)
@@ -84,15 +84,15 @@ BCMap::applyIntegratedBCs(const std::string & name_, mfem::LinearForm & lf, mfem
       auto * bc = dynamic_cast<hephaestus::IntegratedBC *>(bc_);
       if (bc != nullptr)
       {
-        bc->getMarkers(*mesh_);
-        bc->applyBC(lf);
+        bc->GetMarkers(*mesh_);
+        bc->ApplyBC(lf);
       }
     }
   }
 };
 
 void
-BCMap::applyIntegratedBCs(const std::string & name_,
+BCMap::ApplyIntegratedBCs(const std::string & name_,
                           mfem::ParComplexLinearForm & clf,
                           mfem::Mesh * mesh_)
 {
@@ -104,15 +104,15 @@ BCMap::applyIntegratedBCs(const std::string & name_,
       auto * bc = dynamic_cast<hephaestus::IntegratedBC *>(bc_);
       if (bc != nullptr)
       {
-        bc->getMarkers(*mesh_);
-        bc->applyBC(clf);
+        bc->GetMarkers(*mesh_);
+        bc->ApplyBC(clf);
       }
     }
   }
 };
 
 void
-BCMap::applyIntegratedBCs(const std::string & name_,
+BCMap::ApplyIntegratedBCs(const std::string & name_,
                           mfem::ParSesquilinearForm & slf,
                           mfem::Mesh * mesh_)
 {
@@ -124,8 +124,8 @@ BCMap::applyIntegratedBCs(const std::string & name_,
       auto * bc = dynamic_cast<hephaestus::RobinBC *>(bc_);
       if (bc != nullptr)
       {
-        bc->getMarkers(*mesh_);
-        bc->applyBC(slf);
+        bc->GetMarkers(*mesh_);
+        bc->ApplyBC(slf);
       }
     }
   }

--- a/src/boundary_conditions/boundary_conditions.cpp
+++ b/src/boundary_conditions/boundary_conditions.cpp
@@ -13,7 +13,7 @@ BCMap::GetEssentialBdrMarkers(const std::string & name_, mfem::Mesh * mesh_)
   hephaestus::EssentialBC * bc;
   for (auto const & [name, bc_] : *this)
   {
-    if (bc_->name == name_)
+    if (bc_->_name == name_)
     {
       bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
       if (bc != nullptr)
@@ -38,7 +38,7 @@ BCMap::ApplyEssentialBCs(const std::string & name_,
 
   for (auto const & [name, bc_] : *this)
   {
-    if (bc_->name == name_)
+    if (bc_->_name == name_)
     {
       auto * bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
       if (bc != nullptr)
@@ -60,7 +60,7 @@ BCMap::ApplyEssentialBCs(const std::string & name_,
 
   for (auto const & [name, bc_] : *this)
   {
-    if (bc_->name == name_)
+    if (bc_->_name == name_)
     {
       auto * bc = dynamic_cast<hephaestus::EssentialBC *>(bc_);
       if (bc != nullptr)
@@ -79,7 +79,7 @@ BCMap::ApplyIntegratedBCs(const std::string & name_, mfem::LinearForm & lf, mfem
 
   for (auto const & [name, bc_] : *this)
   {
-    if (bc_->name == name_)
+    if (bc_->_name == name_)
     {
       auto * bc = dynamic_cast<hephaestus::IntegratedBC *>(bc_);
       if (bc != nullptr)
@@ -99,7 +99,7 @@ BCMap::ApplyIntegratedBCs(const std::string & name_,
 
   for (auto const & [name, bc_] : *this)
   {
-    if (bc_->name == name_)
+    if (bc_->_name == name_)
     {
       auto * bc = dynamic_cast<hephaestus::IntegratedBC *>(bc_);
       if (bc != nullptr)
@@ -119,7 +119,7 @@ BCMap::ApplyIntegratedBCs(const std::string & name_,
 
   for (auto const & [name, bc_] : *this)
   {
-    if (bc_->name == name_)
+    if (bc_->_name == name_)
     {
       auto * bc = dynamic_cast<hephaestus::RobinBC *>(bc_);
       if (bc != nullptr)

--- a/src/boundary_conditions/boundary_conditions.hpp
+++ b/src/boundary_conditions/boundary_conditions.hpp
@@ -10,25 +10,25 @@ namespace hephaestus
 class BCMap : public hephaestus::NamedFieldsMap<hephaestus::BoundaryCondition>
 {
 public:
-  mfem::Array<int> getEssentialBdrMarkers(const std::string & name_, mfem::Mesh * mesh_);
+  mfem::Array<int> GetEssentialBdrMarkers(const std::string & name_, mfem::Mesh * mesh_);
 
-  void applyEssentialBCs(const std::string & name_,
+  void ApplyEssentialBCs(const std::string & name_,
                          mfem::Array<int> & ess_tdof_list,
                          mfem::GridFunction & gridfunc,
                          mfem::Mesh * mesh_);
 
-  void applyEssentialBCs(const std::string & name_,
+  void ApplyEssentialBCs(const std::string & name_,
                          mfem::Array<int> & ess_tdof_list,
                          mfem::ParComplexGridFunction & gridfunc,
                          mfem::Mesh * mesh_);
 
-  void applyIntegratedBCs(const std::string & name_, mfem::LinearForm & lf, mfem::Mesh * mesh_);
+  void ApplyIntegratedBCs(const std::string & name_, mfem::LinearForm & lf, mfem::Mesh * mesh_);
 
-  void applyIntegratedBCs(const std::string & name_,
+  void ApplyIntegratedBCs(const std::string & name_,
                           mfem::ParComplexLinearForm & clf,
                           mfem::Mesh * mesh_);
 
-  void applyIntegratedBCs(const std::string & name_,
+  void ApplyIntegratedBCs(const std::string & name_,
                           mfem::ParSesquilinearForm & clf,
                           mfem::Mesh * mesh_);
 };

--- a/src/coefficients/coefficients.cpp
+++ b/src/coefficients/coefficients.cpp
@@ -16,11 +16,11 @@ fracFunc(double a, double b)
   return a / b;
 }
 
-Subdomain::Subdomain(std::string name_, int id_) : name(std::move(name_)), id(id_) {}
+Subdomain::Subdomain(std::string name_, int id_) : _name(std::move(name_)), _id(id_) {}
 
 Coefficients::Coefficients() { RegisterDefaultCoefficients(); }
 
-Coefficients::Coefficients(std::vector<Subdomain> subdomains_) : subdomains(std::move(subdomains_))
+Coefficients::Coefficients(std::vector<Subdomain> subdomains_) : _subdomains(std::move(subdomains_))
 {
   AddGlobalCoefficientsFromSubdomains();
   RegisterDefaultCoefficients();
@@ -29,21 +29,21 @@ Coefficients::Coefficients(std::vector<Subdomain> subdomains_) : subdomains(std:
 void
 Coefficients::RegisterDefaultCoefficients()
 {
-  scalars.Register("_one", new mfem::ConstantCoefficient(1.0), true);
+  _scalars.Register("_one", new mfem::ConstantCoefficient(1.0), true);
 }
 
 void
 Coefficients::SetTime(double time)
 {
-  for (auto const & [name, coeff_] : scalars)
+  for (auto const & [name, coeff_] : _scalars)
   {
     coeff_->SetTime(time);
   }
-  for (auto const & [name, vec_coeff_] : vectors)
+  for (auto const & [name, vec_coeff_] : _vectors)
   {
     vec_coeff_->SetTime(time);
   }
-  t = time;
+  _t = time;
 }
 
 // merge subdomains?
@@ -61,11 +61,11 @@ Coefficients::AddGlobalCoefficientsFromSubdomains()
   mfem::Array<int> subdomain_ids;
   std::unordered_set<std::string> scalar_property_names;
 
-  for (auto & subdomain : subdomains)
+  for (auto & subdomain : _subdomains)
   {
-    subdomain_ids.Append(subdomain.id);
+    subdomain_ids.Append(subdomain._id);
     // accumulate property names on subdomains, ignoring duplicates
-    for (auto const & [name, coeff_] : subdomain.scalar_coefficients)
+    for (auto const & [name, coeff_] : subdomain._scalar_coefficients)
     {
       scalar_property_names.insert(name);
     }
@@ -76,13 +76,13 @@ Coefficients::AddGlobalCoefficientsFromSubdomains()
   for (auto & scalar_property_name : scalar_property_names)
   {
     mfem::Array<mfem::Coefficient *> subdomain_coefs;
-    for (auto & subdomain : subdomains)
+    for (auto & subdomain : _subdomains)
     {
-      subdomain_coefs.Append(subdomain.scalar_coefficients.Get(scalar_property_name));
+      subdomain_coefs.Append(subdomain._scalar_coefficients.Get(scalar_property_name));
     }
-    if (!scalars.Has(scalar_property_name))
+    if (!_scalars.Has(scalar_property_name))
     {
-      scalars.Register(
+      _scalars.Register(
           scalar_property_name, new mfem::PWCoefficient(subdomain_ids, subdomain_coefs), true);
     }
   }

--- a/src/coefficients/coefficients.cpp
+++ b/src/coefficients/coefficients.cpp
@@ -18,16 +18,16 @@ fracFunc(double a, double b)
 
 Subdomain::Subdomain(std::string name_, int id_) : name(std::move(name_)), id(id_) {}
 
-Coefficients::Coefficients() { registerDefaultCoefficients(); }
+Coefficients::Coefficients() { RegisterDefaultCoefficients(); }
 
 Coefficients::Coefficients(std::vector<Subdomain> subdomains_) : subdomains(std::move(subdomains_))
 {
   AddGlobalCoefficientsFromSubdomains();
-  registerDefaultCoefficients();
+  RegisterDefaultCoefficients();
 }
 
 void
-Coefficients::registerDefaultCoefficients()
+Coefficients::RegisterDefaultCoefficients()
 {
   scalars.Register("_one", new mfem::ConstantCoefficient(1.0), true);
 }

--- a/src/coefficients/coefficients.hpp
+++ b/src/coefficients/coefficients.hpp
@@ -17,9 +17,9 @@ class Subdomain
 public:
   Subdomain(std::string name_, int id_);
 
-  std::string name;
-  int id;
-  hephaestus::NamedFieldsMap<mfem::Coefficient> scalar_coefficients;
+  std::string _name;
+  int _id;
+  hephaestus::NamedFieldsMap<mfem::Coefficient> _scalar_coefficients;
 };
 
 // Coefficients - stores all scalar and vector coefficients
@@ -30,7 +30,7 @@ public:
 // Stores all coefficients defined over
 class Coefficients
 {
-  double t; // Time at which time-dependent coefficients are evaluated
+  double _t; // Time at which time-dependent coefficients are evaluated
 public:
   Coefficients();
   ~Coefficients() = default;
@@ -40,9 +40,9 @@ public:
   void AddGlobalCoefficientsFromSubdomains();
   void RegisterDefaultCoefficients();
 
-  hephaestus::NamedFieldsMap<mfem::Coefficient> scalars;
-  hephaestus::NamedFieldsMap<mfem::VectorCoefficient> vectors;
-  std::vector<Subdomain> subdomains;
+  hephaestus::NamedFieldsMap<mfem::Coefficient> _scalars;
+  hephaestus::NamedFieldsMap<mfem::VectorCoefficient> _vectors;
+  std::vector<Subdomain> _subdomains;
 };
 
 } // namespace hephaestus

--- a/src/coefficients/coefficients.hpp
+++ b/src/coefficients/coefficients.hpp
@@ -38,7 +38,7 @@ public:
   Coefficients(std::vector<Subdomain> subdomains_);
   void SetTime(double t);
   void AddGlobalCoefficientsFromSubdomains();
-  void registerDefaultCoefficients();
+  void RegisterDefaultCoefficients();
 
   hephaestus::NamedFieldsMap<mfem::Coefficient> scalars;
   hephaestus::NamedFieldsMap<mfem::VectorCoefficient> vectors;

--- a/src/equation_systems/equation_system.cpp
+++ b/src/equation_systems/equation_system.cpp
@@ -144,11 +144,11 @@ EquationSystem::FormLinearSystem(mfem::OperatorHandle & op,
     auto & test_var_name = test_var_names.at(i);
     auto blf = blfs.Get(test_var_name);
     auto lf = lfs.Get(test_var_name);
-    mfem::Vector auxX, auxRHS;
+    mfem::Vector aux_x, aux_rhs;
     hBlocks(i, i) = new mfem::HypreParMatrix;
-    blf->FormLinearSystem(ess_tdof_lists.at(i), *(xs.at(i)), *lf, *hBlocks(i, i), auxX, auxRHS);
-    trueX.GetBlock(i) = auxX;
-    trueRHS.GetBlock(i) = auxRHS;
+    blf->FormLinearSystem(ess_tdof_lists.at(i), *(xs.at(i)), *lf, *hBlocks(i, i), aux_x, aux_rhs);
+    trueX.GetBlock(i) = aux_x;
+    trueRHS.GetBlock(i) = aux_rhs;
   }
 
   // Form off-diagonal blocks
@@ -159,9 +159,9 @@ EquationSystem::FormLinearSystem(mfem::OperatorHandle & op,
     {
       auto trial_var_name = test_var_names.at(j);
 
-      mfem::Vector auxX, auxRHS;
-      mfem::ParLinearForm auxLF(test_pfespaces.at(i));
-      auxLF = 0.0;
+      mfem::Vector aux_x, aux_rhs;
+      mfem::ParLinearForm aux_lf(test_pfespaces.at(i));
+      aux_lf = 0.0;
       if (mblfs.Has(test_var_name) && mblfs.Get(test_var_name)->Has(trial_var_name))
       {
         auto mblf = mblfs.Get(test_var_name)->Get(trial_var_name);
@@ -169,11 +169,11 @@ EquationSystem::FormLinearSystem(mfem::OperatorHandle & op,
         mblf->FormRectangularLinearSystem(ess_tdof_lists.at(j),
                                           ess_tdof_lists.at(i),
                                           *(xs.at(j)),
-                                          auxLF,
+                                          aux_lf,
                                           *hBlocks(i, j),
-                                          auxX,
-                                          auxRHS);
-        trueRHS.GetBlock(i) += auxRHS;
+                                          aux_x,
+                                          aux_rhs);
+        trueRHS.GetBlock(i) += aux_rhs;
       }
     }
   }

--- a/src/equation_systems/equation_system.cpp
+++ b/src/equation_systems/equation_system.cpp
@@ -8,7 +8,7 @@ EquationSystem::EquationSystem(const hephaestus::InputParameters & params) {}
 EquationSystem::~EquationSystem() { hBlocks.DeleteAll(); }
 
 bool
-EquationSystem::vectorContainsName(const std::vector<std::string> & the_vector,
+EquationSystem::VectorContainsName(const std::vector<std::string> & the_vector,
                                    const std::string & name) const
 {
 
@@ -18,28 +18,28 @@ EquationSystem::vectorContainsName(const std::vector<std::string> & the_vector,
 }
 
 void
-EquationSystem::addVariableNameIfMissing(const std::string & var_name)
+EquationSystem::AddVariableNameIfMissing(const std::string & var_name)
 {
-  if (!vectorContainsName(var_names, var_name))
+  if (!VectorContainsName(var_names, var_name))
   {
     var_names.push_back(var_name);
   }
 }
 
 void
-EquationSystem::addTestVariableNameIfMissing(const std::string & test_var_name)
+EquationSystem::AddTestVariableNameIfMissing(const std::string & test_var_name)
 {
-  if (!vectorContainsName(test_var_names, test_var_name))
+  if (!VectorContainsName(test_var_names, test_var_name))
   {
     test_var_names.push_back(test_var_name);
   }
 }
 
 void
-EquationSystem::addKernel(const std::string & test_var_name,
+EquationSystem::AddKernel(const std::string & test_var_name,
                           std::unique_ptr<ParBilinearFormKernel> && blf_kernel)
 {
-  addTestVariableNameIfMissing(test_var_name);
+  AddTestVariableNameIfMissing(test_var_name);
 
   if (!blf_kernels_map.Has(test_var_name))
   {
@@ -54,10 +54,10 @@ EquationSystem::addKernel(const std::string & test_var_name,
 }
 
 void
-EquationSystem::addKernel(const std::string & test_var_name,
+EquationSystem::AddKernel(const std::string & test_var_name,
                           std::unique_ptr<ParLinearFormKernel> && lf_kernel)
 {
-  addTestVariableNameIfMissing(test_var_name);
+  AddTestVariableNameIfMissing(test_var_name);
 
   if (!lf_kernels_map.Has(test_var_name))
   {
@@ -70,10 +70,10 @@ EquationSystem::addKernel(const std::string & test_var_name,
 }
 
 void
-EquationSystem::addKernel(const std::string & test_var_name,
+EquationSystem::AddKernel(const std::string & test_var_name,
                           std::unique_ptr<ParNonlinearFormKernel> && nlf_kernel)
 {
-  addTestVariableNameIfMissing(test_var_name);
+  AddTestVariableNameIfMissing(test_var_name);
 
   if (!nlf_kernels_map.Has(test_var_name))
   {
@@ -86,11 +86,11 @@ EquationSystem::addKernel(const std::string & test_var_name,
 }
 
 void
-EquationSystem::addKernel(const std::string & trial_var_name,
+EquationSystem::AddKernel(const std::string & trial_var_name,
                           const std::string & test_var_name,
                           std::unique_ptr<ParMixedBilinearFormKernel> && mblf_kernel)
 {
-  addTestVariableNameIfMissing(test_var_name);
+  AddTestVariableNameIfMissing(test_var_name);
 
   // Register new mblf kernels map if not present for this test variable
   if (!mblf_kernels_map_map.Has(test_var_name))
@@ -114,7 +114,7 @@ EquationSystem::addKernel(const std::string & trial_var_name,
 }
 
 void
-EquationSystem::applyBoundaryConditions(hephaestus::BCMap & bc_map)
+EquationSystem::ApplyBoundaryConditions(hephaestus::BCMap & bc_map)
 {
   ess_tdof_lists.resize(test_var_names.size());
   for (int i = 0; i < test_var_names.size(); i++)
@@ -123,9 +123,9 @@ EquationSystem::applyBoundaryConditions(hephaestus::BCMap & bc_map)
     // Set default value of gridfunction used in essential BC. Values
     // overwritten in applyEssentialBCs
     *(xs.at(i)) = 0.0;
-    bc_map.applyEssentialBCs(
+    bc_map.ApplyEssentialBCs(
         test_var_name, ess_tdof_lists.at(i), *(xs.at(i)), test_pfespaces.at(i)->GetParMesh());
-    bc_map.applyIntegratedBCs(
+    bc_map.ApplyIntegratedBCs(
         test_var_name, *(lfs.Get(test_var_name)), test_pfespaces.at(i)->GetParMesh());
   }
 }
@@ -208,7 +208,7 @@ EquationSystem::Init(hephaestus::GridFunctions & gridfunctions,
 {
 
   // Add optional kernels to the EquationSystem
-  addKernels();
+  AddKernels();
 
   for (auto & test_var_name : test_var_names)
   {
@@ -264,7 +264,7 @@ EquationSystem::Init(hephaestus::GridFunctions & gridfunctions,
 }
 
 void
-EquationSystem::buildLinearForms(hephaestus::BCMap & bc_map, hephaestus::Sources & sources)
+EquationSystem::BuildLinearForms(hephaestus::BCMap & bc_map, hephaestus::Sources & sources)
 {
   // Register linear forms
   for (int i = 0; i < test_var_names.size(); i++)
@@ -274,7 +274,7 @@ EquationSystem::buildLinearForms(hephaestus::BCMap & bc_map, hephaestus::Sources
     *(lfs.Get(test_var_name)) = 0.0;
   }
   // Apply boundary conditions
-  applyBoundaryConditions(bc_map);
+  ApplyBoundaryConditions(bc_map);
 
   for (auto & test_var_name : test_var_names)
   {
@@ -299,7 +299,7 @@ EquationSystem::buildLinearForms(hephaestus::BCMap & bc_map, hephaestus::Sources
 }
 
 void
-EquationSystem::buildBilinearForms()
+EquationSystem::BuildBilinearForms()
 {
   // Register bilinear forms
   for (int i = 0; i < test_var_names.size(); i++)
@@ -323,7 +323,7 @@ EquationSystem::buildBilinearForms()
 }
 
 void
-EquationSystem::buildMixedBilinearForms()
+EquationSystem::BuildMixedBilinearForms()
 {
   // Register mixed linear forms. Note that not all combinations may
   // have a kernel
@@ -363,11 +363,11 @@ EquationSystem::buildMixedBilinearForms()
 }
 
 void
-EquationSystem::buildEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sources & sources)
+EquationSystem::BuildEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sources & sources)
 {
-  buildLinearForms(bc_map, sources);
-  buildBilinearForms();
-  buildMixedBilinearForms();
+  BuildLinearForms(bc_map, sources);
+  BuildBilinearForms();
+  BuildMixedBilinearForms();
 }
 
 TimeDependentEquationSystem::TimeDependentEquationSystem(const hephaestus::InputParameters & params)
@@ -376,9 +376,9 @@ TimeDependentEquationSystem::TimeDependentEquationSystem(const hephaestus::Input
 }
 
 void
-TimeDependentEquationSystem::addVariableNameIfMissing(const std::string & var_name)
+TimeDependentEquationSystem::AddVariableNameIfMissing(const std::string & var_name)
 {
-  EquationSystem::addVariableNameIfMissing(var_name);
+  EquationSystem::AddVariableNameIfMissing(var_name);
   std::string var_time_derivative_name = GetTimeDerivativeName(var_name);
   if (std::find(var_time_derivative_names.begin(),
                 var_time_derivative_names.end(),
@@ -389,7 +389,7 @@ TimeDependentEquationSystem::addVariableNameIfMissing(const std::string & var_na
 }
 
 void
-TimeDependentEquationSystem::setTimeStep(double dt)
+TimeDependentEquationSystem::SetTimeStep(double dt)
 {
   if (fabs(dt - dtCoef.constant) > 1.0e-12 * dt)
   {
@@ -404,12 +404,12 @@ TimeDependentEquationSystem::setTimeStep(double dt)
 }
 
 void
-TimeDependentEquationSystem::updateEquationSystem(hephaestus::BCMap & bc_map,
+TimeDependentEquationSystem::UpdateEquationSystem(hephaestus::BCMap & bc_map,
                                                   hephaestus::Sources & sources)
 {
-  buildLinearForms(bc_map, sources);
-  buildBilinearForms();
-  buildMixedBilinearForms();
+  BuildLinearForms(bc_map, sources);
+  BuildBilinearForms();
+  BuildMixedBilinearForms();
 };
 
 } // namespace hephaestus

--- a/src/equation_systems/equation_system.hpp
+++ b/src/equation_systems/equation_system.hpp
@@ -40,37 +40,37 @@ public:
       mblfs; // named according to trial variable
 
   // add test variable to EquationSystem;
-  virtual void addTestVariableNameIfMissing(const std::string & test_var_name);
-  virtual void addVariableNameIfMissing(const std::string & var_name);
+  virtual void AddTestVariableNameIfMissing(const std::string & test_var_name);
+  virtual void AddVariableNameIfMissing(const std::string & var_name);
 
   // Add kernels.
-  void addKernel(const std::string & test_var_name,
+  void AddKernel(const std::string & test_var_name,
                  std::unique_ptr<ParBilinearFormKernel> && blf_kernel);
 
-  void addKernel(const std::string & test_var_name,
+  void AddKernel(const std::string & test_var_name,
                  std::unique_ptr<ParLinearFormKernel> && lf_kernel);
 
-  void addKernel(const std::string & test_var_name,
+  void AddKernel(const std::string & test_var_name,
                  std::unique_ptr<ParNonlinearFormKernel> && nlf_kernel);
 
-  void addKernel(const std::string & trial_var_name,
+  void AddKernel(const std::string & trial_var_name,
                  const std::string & test_var_name,
                  std::unique_ptr<ParMixedBilinearFormKernel> && mblf_kernel);
 
-  virtual void applyBoundaryConditions(hephaestus::BCMap & bc_map);
+  virtual void ApplyBoundaryConditions(hephaestus::BCMap & bc_map);
 
   // override to add kernels
-  virtual void addKernels(){};
+  virtual void AddKernels(){};
 
   // Build forms
   virtual void Init(hephaestus::GridFunctions & gridfunctions,
                     const hephaestus::FESpaces & fespaces,
                     hephaestus::BCMap & bc_map,
                     hephaestus::Coefficients & coefficients);
-  virtual void buildLinearForms(hephaestus::BCMap & bc_map, hephaestus::Sources & sources);
-  virtual void buildBilinearForms();
-  virtual void buildMixedBilinearForms();
-  virtual void buildEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sources & sources);
+  virtual void BuildLinearForms(hephaestus::BCMap & bc_map, hephaestus::Sources & sources);
+  virtual void BuildBilinearForms();
+  virtual void BuildMixedBilinearForms();
+  virtual void BuildEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sources & sources);
 
   // Form linear system, with essential boundary conditions accounted for
   virtual void FormLinearSystem(mfem::OperatorHandle & op,
@@ -82,7 +82,7 @@ public:
                                   hephaestus::GridFunctions & gridfunctions);
 
 protected:
-  bool vectorContainsName(const std::vector<std::string> & the_vector,
+  bool VectorContainsName(const std::vector<std::string> & the_vector,
                           const std::string & name) const;
 
   // gridfunctions for setting Dirichlet BCs
@@ -117,10 +117,10 @@ public:
   {
     return std::string("d") + name + std::string("_dt");
   }
-  void addVariableNameIfMissing(const std::string & var_name) override;
+  void AddVariableNameIfMissing(const std::string & var_name) override;
 
-  virtual void setTimeStep(double dt);
-  virtual void updateEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sources & sources);
+  virtual void SetTimeStep(double dt);
+  virtual void UpdateEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sources & sources);
   mfem::ConstantCoefficient dtCoef; // Coefficient for timestep scaling
   std::vector<std::string> var_time_derivative_names;
 };

--- a/src/equation_systems/equation_system.hpp
+++ b/src/equation_systems/equation_system.hpp
@@ -27,17 +27,17 @@ public:
 
   // Names of all gridfunctions corresponding to gridfunctions. This may differ
   // from test_var_names when test gridfunctions include time derivatives.
-  std::vector<std::string> var_names;
+  std::vector<std::string> _var_names;
   // Names of all test gridfunctions with kernels in this equation system.
-  std::vector<std::string> test_var_names;
-  std::vector<mfem::ParFiniteElementSpace *> test_pfespaces;
+  std::vector<std::string> _test_var_names;
+  std::vector<mfem::ParFiniteElementSpace *> _test_pfespaces;
 
   // Components of weak form. // Named according to test variable
-  hephaestus::NamedFieldsMap<mfem::ParBilinearForm> blfs;
-  hephaestus::NamedFieldsMap<mfem::ParLinearForm> lfs;
-  hephaestus::NamedFieldsMap<mfem::ParNonlinearForm> nlfs;
+  hephaestus::NamedFieldsMap<mfem::ParBilinearForm> _blfs;
+  hephaestus::NamedFieldsMap<mfem::ParLinearForm> _lfs;
+  hephaestus::NamedFieldsMap<mfem::ParNonlinearForm> _nlfs;
   hephaestus::NamedFieldsMap<hephaestus::NamedFieldsMap<mfem::ParMixedBilinearForm>>
-      mblfs; // named according to trial variable
+      _mblfs; // named according to trial variable
 
   // add test variable to EquationSystem;
   virtual void AddTestVariableNameIfMissing(const std::string & test_var_name);
@@ -86,22 +86,22 @@ protected:
                           const std::string & name) const;
 
   // gridfunctions for setting Dirichlet BCs
-  std::vector<mfem::Array<int>> ess_tdof_lists;
-  std::vector<std::unique_ptr<mfem::ParGridFunction>> xs;
+  std::vector<mfem::Array<int>> _ess_tdof_lists;
+  std::vector<std::unique_ptr<mfem::ParGridFunction>> _xs;
 
-  mfem::Array2D<mfem::HypreParMatrix *> hBlocks;
+  mfem::Array2D<mfem::HypreParMatrix *> _h_blocks;
 
   // Arrays to store kernels to act on each component of weak form. Named
   // according to test variable
-  hephaestus::NamedFieldsMap<std::vector<std::unique_ptr<ParBilinearFormKernel>>> blf_kernels_map;
+  hephaestus::NamedFieldsMap<std::vector<std::unique_ptr<ParBilinearFormKernel>>> _blf_kernels_map;
 
-  hephaestus::NamedFieldsMap<std::vector<std::unique_ptr<ParLinearFormKernel>>> lf_kernels_map;
+  hephaestus::NamedFieldsMap<std::vector<std::unique_ptr<ParLinearFormKernel>>> _lf_kernels_map;
 
-  hephaestus::NamedFieldsMap<std::vector<std::unique_ptr<ParNonlinearFormKernel>>> nlf_kernels_map;
+  hephaestus::NamedFieldsMap<std::vector<std::unique_ptr<ParNonlinearFormKernel>>> _nlf_kernels_map;
 
   hephaestus::NamedFieldsMap<
       hephaestus::NamedFieldsMap<std::vector<std::unique_ptr<ParMixedBilinearFormKernel>>>>
-      mblf_kernels_map_map;
+      _mblf_kernels_map_map;
 };
 
 /*
@@ -121,8 +121,8 @@ public:
 
   virtual void SetTimeStep(double dt);
   virtual void UpdateEquationSystem(hephaestus::BCMap & bc_map, hephaestus::Sources & sources);
-  mfem::ConstantCoefficient dtCoef; // Coefficient for timestep scaling
-  std::vector<std::string> var_time_derivative_names;
+  mfem::ConstantCoefficient _dt_coef; // Coefficient for timestep scaling
+  std::vector<std::string> _var_time_derivative_names;
 };
 
 } // namespace hephaestus

--- a/src/executioners/steady_executioner.cpp
+++ b/src/executioners/steady_executioner.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 SteadyExecutioner::SteadyExecutioner(const hephaestus::InputParameters & params)
-  : Executioner(params), problem(params.GetParam<hephaestus::SteadyStateProblem *>("Problem"))
+  : Executioner(params), _problem(params.GetParam<hephaestus::SteadyStateProblem *>("Problem"))
 {
 }
 
@@ -12,13 +12,13 @@ void
 SteadyExecutioner::Solve() const
 {
   // Advance time step.
-  problem->preprocessors.Solve();
-  problem->GetOperator()->Solve(*(problem->F));
-  problem->postprocessors.Solve();
+  _problem->_preprocessors.Solve();
+  _problem->GetOperator()->Solve(*(_problem->_f));
+  _problem->_postprocessors.Solve();
 
   // Output data
   // Output timestep summary to console
-  problem->outputs.Write();
+  _problem->_outputs.Write();
 }
 void
 SteadyExecutioner::Execute() const

--- a/src/executioners/steady_executioner.hpp
+++ b/src/executioners/steady_executioner.hpp
@@ -15,7 +15,7 @@ public:
 
   void Execute() const override;
 
-  hephaestus::SteadyStateProblem * problem{nullptr};
+  hephaestus::SteadyStateProblem * _problem{nullptr};
 };
 
 } // namespace hephaestus

--- a/src/executioners/transient_executioner.cpp
+++ b/src/executioners/transient_executioner.cpp
@@ -5,14 +5,14 @@ namespace hephaestus
 
 TransientExecutioner::TransientExecutioner(const hephaestus::InputParameters & params)
   : Executioner(params),
-    problem(params.GetParam<hephaestus::TimeDomainProblem *>("Problem")),
-    t_step(params.GetParam<float>("TimeStep")),
-    t_initial(params.GetParam<float>("StartTime")),
-    t_final(params.GetParam<float>("EndTime")),
-    t(t_initial),
-    it(0),
-    vis_steps(params.GetOptionalParam<int>("VisualisationSteps", 1)),
-    last_step(false)
+    _problem(params.GetParam<hephaestus::TimeDomainProblem *>("Problem")),
+    _t_step(params.GetParam<float>("TimeStep")),
+    _t_initial(params.GetParam<float>("StartTime")),
+    _t_final(params.GetParam<float>("EndTime")),
+    _t(_t_initial),
+    _it(0),
+    _vis_steps(params.GetOptionalParam<int>("VisualisationSteps", 1)),
+    _last_step(false)
 {
 }
 
@@ -20,38 +20,38 @@ void
 TransientExecutioner::Step(double dt, int it) const
 {
   // Check if current time step is final
-  if (t + dt >= t_final - dt / 2)
+  if (_t + dt >= _t_final - dt / 2)
   {
-    last_step = true;
+    _last_step = true;
   }
 
   // Advance time step.
-  problem->preprocessors.Solve(t);
-  problem->ode_solver->Step(*(problem->F), t, dt);
-  problem->postprocessors.Solve(t);
+  _problem->_preprocessors.Solve(_t);
+  _problem->_ode_solver->Step(*(_problem->_f), _t, dt);
+  _problem->_postprocessors.Solve(_t);
 
   // Output data
-  if (last_step || (it % vis_steps) == 0)
+  if (_last_step || (it % _vis_steps) == 0)
   {
-    problem->outputs.Write(t);
+    _problem->_outputs.Write(_t);
   }
 }
 
 void
 TransientExecutioner::Solve() const
 {
-  it++;
-  Step(t_step, it);
+  _it++;
+  Step(_t_step, _it);
 }
 
 void
 TransientExecutioner::Execute() const
 {
   // Initialise time gridfunctions
-  t = t_initial;
-  last_step = false;
-  it = 0;
-  while (last_step != true)
+  _t = _t_initial;
+  _last_step = false;
+  _it = 0;
+  while (_last_step != true)
   {
     Solve();
   }

--- a/src/executioners/transient_executioner.hpp
+++ b/src/executioners/transient_executioner.hpp
@@ -8,15 +8,15 @@ namespace hephaestus
 class TransientExecutioner : public Executioner
 {
 private:
-  double t_initial;       // Start time
-  double t_final;         // End time
-  mutable double t;       // Current time
-  mutable int it;         // Time index
-  int vis_steps;          // Number of cyces between each output update
-  mutable bool last_step; // Flag to check if current step is final
+  double _t_initial;       // Start time
+  double _t_final;         // End time
+  mutable double _t;       // Current time
+  mutable int _it;         // Time index
+  int _vis_steps;          // Number of cyces between each output update
+  mutable bool _last_step; // Flag to check if current step is final
 
 public:
-  mutable double t_step; // Time step
+  mutable double _t_step; // Time step
 
   TransientExecutioner() = default;
   explicit TransientExecutioner(const hephaestus::InputParameters & params);
@@ -29,7 +29,7 @@ public:
 
   void Execute() const override;
 
-  hephaestus::TimeDomainProblem * problem{nullptr};
+  hephaestus::TimeDomainProblem * _problem{nullptr};
 };
 
 } // namespace hephaestus

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 hephaestus::ProblemBuilder *
-Factory::createProblemBuilder(std::string & formulation_name)
+Factory::CreateProblemBuilder(std::string & formulation_name)
 {
   if (formulation_name == "EBForm")
   {
@@ -75,7 +75,7 @@ Factory::createProblemBuilder(std::string & formulation_name)
 };
 
 hephaestus::FrequencyDomainEMFormulation *
-Factory::createFrequencyDomainEMFormulation(std::string & formulation)
+Factory::CreateFrequencyDomainEmFormulation(std::string & formulation)
 {
   if (formulation == "ComplexEForm")
   {
@@ -105,7 +105,7 @@ Factory::createFrequencyDomainEMFormulation(std::string & formulation)
 }
 
 hephaestus::TimeDomainEMFormulation *
-Factory::createTimeDomainEMFormulation(std::string & formulation)
+Factory::CreateTimeDomainEmFormulation(std::string & formulation)
 {
   if (formulation == "EBForm")
   {
@@ -156,7 +156,7 @@ Factory::createTimeDomainEMFormulation(std::string & formulation)
 }
 
 mfem::ParFiniteElementSpace *
-Factory::createParFESpace(hephaestus::InputParameters params, mfem::ParMesh & pmesh)
+Factory::CreateParFESpace(hephaestus::InputParameters params, mfem::ParMesh & pmesh)
 {
   auto FEType(params.GetParam<std::string>("FESpaceType"));
   int order(params.GetParam<int>("order"));

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -158,29 +158,29 @@ Factory::CreateTimeDomainEmFormulation(std::string & formulation)
 mfem::ParFiniteElementSpace *
 Factory::CreateParFESpace(hephaestus::InputParameters params, mfem::ParMesh & pmesh)
 {
-  auto FEType(params.GetParam<std::string>("FESpaceType"));
+  auto fe_type(params.GetParam<std::string>("FESpaceType"));
   int order(params.GetParam<int>("order"));
   int components(params.GetParam<int>("components")); // spatial dimension of mesh. Use
                                                       // FiniteElementCollection::New instead
-  if (FEType == "H1")
+  if (fe_type == "H1")
   {
     return new mfem::common::H1_ParFESpace(&pmesh, order, components);
   }
-  else if (FEType == "ND")
+  else if (fe_type == "ND")
   {
     return new mfem::common::ND_ParFESpace(&pmesh, order, components);
   }
-  else if (FEType == "RT")
+  else if (fe_type == "RT")
   {
     return new mfem::common::RT_ParFESpace(&pmesh, order, components);
   }
-  else if (FEType == "L2")
+  else if (fe_type == "L2")
   {
     return new mfem::common::L2_ParFESpace(&pmesh, order, components);
   }
   else
   {
-    MFEM_WARNING("FESpaceType " << FEType << " not recognised.");
+    MFEM_WARNING("FESpaceType " << fe_type << " not recognised.");
   }
   return nullptr;
 }

--- a/src/factory/factory.hpp
+++ b/src/factory/factory.hpp
@@ -16,15 +16,15 @@ namespace hephaestus
 class Factory
 {
 public:
-  static hephaestus::ProblemBuilder * createProblemBuilder(std::string & formulation_name);
+  static hephaestus::ProblemBuilder * CreateProblemBuilder(std::string & formulation_name);
 
   static hephaestus::TimeDomainEMFormulation *
-  createTimeDomainEMFormulation(std::string & formulation);
+  CreateTimeDomainEmFormulation(std::string & formulation);
 
   static hephaestus::FrequencyDomainEMFormulation *
-  createFrequencyDomainEMFormulation(std::string & formulation);
+  CreateFrequencyDomainEmFormulation(std::string & formulation);
 
-  static mfem::ParFiniteElementSpace * createParFESpace(const hephaestus::InputParameters params,
+  static mfem::ParFiniteElementSpace * CreateParFESpace(const hephaestus::InputParameters params,
                                                         mfem::ParMesh & pmesh);
 };
 

--- a/src/formulations/AV/av_formulation.cpp
+++ b/src/formulations/AV/av_formulation.cpp
@@ -168,40 +168,40 @@ AVEquationSystem::AddKernels()
   std::string dv_dt_name = GetTimeDerivativeName(v_name);
 
   // (α∇×A_{n}, ∇×A')
-  hephaestus::InputParameters weakCurlCurlParams;
-  weakCurlCurlParams.SetParam("CoupledVariableName", a_name);
-  weakCurlCurlParams.SetParam("CoefficientName", alpha_coef_name);
-  AddKernel(da_dt_name, std::make_unique<hephaestus::WeakCurlCurlKernel>(weakCurlCurlParams));
+  hephaestus::InputParameters weak_curl_curl_params;
+  weak_curl_curl_params.SetParam("CoupledVariableName", a_name);
+  weak_curl_curl_params.SetParam("CoefficientName", alpha_coef_name);
+  AddKernel(da_dt_name, std::make_unique<hephaestus::WeakCurlCurlKernel>(weak_curl_curl_params));
 
   // (αdt∇×dA/dt_{n+1}, ∇×A')
-  hephaestus::InputParameters curlCurlParams;
-  curlCurlParams.SetParam("CoefficientName", dtalpha_coef_name);
-  AddKernel(da_dt_name, std::make_unique<hephaestus::CurlCurlKernel>(curlCurlParams));
+  hephaestus::InputParameters curl_curl_params;
+  curl_curl_params.SetParam("CoefficientName", dtalpha_coef_name);
+  AddKernel(da_dt_name, std::make_unique<hephaestus::CurlCurlKernel>(curl_curl_params));
 
   // (βdA/dt_{n+1}, A')
-  hephaestus::InputParameters vectorFEMassParams;
-  vectorFEMassParams.SetParam("CoefficientName", beta_coef_name);
-  AddKernel(da_dt_name, std::make_unique<hephaestus::VectorFEMassKernel>(vectorFEMassParams));
+  hephaestus::InputParameters vector_fe_mass_params;
+  vector_fe_mass_params.SetParam("CoefficientName", beta_coef_name);
+  AddKernel(da_dt_name, std::make_unique<hephaestus::VectorFEMassKernel>(vector_fe_mass_params));
 
   // (σ ∇ V, dA'/dt)
-  hephaestus::InputParameters mixedVectorGradientParams;
-  mixedVectorGradientParams.SetParam("CoefficientName", beta_coef_name);
+  hephaestus::InputParameters mixed_vector_gradient_params;
+  mixed_vector_gradient_params.SetParam("CoefficientName", beta_coef_name);
   AddKernel(v_name,
             da_dt_name,
-            std::make_unique<hephaestus::MixedVectorGradientKernel>(mixedVectorGradientParams));
+            std::make_unique<hephaestus::MixedVectorGradientKernel>(mixed_vector_gradient_params));
 
   // (σ ∇ V, ∇ V')
-  hephaestus::InputParameters diffusionParams;
-  diffusionParams.SetParam("CoefficientName", beta_coef_name);
-  AddKernel(v_name, std::make_unique<hephaestus::DiffusionKernel>(diffusionParams));
+  hephaestus::InputParameters diffusion_params;
+  diffusion_params.SetParam("CoefficientName", beta_coef_name);
+  AddKernel(v_name, std::make_unique<hephaestus::DiffusionKernel>(diffusion_params));
 
   // (σdA/dt, ∇ V')
-  hephaestus::InputParameters vectorFEWeakDivergenceParams;
-  vectorFEWeakDivergenceParams.SetParam("CoefficientName", beta_coef_name);
+  hephaestus::InputParameters vector_fe_weak_divergence_params;
+  vector_fe_weak_divergence_params.SetParam("CoefficientName", beta_coef_name);
   AddKernel(
       da_dt_name,
       v_name,
-      std::make_unique<hephaestus::VectorFEWeakDivergenceKernel>(vectorFEWeakDivergenceParams));
+      std::make_unique<hephaestus::VectorFEWeakDivergenceKernel>(vector_fe_weak_divergence_params));
 }
 
 AVOperator::AVOperator(mfem::ParMesh & pmesh,

--- a/src/formulations/AV/av_formulation.cpp
+++ b/src/formulations/AV/av_formulation.cpp
@@ -160,45 +160,45 @@ AVEquationSystem::Init(hephaestus::GridFunctions & gridfunctions,
 }
 
 void
-AVEquationSystem::addKernels()
+AVEquationSystem::AddKernels()
 {
-  addVariableNameIfMissing(a_name);
+  AddVariableNameIfMissing(a_name);
   std::string da_dt_name = GetTimeDerivativeName(a_name);
-  addVariableNameIfMissing(v_name);
+  AddVariableNameIfMissing(v_name);
   std::string dv_dt_name = GetTimeDerivativeName(v_name);
 
   // (α∇×A_{n}, ∇×A')
   hephaestus::InputParameters weakCurlCurlParams;
   weakCurlCurlParams.SetParam("CoupledVariableName", a_name);
   weakCurlCurlParams.SetParam("CoefficientName", alpha_coef_name);
-  addKernel(da_dt_name, std::make_unique<hephaestus::WeakCurlCurlKernel>(weakCurlCurlParams));
+  AddKernel(da_dt_name, std::make_unique<hephaestus::WeakCurlCurlKernel>(weakCurlCurlParams));
 
   // (αdt∇×dA/dt_{n+1}, ∇×A')
   hephaestus::InputParameters curlCurlParams;
   curlCurlParams.SetParam("CoefficientName", dtalpha_coef_name);
-  addKernel(da_dt_name, std::make_unique<hephaestus::CurlCurlKernel>(curlCurlParams));
+  AddKernel(da_dt_name, std::make_unique<hephaestus::CurlCurlKernel>(curlCurlParams));
 
   // (βdA/dt_{n+1}, A')
   hephaestus::InputParameters vectorFEMassParams;
   vectorFEMassParams.SetParam("CoefficientName", beta_coef_name);
-  addKernel(da_dt_name, std::make_unique<hephaestus::VectorFEMassKernel>(vectorFEMassParams));
+  AddKernel(da_dt_name, std::make_unique<hephaestus::VectorFEMassKernel>(vectorFEMassParams));
 
   // (σ ∇ V, dA'/dt)
   hephaestus::InputParameters mixedVectorGradientParams;
   mixedVectorGradientParams.SetParam("CoefficientName", beta_coef_name);
-  addKernel(v_name,
+  AddKernel(v_name,
             da_dt_name,
             std::make_unique<hephaestus::MixedVectorGradientKernel>(mixedVectorGradientParams));
 
   // (σ ∇ V, ∇ V')
   hephaestus::InputParameters diffusionParams;
   diffusionParams.SetParam("CoefficientName", beta_coef_name);
-  addKernel(v_name, std::make_unique<hephaestus::DiffusionKernel>(diffusionParams));
+  AddKernel(v_name, std::make_unique<hephaestus::DiffusionKernel>(diffusionParams));
 
   // (σdA/dt, ∇ V')
   hephaestus::InputParameters vectorFEWeakDivergenceParams;
   vectorFEWeakDivergenceParams.SetParam("CoefficientName", beta_coef_name);
-  addKernel(
+  AddKernel(
       da_dt_name,
       v_name,
       std::make_unique<hephaestus::VectorFEWeakDivergenceKernel>(vectorFEWeakDivergenceParams));
@@ -250,8 +250,8 @@ AVOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector 
         local_trial_vars.at(ind)->ParFESpace(), dX_dt, true_offsets[ind]);
   }
   _coefficients.SetTime(GetTime());
-  _equation_system->setTimeStep(dt);
-  _equation_system->updateEquationSystem(_bc_map, _sources);
+  _equation_system->SetTimeStep(dt);
+  _equation_system->UpdateEquationSystem(_bc_map, _sources);
 
   _equation_system->FormLinearSystem(blockA, trueX, trueRhs);
 

--- a/src/formulations/AV/av_formulation.hpp
+++ b/src/formulations/AV/av_formulation.hpp
@@ -47,9 +47,9 @@ public:
             hephaestus::Coefficients & coefficients) override;
   void AddKernels() override;
 
-  std::string a_name, v_name, coupled_variable_name, alpha_coef_name, beta_coef_name,
-      dtalpha_coef_name, neg_beta_coef_name;
-  mfem::ConstantCoefficient negCoef;
+  std::string _a_name, _v_name, _coupled_variable_name, _alpha_coef_name, _beta_coef_name,
+      _dtalpha_coef_name, _neg_beta_coef_name;
+  mfem::ConstantCoefficient _neg_coef;
 };
 
 class AVOperator : public TimeDomainEquationSystemOperator

--- a/src/formulations/AV/av_formulation.hpp
+++ b/src/formulations/AV/av_formulation.hpp
@@ -45,7 +45,7 @@ public:
             const hephaestus::FESpaces & fespaces,
             hephaestus::BCMap & bc_map,
             hephaestus::Coefficients & coefficients) override;
-  void addKernels() override;
+  void AddKernels() override;
 
   std::string a_name, v_name, coupled_variable_name, alpha_coef_name, beta_coef_name,
       dtalpha_coef_name, neg_beta_coef_name;

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
@@ -25,7 +25,7 @@ ComplexAFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_
 {
   //* Current density J = Jᵉ + σE
   //* Induced current density Jind = σE = -iωσA
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       j_field_imag_name,
       new hephaestus::ScaledVectorGridFunctionAux(
@@ -43,7 +43,7 @@ ComplexAFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_
                                                     const std::string & b_field_imag_name)
 {
   //* Magnetic flux density B = curl A
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       b_field_real_name,
       new hephaestus::CurlAuxSolver(_magnetic_vector_potential_real_name, b_field_real_name),
@@ -59,7 +59,7 @@ ComplexAFormulation::RegisterElectricFieldAux(const std::string & e_field_real_n
                                               const std::string & e_field_imag_name)
 {
   //* Electric field E =-dA/dt=-iωA
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       e_field_imag_name,
       new hephaestus::ScaledVectorGridFunctionAux(
@@ -81,7 +81,7 @@ ComplexAFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_
                                                     const std::string & conductivity_coef_name)
 {
   //* Time averaged Joule heating density = E.J
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       p_field_name,
       new hephaestus::VectorGridFunctionDotProductAux(p_field_name,

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
@@ -20,7 +20,7 @@ ComplexAFormulation::ComplexAFormulation(const std::string & magnetic_reluctivit
 
 // Enable auxiliary calculation of J ∈ H(div)
 void
-ComplexAFormulation::registerCurrentDensityAux(const std::string & j_field_real_name,
+ComplexAFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_name,
                                                const std::string & j_field_imag_name)
 {
   //* Current density J = Jᵉ + σE
@@ -39,7 +39,7 @@ ComplexAFormulation::registerCurrentDensityAux(const std::string & j_field_real_
 };
 
 void
-ComplexAFormulation::registerMagneticFluxDensityAux(const std::string & b_field_real_name,
+ComplexAFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
                                                     const std::string & b_field_imag_name)
 {
   //* Magnetic flux density B = curl A
@@ -55,7 +55,7 @@ ComplexAFormulation::registerMagneticFluxDensityAux(const std::string & b_field_
 }
 
 void
-ComplexAFormulation::registerElectricFieldAux(const std::string & e_field_real_name,
+ComplexAFormulation::RegisterElectricFieldAux(const std::string & e_field_real_name,
                                               const std::string & e_field_imag_name)
 {
   //* Electric field E =-dA/dt=-iωA
@@ -75,7 +75,7 @@ ComplexAFormulation::registerElectricFieldAux(const std::string & e_field_real_n
 // Enable auxiliary calculation of P ∈ L2
 // Time averaged Joule heating density E.J
 void
-ComplexAFormulation::registerJouleHeatingDensityAux(const std::string & p_field_name,
+ComplexAFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                                     const std::string & e_field_real_name,
                                                     const std::string & e_field_imag_name,
                                                     const std::string & conductivity_coef_name)

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
@@ -41,20 +41,20 @@ public:
 
   // Enable auxiliary calculation of J ∈ H(div)
   //* Induced electric current, Jind = σE = -iωσA
-  void registerCurrentDensityAux(const std::string & j_field_real_name,
+  void RegisterCurrentDensityAux(const std::string & j_field_real_name,
                                  const std::string & j_field_imag_name) override;
 
   //* Magnetic flux density B = curl A
-  void registerMagneticFluxDensityAux(const std::string & b_field_real_name,
+  void RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
                                       const std::string & b_field_imag_name) override;
 
   //* Electric field E =-dA/dt=-iωA
-  void registerElectricFieldAux(const std::string & e_field_real_name,
+  void RegisterElectricFieldAux(const std::string & e_field_real_name,
                                 const std::string & e_field_imag_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
   // Time averaged Joule heating density E.J
-  void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_real_name,
                                       const std::string & e_field_imag_name,
                                       const std::string & conductivity_coef_name) override;

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -20,7 +20,7 @@ ComplexEFormulation::ComplexEFormulation(const std::string & magnetic_reluctivit
 
 // Enable auxiliary calculation of J ∈ H(div)
 void
-ComplexEFormulation::registerCurrentDensityAux(const std::string & j_field_real_name,
+ComplexEFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_name,
                                                const std::string & j_field_imag_name)
 {
   //* Current density J = Jᵉ + σE
@@ -39,7 +39,7 @@ ComplexEFormulation::registerCurrentDensityAux(const std::string & j_field_real_
 };
 
 void
-ComplexEFormulation::registerMagneticFluxDensityAux(const std::string & b_field_real_name,
+ComplexEFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
                                                     const std::string & b_field_imag_name)
 {
   //* Magnetic flux density B = (i/ω) curl E
@@ -59,7 +59,7 @@ ComplexEFormulation::registerMagneticFluxDensityAux(const std::string & b_field_
 
 // Enable auxiliary calculation of P ∈ L2
 void
-ComplexEFormulation::registerJouleHeatingDensityAux(const std::string & p_field_name,
+ComplexEFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                                     const std::string & e_field_real_name,
                                                     const std::string & e_field_imag_name,
                                                     const std::string & conductivity_coef_name)

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -25,7 +25,7 @@ ComplexEFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_
 {
   //* Current density J = Jᵉ + σE
   //* Induced electric current, Jind = σE
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(j_field_real_name,
                       new hephaestus::ScaledVectorGridFunctionAux(_electric_field_real_name,
                                                                   j_field_real_name,
@@ -44,7 +44,7 @@ ComplexEFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_
 {
   //* Magnetic flux density B = (i/ω) curl E
   //* (∇×E = -dB/dt = -iωB)
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       b_field_imag_name,
       new hephaestus::ScaledCurlVectorGridFunctionAux(
@@ -65,7 +65,7 @@ ComplexEFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_
                                                     const std::string & conductivity_coef_name)
 {
   //* Time averaged Joule heating density = E.J
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(p_field_name,
                                                                       p_field_name,

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
@@ -40,21 +40,21 @@ public:
 
   // Enable auxiliary calculation of J ∈ H(div)
   //* Induced electric current, Jind = σE
-  void registerCurrentDensityAux(const std::string & j_field_real_name,
+  void RegisterCurrentDensityAux(const std::string & j_field_real_name,
                                  const std::string & j_field_imag_name) override;
 
   //* Magnetic flux density B = (i/ω) curl E
   //* (∇×E = -dB/dt = -iωB)
-  void registerMagneticFluxDensityAux(const std::string & b_field_real_name,
+  void RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
                                       const std::string & b_field_imag_name) override;
 
   //* Electric field is already a state variable solved for
-  void registerElectricFieldAux(const std::string & e_field_real_name,
+  void RegisterElectricFieldAux(const std::string & e_field_real_name,
                                 const std::string & e_field_imag_name) override{};
 
   // Enable auxiliary calculation of P ∈ L2
   // Time averaged Joule heating density E.J
-  void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_real_name,
                                       const std::string & e_field_imag_name,
                                       const std::string & conductivity_coef_name) override;

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
@@ -75,9 +75,9 @@ ComplexMaxwellOperator::Solve(mfem::Vector & X)
   _sources.Apply(&b1_real_);
 
   mfem::ParComplexLinearForm b1_(u_->ParFESpace(), conv_);
-  _bc_map.applyEssentialBCs(h_curl_var_complex_name, ess_bdr_tdofs_, *u_, pmesh_);
-  _bc_map.applyIntegratedBCs(h_curl_var_complex_name, b1_, pmesh_);
-  _bc_map.applyIntegratedBCs(h_curl_var_complex_name, a1_, pmesh_);
+  _bc_map.ApplyEssentialBCs(h_curl_var_complex_name, ess_bdr_tdofs_, *u_, pmesh_);
+  _bc_map.ApplyIntegratedBCs(h_curl_var_complex_name, b1_, pmesh_);
+  _bc_map.ApplyIntegratedBCs(h_curl_var_complex_name, a1_, pmesh_);
 
   a1_.Assemble();
   a1_.Finalize();

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
@@ -14,25 +14,25 @@ ComplexMaxwellOperator::ComplexMaxwellOperator(mfem::ParMesh & pmesh,
                                                hephaestus::InputParameters & solver_options)
   : EquationSystemOperator(
         pmesh, fespaces, gridfunctions, bc_map, coefficients, sources, solver_options),
-    h_curl_var_complex_name(solver_options.GetParam<std::string>("HCurlVarComplexName")),
-    h_curl_var_real_name(solver_options.GetParam<std::string>("HCurlVarRealName")),
-    h_curl_var_imag_name(solver_options.GetParam<std::string>("HCurlVarImagName")),
-    stiffness_coef_name(solver_options.GetParam<std::string>("StiffnessCoefName")),
-    mass_coef_name(solver_options.GetParam<std::string>("MassCoefName")),
-    loss_coef_name(solver_options.GetParam<std::string>("LossCoefName"))
+    _h_curl_var_complex_name(solver_options.GetParam<std::string>("HCurlVarComplexName")),
+    _h_curl_var_real_name(solver_options.GetParam<std::string>("HCurlVarRealName")),
+    _h_curl_var_imag_name(solver_options.GetParam<std::string>("HCurlVarImagName")),
+    _stiffness_coef_name(solver_options.GetParam<std::string>("StiffnessCoefName")),
+    _mass_coef_name(solver_options.GetParam<std::string>("MassCoefName")),
+    _loss_coef_name(solver_options.GetParam<std::string>("LossCoefName"))
 {
 }
 
 void
 ComplexMaxwellOperator::SetGridFunctions()
 {
-  state_var_names.push_back(h_curl_var_real_name);
-  state_var_names.push_back(h_curl_var_imag_name);
+  _state_var_names.push_back(_h_curl_var_real_name);
+  _state_var_names.push_back(_h_curl_var_imag_name);
 
   EquationSystemOperator::SetGridFunctions();
 
-  u_ = new mfem::ParComplexGridFunction(local_test_vars.at(0)->ParFESpace());
-  *u_ = std::complex(0.0, 0.0);
+  _u = new mfem::ParComplexGridFunction(_local_test_vars.at(0)->ParFESpace());
+  *_u = std::complex(0.0, 0.0);
 };
 
 void
@@ -40,9 +40,9 @@ ComplexMaxwellOperator::Init(mfem::Vector & X)
 {
   EquationSystemOperator::Init(X);
 
-  stiffCoef_ = _coefficients.scalars.Get(stiffness_coef_name);
-  massCoef_ = _coefficients.scalars.Get(mass_coef_name);
-  lossCoef_ = _coefficients.scalars.Get(loss_coef_name);
+  _stiff_coef = _coefficients._scalars.Get(_stiffness_coef_name);
+  _mass_coef = _coefficients._scalars.Get(_mass_coef_name);
+  _loss_coef = _coefficients._scalars.Get(_loss_coef_name);
 }
 
 void
@@ -56,28 +56,28 @@ ComplexMaxwellOperator::Solve(mfem::Vector & X)
   zero_vec = 0.0;
   mfem::VectorConstantCoefficient zero_coef(zero_vec);
 
-  mfem::ParSesquilinearForm sqlf(u_->ParFESpace(), conv_);
-  sqlf.AddDomainIntegrator(new mfem::CurlCurlIntegrator(*stiffCoef_), nullptr);
-  if (massCoef_)
+  mfem::ParSesquilinearForm sqlf(_u->ParFESpace(), _conv);
+  sqlf.AddDomainIntegrator(new mfem::CurlCurlIntegrator(*_stiff_coef), nullptr);
+  if (_mass_coef)
   {
-    sqlf.AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*massCoef_), nullptr);
+    sqlf.AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*_mass_coef), nullptr);
   }
-  if (lossCoef_)
+  if (_loss_coef)
   {
-    sqlf.AddDomainIntegrator(nullptr, new mfem::VectorFEMassIntegrator(*lossCoef_));
+    sqlf.AddDomainIntegrator(nullptr, new mfem::VectorFEMassIntegrator(*_loss_coef));
   }
 
-  mfem::ParLinearForm lf_real(u_->ParFESpace());
-  mfem::ParLinearForm lf_imag(u_->ParFESpace());
+  mfem::ParLinearForm lf_real(_u->ParFESpace());
+  mfem::ParLinearForm lf_imag(_u->ParFESpace());
   lf_real = 0.0;
   lf_imag = 0.0;
 
   _sources.Apply(&lf_real);
 
-  mfem::ParComplexLinearForm lf(u_->ParFESpace(), conv_);
-  _bc_map.ApplyEssentialBCs(h_curl_var_complex_name, ess_bdr_tdofs_, *u_, pmesh_);
-  _bc_map.ApplyIntegratedBCs(h_curl_var_complex_name, lf, pmesh_);
-  _bc_map.ApplyIntegratedBCs(h_curl_var_complex_name, sqlf, pmesh_);
+  mfem::ParComplexLinearForm lf(_u->ParFESpace(), _conv);
+  _bc_map.ApplyEssentialBCs(_h_curl_var_complex_name, _ess_bdr_tdofs, *_u, _pmesh);
+  _bc_map.ApplyIntegratedBCs(_h_curl_var_complex_name, lf, _pmesh);
+  _bc_map.ApplyIntegratedBCs(_h_curl_var_complex_name, sqlf, _pmesh);
 
   sqlf.Assemble();
   sqlf.Finalize();
@@ -86,7 +86,7 @@ ComplexMaxwellOperator::Solve(mfem::Vector & X)
   lf.real() += lf_real;
   lf.imag() += lf_imag;
 
-  sqlf.FormLinearSystem(ess_bdr_tdofs_, *u_, lf, jac, u, rhs);
+  sqlf.FormLinearSystem(_ess_bdr_tdofs, *_u, lf, jac, u, rhs);
 
   auto * jac_z = jac.As<mfem::ComplexHypreParMatrix>();
   auto jac_c = std::unique_ptr<mfem::HypreParMatrix>(jac_z->GetSystemMatrix());
@@ -96,10 +96,10 @@ ComplexMaxwellOperator::Solve(mfem::Vector & X)
   solver.SetOperator(a_super_lu);
   solver.Mult(rhs, u);
 
-  sqlf.RecoverFEMSolution(u, lf, *u_);
+  sqlf.RecoverFEMSolution(u, lf, *_u);
 
-  *_gridfunctions.Get(state_var_names.at(0)) = u_->real();
-  *_gridfunctions.Get(state_var_names.at(1)) = u_->imag();
+  *_gridfunctions.Get(_state_var_names.at(0)) = _u->real();
+  *_gridfunctions.Get(_state_var_names.at(1)) = _u->imag();
 }
 
 ComplexMaxwellFormulation::ComplexMaxwellFormulation(std::string alpha_coef_name,
@@ -124,30 +124,30 @@ ComplexMaxwellFormulation::ComplexMaxwellFormulation(std::string alpha_coef_name
 void
 ComplexMaxwellFormulation::ConstructOperator()
 {
-  hephaestus::InputParameters & solver_options = GetProblem()->solver_options;
+  hephaestus::InputParameters & solver_options = GetProblem()->_solver_options;
   solver_options.SetParam("HCurlVarComplexName", _h_curl_var_complex_name);
   solver_options.SetParam("HCurlVarRealName", _h_curl_var_real_name);
   solver_options.SetParam("HCurlVarImagName", _h_curl_var_imag_name);
   solver_options.SetParam("StiffnessCoefName", _alpha_coef_name);
   solver_options.SetParam("MassCoefName", _mass_coef_name);
   solver_options.SetParam("LossCoefName", _loss_coef_name);
-  problem->eq_sys_operator =
-      std::make_unique<hephaestus::ComplexMaxwellOperator>(*(problem->pmesh),
-                                                           problem->fespaces,
-                                                           problem->gridfunctions,
-                                                           problem->bc_map,
-                                                           problem->coefficients,
-                                                           problem->sources,
-                                                           problem->solver_options);
-  problem->GetOperator()->SetGridFunctions();
+  _problem->_eq_sys_operator =
+      std::make_unique<hephaestus::ComplexMaxwellOperator>(*(_problem->_pmesh),
+                                                           _problem->_fespaces,
+                                                           _problem->_gridfunctions,
+                                                           _problem->_bc_map,
+                                                           _problem->_coefficients,
+                                                           _problem->_sources,
+                                                           _problem->_solver_options);
+  _problem->GetOperator()->SetGridFunctions();
 }
 
 void
 ComplexMaxwellFormulation::RegisterGridFunctions()
 {
-  int & myid = GetProblem()->myid_;
-  hephaestus::GridFunctions & gridfunctions = GetProblem()->gridfunctions;
-  hephaestus::FESpaces & fespaces = GetProblem()->fespaces;
+  int & myid = GetProblem()->_myid;
+  hephaestus::GridFunctions & gridfunctions = GetProblem()->_gridfunctions;
+  hephaestus::FESpaces & fespaces = GetProblem()->_fespaces;
 
   // Register default ParGridFunctions of state gridfunctions if not provided
   if (!gridfunctions.Has(_h_curl_var_real_name))
@@ -166,66 +166,66 @@ ComplexMaxwellFormulation::RegisterGridFunctions()
 void
 ComplexMaxwellFormulation::RegisterCoefficients()
 {
-  hephaestus::Coefficients & coefficients = GetProblem()->coefficients;
+  hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;
 
-  if (!coefficients.scalars.Has(_frequency_coef_name))
+  if (!coefficients._scalars.Has(_frequency_coef_name))
   {
     MFEM_ABORT(_frequency_coef_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has("magnetic_permeability"))
+  if (!coefficients._scalars.Has("magnetic_permeability"))
   {
     MFEM_ABORT("Magnetic permeability coefficient not found.");
   }
-  if (!coefficients.scalars.Has(_beta_coef_name))
+  if (!coefficients._scalars.Has(_beta_coef_name))
   {
     MFEM_ABORT(_beta_coef_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has(_zeta_coef_name))
+  if (!coefficients._scalars.Has(_zeta_coef_name))
   {
     MFEM_ABORT(_zeta_coef_name + " coefficient not found.");
   }
 
-  freqCoef =
-      dynamic_cast<mfem::ConstantCoefficient *>(coefficients.scalars.Get(_frequency_coef_name));
+  _freq_coef =
+      dynamic_cast<mfem::ConstantCoefficient *>(coefficients._scalars.Get(_frequency_coef_name));
 
   // define transformed
-  coefficients.scalars.Register(
-      "_angular_frequency", new mfem::ConstantCoefficient(2.0 * M_PI * freqCoef->constant), true);
-  coefficients.scalars.Register("_neg_angular_frequency",
-                                new mfem::ConstantCoefficient(-2.0 * M_PI * freqCoef->constant),
-                                true);
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
+      "_angular_frequency", new mfem::ConstantCoefficient(2.0 * M_PI * _freq_coef->constant), true);
+  coefficients._scalars.Register("_neg_angular_frequency",
+                                 new mfem::ConstantCoefficient(-2.0 * M_PI * _freq_coef->constant),
+                                 true);
+  coefficients._scalars.Register(
       "_angular_frequency_sq",
-      new mfem::ConstantCoefficient(pow(2.0 * M_PI * freqCoef->constant, 2)),
+      new mfem::ConstantCoefficient(pow(2.0 * M_PI * _freq_coef->constant, 2)),
       true);
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       "_neg_angular_frequency_sq",
-      new mfem::ConstantCoefficient(-pow(2.0 * M_PI * freqCoef->constant, 2)),
+      new mfem::ConstantCoefficient(-pow(2.0 * M_PI * _freq_coef->constant, 2)),
       true);
 
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       "_inv_angular_frequency",
-      new mfem::RatioCoefficient(1.0, *coefficients.scalars.Get("_angular_frequency")),
+      new mfem::RatioCoefficient(1.0, *coefficients._scalars.Get("_angular_frequency")),
       true);
 
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       _mass_coef_name,
-      new mfem::TransformedCoefficient(coefficients.scalars.Get("_neg_angular_frequency_sq"),
-                                       coefficients.scalars.Get(_zeta_coef_name),
+      new mfem::TransformedCoefficient(coefficients._scalars.Get("_neg_angular_frequency_sq"),
+                                       coefficients._scalars.Get(_zeta_coef_name),
                                        prodFunc),
       true);
 
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       _loss_coef_name,
-      new mfem::TransformedCoefficient(coefficients.scalars.Get("_angular_frequency"),
-                                       coefficients.scalars.Get(_beta_coef_name),
+      new mfem::TransformedCoefficient(coefficients._scalars.Get("_angular_frequency"),
+                                       coefficients._scalars.Get(_beta_coef_name),
                                        prodFunc),
       true);
 
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       _alpha_coef_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get("magnetic_permeability"), fracFunc),
+          &_one_coef, coefficients._scalars.Get("magnetic_permeability"), fracFunc),
       true);
 }
 

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
@@ -42,17 +42,17 @@ public:
   void Init(mfem::Vector & X) override;
   void Solve(mfem::Vector & X) override;
 
-  std::string h_curl_var_complex_name, h_curl_var_real_name, h_curl_var_imag_name,
-      stiffness_coef_name, mass_coef_name, loss_coef_name;
+  std::string _h_curl_var_complex_name, _h_curl_var_real_name, _h_curl_var_imag_name,
+      _stiffness_coef_name, _mass_coef_name, _loss_coef_name;
 
-  mfem::ComplexOperator::Convention conv_{mfem::ComplexOperator::HERMITIAN};
+  mfem::ComplexOperator::Convention _conv{mfem::ComplexOperator::HERMITIAN};
 
-  mfem::ParComplexGridFunction * u_{nullptr};
-  mfem::Coefficient * stiffCoef_{nullptr}; // Dia/Paramagnetic Material Coefficient
-  mfem::Coefficient * massCoef_{nullptr};  // -omega^2 epsilon
-  mfem::Coefficient * lossCoef_{nullptr};  // omega sigma
+  mfem::ParComplexGridFunction * _u{nullptr};
+  mfem::Coefficient * _stiff_coef{nullptr}; // Dia/Paramagnetic Material Coefficient
+  mfem::Coefficient * _mass_coef{nullptr};  // -omega^2 epsilon
+  mfem::Coefficient * _loss_coef{nullptr};  // omega sigma
 
-  mfem::Array<int> ess_bdr_tdofs_;
+  mfem::Array<int> _ess_bdr_tdofs;
 };
 
 //

--- a/src/formulations/Dual/dual_formulation.cpp
+++ b/src/formulations/Dual/dual_formulation.cpp
@@ -164,21 +164,22 @@ WeakCurlEquationSystem::AddKernels()
   std::string dh_curl_var_dt = GetTimeDerivativeName(_h_curl_var_name);
 
   // (αv_{n}, ∇×u')
-  hephaestus::InputParameters weakCurlParams;
-  weakCurlParams.SetParam("HCurlVarName", _h_curl_var_name);
-  weakCurlParams.SetParam("HDivVarName", _h_div_var_name);
-  weakCurlParams.SetParam("CoefficientName", _alpha_coef_name);
-  AddKernel(_h_curl_var_name, std::make_unique<hephaestus::WeakCurlKernel>(weakCurlParams));
+  hephaestus::InputParameters weak_curl_params;
+  weak_curl_params.SetParam("HCurlVarName", _h_curl_var_name);
+  weak_curl_params.SetParam("HDivVarName", _h_div_var_name);
+  weak_curl_params.SetParam("CoefficientName", _alpha_coef_name);
+  AddKernel(_h_curl_var_name, std::make_unique<hephaestus::WeakCurlKernel>(weak_curl_params));
 
   // (αdt∇×u_{n+1}, ∇×u')
-  hephaestus::InputParameters curlCurlParams;
-  curlCurlParams.SetParam("CoefficientName", _dtalpha_coef_name);
-  AddKernel(_h_curl_var_name, std::make_unique<hephaestus::CurlCurlKernel>(curlCurlParams));
+  hephaestus::InputParameters curl_curl_params;
+  curl_curl_params.SetParam("CoefficientName", _dtalpha_coef_name);
+  AddKernel(_h_curl_var_name, std::make_unique<hephaestus::CurlCurlKernel>(curl_curl_params));
 
   // (βu_{n+1}, u')
-  hephaestus::InputParameters vectorFEMassParams;
-  vectorFEMassParams.SetParam("CoefficientName", _beta_coef_name);
-  AddKernel(_h_curl_var_name, std::make_unique<hephaestus::VectorFEMassKernel>(vectorFEMassParams));
+  hephaestus::InputParameters vector_fe_mass_params;
+  vector_fe_mass_params.SetParam("CoefficientName", _beta_coef_name);
+  AddKernel(_h_curl_var_name,
+            std::make_unique<hephaestus::VectorFEMassKernel>(vector_fe_mass_params));
 }
 
 DualOperator::DualOperator(mfem::ParMesh & pmesh,
@@ -226,10 +227,10 @@ DualOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vecto
 
   _equation_system->FormLinearSystem(blockA, trueX, trueRhs);
 
-  a1_solver = std::make_unique<hephaestus::DefaultHCurlPCGSolver>(
+  jacobian_solver = std::make_unique<hephaestus::DefaultHCurlPCGSolver>(
       _solver_options, *blockA.As<mfem::HypreParMatrix>(), _equation_system->test_pfespaces.at(0));
 
-  a1_solver->Mult(trueRhs, trueX);
+  jacobian_solver->Mult(trueRhs, trueX);
   _equation_system->RecoverFEMSolution(trueX, _gridfunctions);
 
   // Subtract off contribution from source

--- a/src/formulations/Dual/dual_formulation.cpp
+++ b/src/formulations/Dual/dual_formulation.cpp
@@ -157,10 +157,10 @@ WeakCurlEquationSystem::Init(hephaestus::GridFunctions & gridfunctions,
 }
 
 void
-WeakCurlEquationSystem::addKernels()
+WeakCurlEquationSystem::AddKernels()
 {
-  addVariableNameIfMissing(_h_curl_var_name);
-  addVariableNameIfMissing(_h_div_var_name);
+  AddVariableNameIfMissing(_h_curl_var_name);
+  AddVariableNameIfMissing(_h_div_var_name);
   std::string dh_curl_var_dt = GetTimeDerivativeName(_h_curl_var_name);
 
   // (αv_{n}, ∇×u')
@@ -168,17 +168,17 @@ WeakCurlEquationSystem::addKernels()
   weakCurlParams.SetParam("HCurlVarName", _h_curl_var_name);
   weakCurlParams.SetParam("HDivVarName", _h_div_var_name);
   weakCurlParams.SetParam("CoefficientName", _alpha_coef_name);
-  addKernel(_h_curl_var_name, std::make_unique<hephaestus::WeakCurlKernel>(weakCurlParams));
+  AddKernel(_h_curl_var_name, std::make_unique<hephaestus::WeakCurlKernel>(weakCurlParams));
 
   // (αdt∇×u_{n+1}, ∇×u')
   hephaestus::InputParameters curlCurlParams;
   curlCurlParams.SetParam("CoefficientName", _dtalpha_coef_name);
-  addKernel(_h_curl_var_name, std::make_unique<hephaestus::CurlCurlKernel>(curlCurlParams));
+  AddKernel(_h_curl_var_name, std::make_unique<hephaestus::CurlCurlKernel>(curlCurlParams));
 
   // (βu_{n+1}, u')
   hephaestus::InputParameters vectorFEMassParams;
   vectorFEMassParams.SetParam("CoefficientName", _beta_coef_name);
-  addKernel(_h_curl_var_name, std::make_unique<hephaestus::VectorFEMassKernel>(vectorFEMassParams));
+  AddKernel(_h_curl_var_name, std::make_unique<hephaestus::VectorFEMassKernel>(vectorFEMassParams));
 }
 
 DualOperator::DualOperator(mfem::ParMesh & pmesh,
@@ -221,8 +221,8 @@ DualOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vecto
         local_trial_vars.at(ind)->ParFESpace(), dX_dt, true_offsets[ind]);
   }
   _coefficients.SetTime(GetTime());
-  _equation_system->setTimeStep(dt);
-  _equation_system->updateEquationSystem(_bc_map, _sources);
+  _equation_system->SetTimeStep(dt);
+  _equation_system->UpdateEquationSystem(_bc_map, _sources);
 
   _equation_system->FormLinearSystem(blockA, trueX, trueRhs);
 

--- a/src/formulations/Dual/dual_formulation.cpp
+++ b/src/formulations/Dual/dual_formulation.cpp
@@ -66,29 +66,29 @@ DualFormulation::ConstructEquationSystem()
   weak_form_params.SetParam("HDivVarName", _h_div_var_name);
   weak_form_params.SetParam("AlphaCoefName", _alpha_coef_name);
   weak_form_params.SetParam("BetaCoefName", _beta_coef_name);
-  GetProblem()->td_equation_system =
+  GetProblem()->_td_equation_system =
       std::make_unique<hephaestus::WeakCurlEquationSystem>(weak_form_params);
 }
 
 void
 DualFormulation::ConstructOperator()
 {
-  problem->td_operator = std::make_unique<hephaestus::DualOperator>(*(problem->pmesh),
-                                                                    problem->fespaces,
-                                                                    problem->gridfunctions,
-                                                                    problem->bc_map,
-                                                                    problem->coefficients,
-                                                                    problem->sources,
-                                                                    problem->solver_options);
-  problem->td_operator->SetEquationSystem(problem->td_equation_system.get());
-  problem->td_operator->SetGridFunctions();
+  _problem->_td_operator = std::make_unique<hephaestus::DualOperator>(*(_problem->_pmesh),
+                                                                      _problem->_fespaces,
+                                                                      _problem->_gridfunctions,
+                                                                      _problem->_bc_map,
+                                                                      _problem->_coefficients,
+                                                                      _problem->_sources,
+                                                                      _problem->_solver_options);
+  _problem->_td_operator->SetEquationSystem(_problem->_td_equation_system.get());
+  _problem->_td_operator->SetGridFunctions();
 };
 
 void
 DualFormulation::RegisterGridFunctions()
 {
-  int & myid = GetProblem()->myid_;
-  hephaestus::GridFunctions & gridfunctions = GetProblem()->gridfunctions;
+  int & myid = GetProblem()->_myid;
+  hephaestus::GridFunctions & gridfunctions = GetProblem()->_gridfunctions;
 
   // Register default ParGridFunctions of state gridfunctions if not provided
   if (!gridfunctions.Has(_h_curl_var_name))
@@ -121,13 +121,13 @@ DualFormulation::RegisterGridFunctions()
 void
 DualFormulation::RegisterCoefficients()
 {
-  hephaestus::Coefficients & coefficients = GetProblem()->coefficients;
+  hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;
 
-  if (!coefficients.scalars.Has(_alpha_coef_name))
+  if (!coefficients._scalars.Has(_alpha_coef_name))
   {
     MFEM_ABORT(_alpha_coef_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has(_beta_coef_name))
+  if (!coefficients._scalars.Has(_beta_coef_name))
   {
     MFEM_ABORT(_beta_coef_name + " coefficient not found.");
   }
@@ -149,10 +149,11 @@ WeakCurlEquationSystem::Init(hephaestus::GridFunctions & gridfunctions,
                              hephaestus::BCMap & bc_map,
                              hephaestus::Coefficients & coefficients)
 {
-  coefficients.scalars.Register(_dtalpha_coef_name,
-                                new mfem::TransformedCoefficient(
-                                    &dtCoef, coefficients.scalars.Get(_alpha_coef_name), prodFunc),
-                                true);
+  coefficients._scalars.Register(
+      _dtalpha_coef_name,
+      new mfem::TransformedCoefficient(
+          &_dt_coef, coefficients._scalars.Get(_alpha_coef_name), prodFunc),
+      true);
   TimeDependentEquationSystem::Init(gridfunctions, fespaces, bc_map, coefficients);
 }
 
@@ -201,44 +202,46 @@ DualOperator::Init(mfem::Vector & X)
   auto * eqs = dynamic_cast<hephaestus::WeakCurlEquationSystem *>(_equation_system);
   _h_curl_var_name = eqs->_h_curl_var_name;
   _h_div_var_name = eqs->_h_div_var_name;
-  u_ = _gridfunctions.Get(_h_curl_var_name);
-  dv_ = _gridfunctions.Get(GetTimeDerivativeName(_h_div_var_name));
-  HCurlFESpace_ = u_->ParFESpace();
-  HDivFESpace_ = dv_->ParFESpace();
+  _u = _gridfunctions.Get(_h_curl_var_name);
+  _dv = _gridfunctions.Get(GetTimeDerivativeName(_h_div_var_name));
+  _h_curl_fe_space = _u->ParFESpace();
+  _h_div_fe_space = _dv->ParFESpace();
 
-  curl = std::make_unique<mfem::ParDiscreteLinearOperator>(HCurlFESpace_, HDivFESpace_);
-  curl->AddDomainInterpolator(new mfem::CurlInterpolator);
-  curl->Assemble();
+  _curl = std::make_unique<mfem::ParDiscreteLinearOperator>(_h_curl_fe_space, _h_div_fe_space);
+  _curl->AddDomainInterpolator(new mfem::CurlInterpolator);
+  _curl->Assemble();
 }
 
 void
 DualOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt)
 {
-  for (unsigned int ind = 0; ind < local_test_vars.size(); ++ind)
+  for (unsigned int ind = 0; ind < _local_test_vars.size(); ++ind)
   {
-    local_test_vars.at(ind)->MakeRef(
-        local_test_vars.at(ind)->ParFESpace(), const_cast<mfem::Vector &>(X), true_offsets[ind]);
-    local_trial_vars.at(ind)->MakeRef(
-        local_trial_vars.at(ind)->ParFESpace(), dX_dt, true_offsets[ind]);
+    _local_test_vars.at(ind)->MakeRef(
+        _local_test_vars.at(ind)->ParFESpace(), const_cast<mfem::Vector &>(X), _true_offsets[ind]);
+    _local_trial_vars.at(ind)->MakeRef(
+        _local_trial_vars.at(ind)->ParFESpace(), dX_dt, _true_offsets[ind]);
   }
   _coefficients.SetTime(GetTime());
   _equation_system->SetTimeStep(dt);
   _equation_system->UpdateEquationSystem(_bc_map, _sources);
 
-  _equation_system->FormLinearSystem(blockA, trueX, trueRhs);
+  _equation_system->FormLinearSystem(_block_a, _true_x, _true_rhs);
 
-  jacobian_solver = std::make_unique<hephaestus::DefaultHCurlPCGSolver>(
-      _solver_options, *blockA.As<mfem::HypreParMatrix>(), _equation_system->test_pfespaces.at(0));
+  _jacobian_solver =
+      std::make_unique<hephaestus::DefaultHCurlPCGSolver>(_solver_options,
+                                                          *_block_a.As<mfem::HypreParMatrix>(),
+                                                          _equation_system->_test_pfespaces.at(0));
 
-  jacobian_solver->Mult(trueRhs, trueX);
-  _equation_system->RecoverFEMSolution(trueX, _gridfunctions);
+  _jacobian_solver->Mult(_true_rhs, _true_x);
+  _equation_system->RecoverFEMSolution(_true_x, _gridfunctions);
 
   // Subtract off contribution from source
-  _sources.SubtractSources(u_);
+  _sources.SubtractSources(_u);
 
   // dv/dt_{n+1} = -∇×u
-  curl->Mult(*u_, *dv_);
-  *dv_ *= -1.0;
+  _curl->Mult(*_u, *_dv);
+  *_dv *= -1.0;
 }
 
 void
@@ -248,16 +251,16 @@ DualOperator::SetGridFunctions()
   // Blocks for solution vector are smaller than the operator size
   // for DualOperator, as curl is stored separately.
   // Block operator only has the HCurl TrueVSize;
-  block_trueOffsets.SetSize(local_test_vars.size());
-  block_trueOffsets[0] = 0;
-  for (unsigned int ind = 0; ind < local_test_vars.size() - 1; ++ind)
+  _block_true_offsets.SetSize(_local_test_vars.size());
+  _block_true_offsets[0] = 0;
+  for (unsigned int ind = 0; ind < _local_test_vars.size() - 1; ++ind)
   {
-    block_trueOffsets[ind + 1] = local_test_vars.at(ind)->ParFESpace()->TrueVSize();
+    _block_true_offsets[ind + 1] = _local_test_vars.at(ind)->ParFESpace()->TrueVSize();
   }
-  block_trueOffsets.PartialSum();
+  _block_true_offsets.PartialSum();
 
-  trueX.Update(block_trueOffsets);
-  trueRhs.Update(block_trueOffsets);
+  _true_x.Update(_block_true_offsets);
+  _true_rhs.Update(_block_true_offsets);
 }
 
 } // namespace hephaestus

--- a/src/formulations/Dual/dual_formulation.hpp
+++ b/src/formulations/Dual/dual_formulation.hpp
@@ -64,15 +64,15 @@ public:
 
   void ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
   void SetGridFunctions() override;
-  mfem::ParFiniteElementSpace * HCurlFESpace_;
-  mfem::ParFiniteElementSpace * HDivFESpace_;
+  mfem::ParFiniteElementSpace * _h_curl_fe_space;
+  mfem::ParFiniteElementSpace * _h_div_fe_space;
 
   std::string _h_curl_var_name, _h_div_var_name;
 
-  mfem::ParGridFunction * u_;  // HCurl vector field
-  mfem::ParGridFunction * dv_; // HDiv vector field
+  mfem::ParGridFunction * _u;  // HCurl vector field
+  mfem::ParGridFunction * _dv; // HDiv vector field
 
 protected:
-  std::unique_ptr<mfem::ParDiscreteLinearOperator> curl;
+  std::unique_ptr<mfem::ParDiscreteLinearOperator> _curl;
 };
 } // namespace hephaestus

--- a/src/formulations/Dual/dual_formulation.hpp
+++ b/src/formulations/Dual/dual_formulation.hpp
@@ -41,7 +41,7 @@ public:
             const hephaestus::FESpaces & fespaces,
             hephaestus::BCMap & bc_map,
             hephaestus::Coefficients & coefficients) override;
-  void addKernels() override;
+  void AddKernels() override;
 
   std::string _h_curl_var_name, _h_div_var_name, _alpha_coef_name, _beta_coef_name,
       _dtalpha_coef_name;

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -17,7 +17,7 @@ EBDualFormulation::EBDualFormulation(const std::string & magnetic_reluctivity_na
 }
 
 void
-EBDualFormulation::registerCurrentDensityAux(const std::string & j_field_name)
+EBDualFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
 {
   //* Current density J = Jᵉ + σE
   //* Induced electric field, Jind = σE
@@ -29,7 +29,7 @@ EBDualFormulation::registerCurrentDensityAux(const std::string & j_field_name)
 }
 
 void
-EBDualFormulation::registerLorentzForceDensityAux(const std::string & f_field_name,
+EBDualFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                                   const std::string & b_field_name,
                                                   const std::string & j_field_name)
 {
@@ -43,7 +43,7 @@ EBDualFormulation::registerLorentzForceDensityAux(const std::string & f_field_na
 }
 
 void
-EBDualFormulation::registerJouleHeatingDensityAux(const std::string & p_field_name,
+EBDualFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                                   const std::string & e_field_name,
                                                   const std::string & conductivity_coef_name)
 {

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -21,7 +21,7 @@ EBDualFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
 {
   //* Current density J = Jᵉ + σE
   //* Induced electric field, Jind = σE
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(j_field_name,
                       new hephaestus::ScaledVectorGridFunctionAux(
                           _h_curl_var_name, j_field_name, _electric_conductivity_name),
@@ -34,7 +34,7 @@ EBDualFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_na
                                                   const std::string & j_field_name)
 {
   //* Lorentz force density = J x B
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(f_field_name,
                       new hephaestus::VectorGridFunctionCrossProductAux(
                           f_field_name, f_field_name, j_field_name, b_field_name),
@@ -48,7 +48,7 @@ EBDualFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_na
                                                   const std::string & conductivity_coef_name)
 {
   //* Joule heating density = E.J
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       p_field_name,
       new hephaestus::VectorGridFunctionDotProductAux(
@@ -60,15 +60,15 @@ EBDualFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_na
 void
 EBDualFormulation::RegisterCoefficients()
 {
-  hephaestus::Coefficients & coefficients = GetProblem()->coefficients;
-  if (!coefficients.scalars.Has(_magnetic_permeability_name))
+  hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;
+  if (!coefficients._scalars.Has(_magnetic_permeability_name))
   {
     MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       _magnetic_reluctivity_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get(_magnetic_permeability_name), fracFunc),
+          &_one_coef, coefficients._scalars.Get(_magnetic_permeability_name), fracFunc),
       true);
   DualFormulation::RegisterCoefficients();
 }

--- a/src/formulations/Dual/eb_dual_formulation.hpp
+++ b/src/formulations/Dual/eb_dual_formulation.hpp
@@ -18,15 +18,15 @@ public:
   ~EBDualFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  void registerCurrentDensityAux(const std::string & j_field_name) override;
+  void RegisterCurrentDensityAux(const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of F ∈ L2
-  void registerLorentzForceDensityAux(const std::string & f_field_name,
+  void RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                       const std::string & b_field_name,
                                       const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
-  void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
                                       const std::string & conductivity_coef_name) override;
 

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -31,7 +31,7 @@ AFormulation::AFormulation(const std::string & magnetic_reluctivity_name,
 }
 
 void
-AFormulation::registerCurrentDensityAux(const std::string & j_field_name)
+AFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
 {
   //* Current density J = Jᵉ -σdA/dt
   //* Induced electric field, Jind = -σdA/dt
@@ -44,7 +44,7 @@ AFormulation::registerCurrentDensityAux(const std::string & j_field_name)
 }
 
 void
-AFormulation::registerMagneticFluxDensityAux(const std::string & b_field_name)
+AFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
 {
   //* Magnetic flux density, B = ∇×A
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
@@ -53,7 +53,7 @@ AFormulation::registerMagneticFluxDensityAux(const std::string & b_field_name)
 }
 
 void
-AFormulation::registerElectricFieldAux(const std::string & e_field_name)
+AFormulation::RegisterElectricFieldAux(const std::string & e_field_name)
 {
   //* Total electric field, E = ρJᵉ -dA/dt
   //* Induced electric field, Eind = -dA/dt
@@ -65,7 +65,7 @@ AFormulation::registerElectricFieldAux(const std::string & e_field_name)
 }
 
 void
-AFormulation::registerMagneticFieldAux(const std::string & h_field_name)
+AFormulation::RegisterMagneticFieldAux(const std::string & h_field_name)
 {
   //* Magnetic field H = ν∇×A
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
@@ -76,7 +76,7 @@ AFormulation::registerMagneticFieldAux(const std::string & h_field_name)
 }
 
 void
-AFormulation::registerLorentzForceDensityAux(const std::string & f_field_name,
+AFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                              const std::string & b_field_name,
                                              const std::string & j_field_name)
 {
@@ -90,7 +90,7 @@ AFormulation::registerLorentzForceDensityAux(const std::string & f_field_name,
 }
 
 void
-AFormulation::registerJouleHeatingDensityAux(const std::string & p_field_name,
+AFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                              const std::string & e_field_name,
                                              const std::string & conductivity_coef_name)
 {

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -35,7 +35,7 @@ AFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
 {
   //* Current density J = Jᵉ -σdA/dt
   //* Induced electric field, Jind = -σdA/dt
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       j_field_name,
       new hephaestus::ScaledVectorGridFunctionAux(
@@ -47,7 +47,7 @@ void
 AFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
 {
   //* Magnetic flux density, B = ∇×A
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       b_field_name, new hephaestus::CurlAuxSolver(_h_curl_var_name, b_field_name), true);
 }
@@ -57,7 +57,7 @@ AFormulation::RegisterElectricFieldAux(const std::string & e_field_name)
 {
   //* Total electric field, E = ρJᵉ -dA/dt
   //* Induced electric field, Eind = -dA/dt
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(e_field_name,
                       new hephaestus::ScaledVectorGridFunctionAux(
                           GetTimeDerivativeName(_h_curl_var_name), e_field_name, "_one", -1.0),
@@ -68,7 +68,7 @@ void
 AFormulation::RegisterMagneticFieldAux(const std::string & h_field_name)
 {
   //* Magnetic field H = ν∇×A
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(h_field_name,
                       new hephaestus::ScaledCurlVectorGridFunctionAux(
                           _h_curl_var_name, h_field_name, _magnetic_reluctivity_name),
@@ -81,7 +81,7 @@ AFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                              const std::string & j_field_name)
 {
   //* Lorentz force density = J x B
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(f_field_name,
                       new hephaestus::VectorGridFunctionCrossProductAux(
                           f_field_name, f_field_name, j_field_name, b_field_name),
@@ -95,7 +95,7 @@ AFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                              const std::string & conductivity_coef_name)
 {
   //* Joule heating density = E.J
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       p_field_name,
       new hephaestus::VectorGridFunctionDotProductAux(
@@ -107,19 +107,19 @@ AFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
 void
 AFormulation::RegisterCoefficients()
 {
-  hephaestus::Coefficients & coefficients = GetProblem()->coefficients;
-  if (!coefficients.scalars.Has(_magnetic_permeability_name))
+  hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;
+  if (!coefficients._scalars.Has(_magnetic_permeability_name))
   {
     MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has(_electric_conductivity_name))
+  if (!coefficients._scalars.Has(_electric_conductivity_name))
   {
     MFEM_ABORT(_electric_conductivity_name + " coefficient not found.");
   }
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       _magnetic_reluctivity_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get(_magnetic_permeability_name), fracFunc),
+          &_one_coef, coefficients._scalars.Get(_magnetic_permeability_name), fracFunc),
       true);
 }
 } // namespace hephaestus

--- a/src/formulations/HCurl/a_formulation.hpp
+++ b/src/formulations/HCurl/a_formulation.hpp
@@ -17,24 +17,24 @@ public:
   ~AFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  void registerCurrentDensityAux(const std::string & j_field_name) override;
+  void RegisterCurrentDensityAux(const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of B ∈ H(div)
-  void registerMagneticFluxDensityAux(const std::string & b_field_name) override;
+  void RegisterMagneticFluxDensityAux(const std::string & b_field_name) override;
 
   // Enable auxiliary calculation of E ∈ H(curl)
-  void registerElectricFieldAux(const std::string & e_field_name) override;
+  void RegisterElectricFieldAux(const std::string & e_field_name) override;
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  void registerMagneticFieldAux(const std::string & h_field_name) override;
+  void RegisterMagneticFieldAux(const std::string & h_field_name) override;
 
   // Enable auxiliary calculation of F ∈ L2
-  void registerLorentzForceDensityAux(const std::string & f_field_name,
+  void RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                       const std::string & b_field_name,
                                       const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
-  void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
                                       const std::string & conductivity_coef_name) override;
 

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -48,7 +48,7 @@ EFormulation::RegisterCoefficients()
 }
 
 void
-EFormulation::registerCurrentDensityAux(const std::string & j_field_name)
+EFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
 {
   //* Current density J = Jᵉ + σE
   //* Induced electric field, Jind = σE
@@ -60,7 +60,7 @@ EFormulation::registerCurrentDensityAux(const std::string & j_field_name)
 }
 
 void
-EFormulation::registerJouleHeatingDensityAux(const std::string & p_field_name,
+EFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                              const std::string & e_field_name,
                                              const std::string & conductivity_coef_name)
 {

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -31,19 +31,19 @@ EFormulation::EFormulation(const std::string & magnetic_reluctivity_name,
 void
 EFormulation::RegisterCoefficients()
 {
-  hephaestus::Coefficients & coefficients = GetProblem()->coefficients;
-  if (!coefficients.scalars.Has(_magnetic_permeability_name))
+  hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;
+  if (!coefficients._scalars.Has(_magnetic_permeability_name))
   {
     MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has(_electric_conductivity_name))
+  if (!coefficients._scalars.Has(_electric_conductivity_name))
   {
     MFEM_ABORT(_electric_conductivity_name + " coefficient not found.");
   }
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       _magnetic_reluctivity_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get(_magnetic_permeability_name), fracFunc),
+          &_one_coef, coefficients._scalars.Get(_magnetic_permeability_name), fracFunc),
       true);
 }
 
@@ -52,7 +52,7 @@ EFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
 {
   //* Current density J = Jᵉ + σE
   //* Induced electric field, Jind = σE
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(j_field_name,
                       new hephaestus::ScaledVectorGridFunctionAux(
                           _h_curl_var_name, j_field_name, _electric_conductivity_name),
@@ -65,7 +65,7 @@ EFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                              const std::string & conductivity_coef_name)
 {
   //* Joule heating density = E.J
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       p_field_name,
       new hephaestus::VectorGridFunctionDotProductAux(

--- a/src/formulations/HCurl/e_formulation.hpp
+++ b/src/formulations/HCurl/e_formulation.hpp
@@ -19,10 +19,10 @@ public:
   void RegisterCoefficients() override;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  void registerCurrentDensityAux(const std::string & j_field_name) override;
+  void RegisterCurrentDensityAux(const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
-  void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
                                       const std::string & conductivity_coef_name) override;
 

--- a/src/formulations/HCurl/h_formulation.cpp
+++ b/src/formulations/HCurl/h_formulation.cpp
@@ -31,7 +31,7 @@ void
 HFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
 {
   //* Current density J = ∇×H
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       j_field_name, new hephaestus::CurlAuxSolver(_h_curl_var_name, j_field_name), true);
 }
@@ -41,7 +41,7 @@ HFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
 {
   //* Magnetic flux density, B = Bᵉ + μH
   //* Induced flux density, B = μH
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(b_field_name,
                       new hephaestus::ScaledVectorGridFunctionAux(
                           _h_curl_var_name, b_field_name, _magnetic_permeability_name),
@@ -52,7 +52,7 @@ void
 HFormulation::RegisterElectricFieldAux(const std::string & e_field_name)
 {
   //* Electric field, E = ρ∇×H
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(e_field_name,
                       new hephaestus::ScaledCurlVectorGridFunctionAux(
                           _h_curl_var_name, e_field_name, _electric_resistivity_name),
@@ -71,7 +71,7 @@ HFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                              const std::string & j_field_name)
 {
   //* Lorentz force density = J x B
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(f_field_name,
                       new hephaestus::VectorGridFunctionCrossProductAux(
                           f_field_name, f_field_name, j_field_name, b_field_name),
@@ -85,7 +85,7 @@ HFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                              const std::string & conductivity_coef_name)
 {
   //* Joule heating density = E.J
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       p_field_name,
       new hephaestus::VectorGridFunctionDotProductAux(
@@ -97,15 +97,15 @@ HFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
 void
 HFormulation::RegisterCoefficients()
 {
-  hephaestus::Coefficients & coefficients = GetProblem()->coefficients;
-  if (!coefficients.scalars.Has(_electric_conductivity_name))
+  hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;
+  if (!coefficients._scalars.Has(_electric_conductivity_name))
   {
     MFEM_ABORT(_electric_conductivity_name + " coefficient not found.");
   }
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       _electric_resistivity_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get(_electric_conductivity_name), fracFunc),
+          &_one_coef, coefficients._scalars.Get(_electric_conductivity_name), fracFunc),
       true);
   HCurlFormulation::RegisterCoefficients();
 }

--- a/src/formulations/HCurl/h_formulation.cpp
+++ b/src/formulations/HCurl/h_formulation.cpp
@@ -28,7 +28,7 @@ HFormulation::HFormulation(const std::string & electric_resistivity_name,
 }
 
 void
-HFormulation::registerCurrentDensityAux(const std::string & j_field_name)
+HFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
 {
   //* Current density J = ∇×H
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
@@ -37,7 +37,7 @@ HFormulation::registerCurrentDensityAux(const std::string & j_field_name)
 }
 
 void
-HFormulation::registerMagneticFluxDensityAux(const std::string & b_field_name)
+HFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
 {
   //* Magnetic flux density, B = Bᵉ + μH
   //* Induced flux density, B = μH
@@ -49,7 +49,7 @@ HFormulation::registerMagneticFluxDensityAux(const std::string & b_field_name)
 }
 
 void
-HFormulation::registerElectricFieldAux(const std::string & e_field_name)
+HFormulation::RegisterElectricFieldAux(const std::string & e_field_name)
 {
   //* Electric field, E = ρ∇×H
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
@@ -60,13 +60,13 @@ HFormulation::registerElectricFieldAux(const std::string & e_field_name)
 }
 
 void
-HFormulation::registerMagneticFieldAux(const std::string & h_field_name)
+HFormulation::RegisterMagneticFieldAux(const std::string & h_field_name)
 {
   //* Magnetic field H is a state variable; no additional calculation needed
 }
 
 void
-HFormulation::registerLorentzForceDensityAux(const std::string & f_field_name,
+HFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                              const std::string & b_field_name,
                                              const std::string & j_field_name)
 {
@@ -80,7 +80,7 @@ HFormulation::registerLorentzForceDensityAux(const std::string & f_field_name,
 }
 
 void
-HFormulation::registerJouleHeatingDensityAux(const std::string & p_field_name,
+HFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                              const std::string & e_field_name,
                                              const std::string & conductivity_coef_name)
 {

--- a/src/formulations/HCurl/h_formulation.hpp
+++ b/src/formulations/HCurl/h_formulation.hpp
@@ -17,24 +17,24 @@ public:
   ~HFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  void registerCurrentDensityAux(const std::string & j_field_name) override;
+  void RegisterCurrentDensityAux(const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of B ∈ H(div)
-  void registerMagneticFluxDensityAux(const std::string & b_field_name) override;
+  void RegisterMagneticFluxDensityAux(const std::string & b_field_name) override;
 
   // Enable auxiliary calculation of E ∈ H(curl)
-  void registerElectricFieldAux(const std::string & e_field_name) override;
+  void RegisterElectricFieldAux(const std::string & e_field_name) override;
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  void registerMagneticFieldAux(const std::string & h_field_name) override;
+  void RegisterMagneticFieldAux(const std::string & h_field_name) override;
 
   // Enable auxiliary calculation of F ∈ L2
-  void registerLorentzForceDensityAux(const std::string & f_field_name,
+  void RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                       const std::string & b_field_name,
                                       const std::string & j_field_name) override;
 
   // Enable auxiliary calculation of P ∈ L2
-  void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
                                       const std::string & conductivity_coef_name) override;
 

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -59,30 +59,30 @@ HCurlFormulation::ConstructEquationSystem()
   weak_form_params.SetParam("HCurlVarName", _h_curl_var_name);
   weak_form_params.SetParam("AlphaCoefName", _alpha_coef_name);
   weak_form_params.SetParam("BetaCoefName", _beta_coef_name);
-  GetProblem()->td_equation_system =
+  GetProblem()->_td_equation_system =
       std::make_unique<hephaestus::CurlCurlEquationSystem>(weak_form_params);
 }
 
 void
 HCurlFormulation::ConstructOperator()
 {
-  problem->td_operator = std::make_unique<hephaestus::HCurlOperator>(*(problem->pmesh),
-                                                                     problem->fespaces,
-                                                                     problem->gridfunctions,
-                                                                     problem->bc_map,
-                                                                     problem->coefficients,
-                                                                     problem->sources,
-                                                                     problem->solver_options);
-  problem->td_operator->SetEquationSystem(problem->td_equation_system.get());
-  problem->td_operator->SetGridFunctions();
+  _problem->_td_operator = std::make_unique<hephaestus::HCurlOperator>(*(_problem->_pmesh),
+                                                                       _problem->_fespaces,
+                                                                       _problem->_gridfunctions,
+                                                                       _problem->_bc_map,
+                                                                       _problem->_coefficients,
+                                                                       _problem->_sources,
+                                                                       _problem->_solver_options);
+  _problem->_td_operator->SetEquationSystem(_problem->_td_equation_system.get());
+  _problem->_td_operator->SetGridFunctions();
 };
 
 void
 HCurlFormulation::RegisterGridFunctions()
 {
-  int & myid = GetProblem()->myid_;
-  hephaestus::GridFunctions & gridfunctions = GetProblem()->gridfunctions;
-  hephaestus::FESpaces & fespaces = GetProblem()->fespaces;
+  int & myid = GetProblem()->_myid;
+  hephaestus::GridFunctions & gridfunctions = GetProblem()->_gridfunctions;
+  hephaestus::FESpaces & fespaces = GetProblem()->_fespaces;
 
   // Register default ParGridFunctions of state gridfunctions if not provided
   if (!gridfunctions.Has(_h_curl_var_name))
@@ -101,10 +101,10 @@ HCurlFormulation::RegisterGridFunctions()
 
 CurlCurlEquationSystem::CurlCurlEquationSystem(const hephaestus::InputParameters & params)
   : TimeDependentEquationSystem(params),
-    h_curl_var_name(params.GetParam<std::string>("HCurlVarName")),
-    alpha_coef_name(params.GetParam<std::string>("AlphaCoefName")),
-    beta_coef_name(params.GetParam<std::string>("BetaCoefName")),
-    dtalpha_coef_name(std::string("dt_") + alpha_coef_name)
+    _h_curl_var_name(params.GetParam<std::string>("HCurlVarName")),
+    _alpha_coef_name(params.GetParam<std::string>("AlphaCoefName")),
+    _beta_coef_name(params.GetParam<std::string>("BetaCoefName")),
+    _dtalpha_coef_name(std::string("dt_") + _alpha_coef_name)
 {
 }
 
@@ -114,34 +114,35 @@ CurlCurlEquationSystem::Init(hephaestus::GridFunctions & gridfunctions,
                              hephaestus::BCMap & bc_map,
                              hephaestus::Coefficients & coefficients)
 {
-  coefficients.scalars.Register(dtalpha_coef_name,
-                                new mfem::TransformedCoefficient(
-                                    &dtCoef, coefficients.scalars.Get(alpha_coef_name), prodFunc),
-                                true);
+  coefficients._scalars.Register(
+      _dtalpha_coef_name,
+      new mfem::TransformedCoefficient(
+          &_dt_coef, coefficients._scalars.Get(_alpha_coef_name), prodFunc),
+      true);
   TimeDependentEquationSystem::Init(gridfunctions, fespaces, bc_map, coefficients);
 }
 
 void
 CurlCurlEquationSystem::AddKernels()
 {
-  AddVariableNameIfMissing(h_curl_var_name);
-  std::string dh_curl_var_dt = GetTimeDerivativeName(h_curl_var_name);
+  AddVariableNameIfMissing(_h_curl_var_name);
+  std::string dh_curl_var_dt = GetTimeDerivativeName(_h_curl_var_name);
 
   // (α∇×u_{n}, ∇×u')
   hephaestus::InputParameters weak_curl_curl_params;
-  weak_curl_curl_params.SetParam("CoupledVariableName", h_curl_var_name);
-  weak_curl_curl_params.SetParam("CoefficientName", alpha_coef_name);
+  weak_curl_curl_params.SetParam("CoupledVariableName", _h_curl_var_name);
+  weak_curl_curl_params.SetParam("CoefficientName", _alpha_coef_name);
   AddKernel(dh_curl_var_dt,
             std::make_unique<hephaestus::WeakCurlCurlKernel>(weak_curl_curl_params));
 
   // (αdt∇×du/dt_{n+1}, ∇×u')
   hephaestus::InputParameters curl_curl_params;
-  curl_curl_params.SetParam("CoefficientName", dtalpha_coef_name);
+  curl_curl_params.SetParam("CoefficientName", _dtalpha_coef_name);
   AddKernel(dh_curl_var_dt, std::make_unique<hephaestus::CurlCurlKernel>(curl_curl_params));
 
   // (βdu/dt_{n+1}, u')
   hephaestus::InputParameters vector_fe_mass_params;
-  vector_fe_mass_params.SetParam("CoefficientName", beta_coef_name);
+  vector_fe_mass_params.SetParam("CoefficientName", _beta_coef_name);
   AddKernel(dh_curl_var_dt,
             std::make_unique<hephaestus::VectorFEMassKernel>(vector_fe_mass_params));
 }
@@ -149,12 +150,12 @@ CurlCurlEquationSystem::AddKernels()
 void
 HCurlFormulation::RegisterCoefficients()
 {
-  hephaestus::Coefficients & coefficients = GetProblem()->coefficients;
-  if (!coefficients.scalars.Has(_alpha_coef_name))
+  hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;
+  if (!coefficients._scalars.Has(_alpha_coef_name))
   {
     MFEM_ABORT(_alpha_coef_name + " coefficient not found.");
   }
-  if (!coefficients.scalars.Has(_beta_coef_name))
+  if (!coefficients._scalars.Has(_beta_coef_name))
   {
     MFEM_ABORT(_beta_coef_name + " coefficient not found.");
   }
@@ -191,24 +192,26 @@ u_{n+1} = u_{n} + dt du/dt_{n+1}
 void
 HCurlOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt)
 {
-  for (unsigned int ind = 0; ind < local_test_vars.size(); ++ind)
+  for (unsigned int ind = 0; ind < _local_test_vars.size(); ++ind)
   {
-    local_test_vars.at(ind)->MakeRef(
-        local_test_vars.at(ind)->ParFESpace(), const_cast<mfem::Vector &>(X), true_offsets[ind]);
-    local_trial_vars.at(ind)->MakeRef(
-        local_trial_vars.at(ind)->ParFESpace(), dX_dt, true_offsets[ind]);
+    _local_test_vars.at(ind)->MakeRef(
+        _local_test_vars.at(ind)->ParFESpace(), const_cast<mfem::Vector &>(X), _true_offsets[ind]);
+    _local_trial_vars.at(ind)->MakeRef(
+        _local_trial_vars.at(ind)->ParFESpace(), dX_dt, _true_offsets[ind]);
   }
   _coefficients.SetTime(GetTime());
   _equation_system->SetTimeStep(dt);
   _equation_system->UpdateEquationSystem(_bc_map, _sources);
 
-  _equation_system->FormLinearSystem(blockA, trueX, trueRhs);
+  _equation_system->FormLinearSystem(_block_a, _true_x, _true_rhs);
 
-  jacobian_solver = std::make_unique<hephaestus::DefaultHCurlPCGSolver>(
-      _solver_options, *blockA.As<mfem::HypreParMatrix>(), _equation_system->test_pfespaces.at(0));
+  _jacobian_solver =
+      std::make_unique<hephaestus::DefaultHCurlPCGSolver>(_solver_options,
+                                                          *_block_a.As<mfem::HypreParMatrix>(),
+                                                          _equation_system->_test_pfespaces.at(0));
 
-  jacobian_solver->Mult(trueRhs, trueX);
-  _equation_system->RecoverFEMSolution(trueX, _gridfunctions);
+  _jacobian_solver->Mult(_true_rhs, _true_x);
+  _equation_system->RecoverFEMSolution(_true_x, _gridfunctions);
 }
 
 } // namespace hephaestus

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -122,26 +122,26 @@ CurlCurlEquationSystem::Init(hephaestus::GridFunctions & gridfunctions,
 }
 
 void
-CurlCurlEquationSystem::addKernels()
+CurlCurlEquationSystem::AddKernels()
 {
-  addVariableNameIfMissing(h_curl_var_name);
+  AddVariableNameIfMissing(h_curl_var_name);
   std::string dh_curl_var_dt = GetTimeDerivativeName(h_curl_var_name);
 
   // (α∇×u_{n}, ∇×u')
   hephaestus::InputParameters weakCurlCurlParams;
   weakCurlCurlParams.SetParam("CoupledVariableName", h_curl_var_name);
   weakCurlCurlParams.SetParam("CoefficientName", alpha_coef_name);
-  addKernel(dh_curl_var_dt, std::make_unique<hephaestus::WeakCurlCurlKernel>(weakCurlCurlParams));
+  AddKernel(dh_curl_var_dt, std::make_unique<hephaestus::WeakCurlCurlKernel>(weakCurlCurlParams));
 
   // (αdt∇×du/dt_{n+1}, ∇×u')
   hephaestus::InputParameters curlCurlParams;
   curlCurlParams.SetParam("CoefficientName", dtalpha_coef_name);
-  addKernel(dh_curl_var_dt, std::make_unique<hephaestus::CurlCurlKernel>(curlCurlParams));
+  AddKernel(dh_curl_var_dt, std::make_unique<hephaestus::CurlCurlKernel>(curlCurlParams));
 
   // (βdu/dt_{n+1}, u')
   hephaestus::InputParameters vectorFEMassParams;
   vectorFEMassParams.SetParam("CoefficientName", beta_coef_name);
-  addKernel(dh_curl_var_dt, std::make_unique<hephaestus::VectorFEMassKernel>(vectorFEMassParams));
+  AddKernel(dh_curl_var_dt, std::make_unique<hephaestus::VectorFEMassKernel>(vectorFEMassParams));
 }
 
 void
@@ -197,8 +197,8 @@ HCurlOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vect
         local_trial_vars.at(ind)->ParFESpace(), dX_dt, true_offsets[ind]);
   }
   _coefficients.SetTime(GetTime());
-  _equation_system->setTimeStep(dt);
-  _equation_system->updateEquationSystem(_bc_map, _sources);
+  _equation_system->SetTimeStep(dt);
+  _equation_system->UpdateEquationSystem(_bc_map, _sources);
 
   _equation_system->FormLinearSystem(blockA, trueX, trueRhs);
 

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -128,20 +128,22 @@ CurlCurlEquationSystem::AddKernels()
   std::string dh_curl_var_dt = GetTimeDerivativeName(h_curl_var_name);
 
   // (α∇×u_{n}, ∇×u')
-  hephaestus::InputParameters weakCurlCurlParams;
-  weakCurlCurlParams.SetParam("CoupledVariableName", h_curl_var_name);
-  weakCurlCurlParams.SetParam("CoefficientName", alpha_coef_name);
-  AddKernel(dh_curl_var_dt, std::make_unique<hephaestus::WeakCurlCurlKernel>(weakCurlCurlParams));
+  hephaestus::InputParameters weak_curl_curl_params;
+  weak_curl_curl_params.SetParam("CoupledVariableName", h_curl_var_name);
+  weak_curl_curl_params.SetParam("CoefficientName", alpha_coef_name);
+  AddKernel(dh_curl_var_dt,
+            std::make_unique<hephaestus::WeakCurlCurlKernel>(weak_curl_curl_params));
 
   // (αdt∇×du/dt_{n+1}, ∇×u')
-  hephaestus::InputParameters curlCurlParams;
-  curlCurlParams.SetParam("CoefficientName", dtalpha_coef_name);
-  AddKernel(dh_curl_var_dt, std::make_unique<hephaestus::CurlCurlKernel>(curlCurlParams));
+  hephaestus::InputParameters curl_curl_params;
+  curl_curl_params.SetParam("CoefficientName", dtalpha_coef_name);
+  AddKernel(dh_curl_var_dt, std::make_unique<hephaestus::CurlCurlKernel>(curl_curl_params));
 
   // (βdu/dt_{n+1}, u')
-  hephaestus::InputParameters vectorFEMassParams;
-  vectorFEMassParams.SetParam("CoefficientName", beta_coef_name);
-  AddKernel(dh_curl_var_dt, std::make_unique<hephaestus::VectorFEMassKernel>(vectorFEMassParams));
+  hephaestus::InputParameters vector_fe_mass_params;
+  vector_fe_mass_params.SetParam("CoefficientName", beta_coef_name);
+  AddKernel(dh_curl_var_dt,
+            std::make_unique<hephaestus::VectorFEMassKernel>(vector_fe_mass_params));
 }
 
 void
@@ -202,10 +204,10 @@ HCurlOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vect
 
   _equation_system->FormLinearSystem(blockA, trueX, trueRhs);
 
-  a1_solver = std::make_unique<hephaestus::DefaultHCurlPCGSolver>(
+  jacobian_solver = std::make_unique<hephaestus::DefaultHCurlPCGSolver>(
       _solver_options, *blockA.As<mfem::HypreParMatrix>(), _equation_system->test_pfespaces.at(0));
 
-  a1_solver->Mult(trueRhs, trueX);
+  jacobian_solver->Mult(trueRhs, trueX);
   _equation_system->RecoverFEMSolution(trueX, _gridfunctions);
 }
 

--- a/src/formulations/HCurl/hcurl_formulation.hpp
+++ b/src/formulations/HCurl/hcurl_formulation.hpp
@@ -39,7 +39,7 @@ public:
             const hephaestus::FESpaces & fespaces,
             hephaestus::BCMap & bc_map,
             hephaestus::Coefficients & coefficients) override;
-  void addKernels() override;
+  void AddKernels() override;
 
   std::string h_curl_var_name, alpha_coef_name, beta_coef_name, dtalpha_coef_name;
 };

--- a/src/formulations/HCurl/hcurl_formulation.hpp
+++ b/src/formulations/HCurl/hcurl_formulation.hpp
@@ -41,7 +41,7 @@ public:
             hephaestus::Coefficients & coefficients) override;
   void AddKernels() override;
 
-  std::string h_curl_var_name, alpha_coef_name, beta_coef_name, dtalpha_coef_name;
+  std::string _h_curl_var_name, _alpha_coef_name, _beta_coef_name, _dtalpha_coef_name;
 };
 
 class HCurlOperator : public TimeDomainEquationSystemOperator

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
@@ -29,7 +29,7 @@ MagnetostaticFormulation::MagnetostaticFormulation(
 }
 
 void
-MagnetostaticFormulation::registerMagneticFluxDensityAux(const std::string & b_field_name)
+MagnetostaticFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
 {
   //* Magnetic flux density, B = ∇×A
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
@@ -38,7 +38,7 @@ MagnetostaticFormulation::registerMagneticFluxDensityAux(const std::string & b_f
 }
 
 void
-MagnetostaticFormulation::registerMagneticFieldAux(const std::string & h_field_name)
+MagnetostaticFormulation::RegisterMagneticFieldAux(const std::string & h_field_name)
 {
   //* Magnetic field H = ν∇×A
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
@@ -49,7 +49,7 @@ MagnetostaticFormulation::registerMagneticFieldAux(const std::string & h_field_n
 }
 
 void
-MagnetostaticFormulation::registerLorentzForceDensityAux(const std::string & f_field_name,
+MagnetostaticFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                                          const std::string & b_field_name,
                                                          const std::string & j_field_name)
 {

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
@@ -32,7 +32,7 @@ void
 MagnetostaticFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
 {
   //* Magnetic flux density, B = ∇×A
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       b_field_name, new hephaestus::CurlAuxSolver(_h_curl_var_name, b_field_name), true);
 }
@@ -41,7 +41,7 @@ void
 MagnetostaticFormulation::RegisterMagneticFieldAux(const std::string & h_field_name)
 {
   //* Magnetic field H = ν∇×A
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(h_field_name,
                       new hephaestus::ScaledCurlVectorGridFunctionAux(
                           _h_curl_var_name, h_field_name, _magnetic_reluctivity_name),
@@ -54,7 +54,7 @@ MagnetostaticFormulation::RegisterLorentzForceDensityAux(const std::string & f_f
                                                          const std::string & j_field_name)
 {
   //* Lorentz force density = J x B
-  hephaestus::AuxSolvers & auxsolvers = GetProblem()->postprocessors;
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(f_field_name,
                       new hephaestus::VectorGridFunctionCrossProductAux(
                           f_field_name, f_field_name, j_field_name, b_field_name),
@@ -65,15 +65,15 @@ MagnetostaticFormulation::RegisterLorentzForceDensityAux(const std::string & f_f
 void
 MagnetostaticFormulation::RegisterCoefficients()
 {
-  hephaestus::Coefficients & coefficients = GetProblem()->coefficients;
-  if (!coefficients.scalars.Has(_magnetic_permeability_name))
+  hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;
+  if (!coefficients._scalars.Has(_magnetic_permeability_name))
   {
     MFEM_ABORT(_magnetic_permeability_name + " coefficient not found.");
   }
-  coefficients.scalars.Register(
+  coefficients._scalars.Register(
       _magnetic_reluctivity_name,
       new mfem::TransformedCoefficient(
-          &oneCoef, coefficients.scalars.Get(_magnetic_permeability_name), fracFunc),
+          &_one_coef, coefficients._scalars.Get(_magnetic_permeability_name), fracFunc),
       true);
 }
 } // namespace hephaestus

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
@@ -16,13 +16,13 @@ public:
   ~MagnetostaticFormulation() override = default;
 
   // Enable auxiliary calculation of B ∈ H(div)
-  void registerMagneticFluxDensityAux(const std::string & b_field_name) override;
+  void RegisterMagneticFluxDensityAux(const std::string & b_field_name) override;
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  void registerMagneticFieldAux(const std::string & h_field_name) override;
+  void RegisterMagneticFieldAux(const std::string & h_field_name) override;
 
   // Enable auxiliary calculation of F ∈ L2
-  void registerLorentzForceDensityAux(const std::string & f_field_name,
+  void RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                       const std::string & b_field_name,
                                       const std::string & j_field_name) override;
 

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -129,8 +129,8 @@ StaticsOperator::Solve(mfem::Vector & X)
   mfem::ParLinearForm b1_(a_.ParFESpace());
   b1_ = 0.0;
   mfem::Array<int> ess_bdr_tdofs_;
-  _bc_map.applyEssentialBCs(h_curl_var_name, ess_bdr_tdofs_, a_, pmesh_);
-  _bc_map.applyIntegratedBCs(h_curl_var_name, b1_, pmesh_);
+  _bc_map.ApplyEssentialBCs(h_curl_var_name, ess_bdr_tdofs_, a_, pmesh_);
+  _bc_map.ApplyIntegratedBCs(h_curl_var_name, b1_, pmesh_);
   b1_.Assemble();
   _sources.Apply(&b1_);
   mfem::ParBilinearForm a1_(a_.ParFESpace());

--- a/src/formulations/Magnetostatic/statics_formulation.hpp
+++ b/src/formulations/Magnetostatic/statics_formulation.hpp
@@ -43,9 +43,9 @@ public:
   void Solve(mfem::Vector & X) override;
 
 private:
-  std::string h_curl_var_name, stiffness_coef_name;
+  std::string _h_curl_var_name, _stiffness_coef_name;
 
-  mfem::Coefficient * stiffCoef_; // Stiffness Material Coefficient
+  mfem::Coefficient * _stiff_coef; // Stiffness Material Coefficient
 };
 
 } // namespace hephaestus

--- a/src/formulations/complex_em_formulation_interface.hpp
+++ b/src/formulations/complex_em_formulation_interface.hpp
@@ -11,35 +11,35 @@ public:
   ComplexEMFormulationInterface() = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  virtual void registerCurrentDensityAux(const std::string & j_field_real_name,
+  virtual void RegisterCurrentDensityAux(const std::string & j_field_real_name,
                                          const std::string & j_field_imag_name)
   {
     MFEM_ABORT("Current density auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of B ∈ H(div)
-  virtual void registerMagneticFluxDensityAux(const std::string & b_field_real_name,
+  virtual void RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
                                               const std::string & b_field_imag_name)
   {
     MFEM_ABORT("Magnetic flux density auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of E ∈ H(curl)
-  virtual void registerElectricFieldAux(const std::string & e_field_real_name,
+  virtual void RegisterElectricFieldAux(const std::string & e_field_real_name,
                                         const std::string & e_field_imag_name)
   {
     MFEM_ABORT("Electric field auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  virtual void registerMagneticFieldAux(const std::string & h_field_real_name,
+  virtual void RegisterMagneticFieldAux(const std::string & h_field_real_name,
                                         const std::string & h_field_imag_name)
   {
     MFEM_ABORT("Magnetic field auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of P ∈ L2
-  virtual void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  virtual void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                               const std::string & e_field_real_name,
                                               const std::string & e_field_imag_name,
                                               const std::string & conductivity_coef_name)

--- a/src/formulations/em_formulation_interface.hpp
+++ b/src/formulations/em_formulation_interface.hpp
@@ -11,31 +11,31 @@ public:
   EMFormulationInterface() = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  virtual void registerCurrentDensityAux(const std::string & j_field_name)
+  virtual void RegisterCurrentDensityAux(const std::string & j_field_name)
   {
     MFEM_ABORT("Current density auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of B ∈ H(div)
-  virtual void registerMagneticFluxDensityAux(const std::string & b_field_name)
+  virtual void RegisterMagneticFluxDensityAux(const std::string & b_field_name)
   {
     MFEM_ABORT("Magnetic flux density auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of E ∈ H(curl)
-  virtual void registerElectricFieldAux(const std::string & e_field_name)
+  virtual void RegisterElectricFieldAux(const std::string & e_field_name)
   {
     MFEM_ABORT("Electric field auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  virtual void registerMagneticFieldAux(const std::string & h_field_name)
+  virtual void RegisterMagneticFieldAux(const std::string & h_field_name)
   {
     MFEM_ABORT("Magnetic field auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of F ∈ L2
-  virtual void registerLorentzForceDensityAux(const std::string & f_field_name,
+  virtual void RegisterLorentzForceDensityAux(const std::string & f_field_name,
                                               const std::string & b_field_name,
                                               const std::string & j_field_name)
   {
@@ -43,7 +43,7 @@ public:
   }
 
   // Enable auxiliary calculation of P ∈ L2
-  virtual void registerJouleHeatingDensityAux(const std::string & p_field_name,
+  virtual void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                               const std::string & e_field_name,
                                               const std::string & conductivity_coef_name)
   {

--- a/src/formulations/equation_system_operator.cpp
+++ b/src/formulations/equation_system_operator.cpp
@@ -6,37 +6,37 @@ namespace hephaestus
 void
 EquationSystemOperator::SetGridFunctions()
 {
-  local_test_vars = _gridfunctions.Get(state_var_names);
+  _local_test_vars = _gridfunctions.Get(_state_var_names);
 
   // Set operator size and block structure
-  block_trueOffsets.SetSize(local_test_vars.size() + 1);
-  block_trueOffsets[0] = 0;
-  for (unsigned int ind = 0; ind < local_test_vars.size(); ++ind)
+  _block_true_offsets.SetSize(_local_test_vars.size() + 1);
+  _block_true_offsets[0] = 0;
+  for (unsigned int ind = 0; ind < _local_test_vars.size(); ++ind)
   {
-    block_trueOffsets[ind + 1] = local_test_vars.at(ind)->ParFESpace()->TrueVSize();
+    _block_true_offsets[ind + 1] = _local_test_vars.at(ind)->ParFESpace()->TrueVSize();
   }
-  block_trueOffsets.PartialSum();
+  _block_true_offsets.PartialSum();
 
-  true_offsets.SetSize(local_test_vars.size() + 1);
-  true_offsets[0] = 0;
-  for (unsigned int ind = 0; ind < local_test_vars.size(); ++ind)
+  _true_offsets.SetSize(_local_test_vars.size() + 1);
+  _true_offsets[0] = 0;
+  for (unsigned int ind = 0; ind < _local_test_vars.size(); ++ind)
   {
-    true_offsets[ind + 1] = local_test_vars.at(ind)->ParFESpace()->GetVSize();
+    _true_offsets[ind + 1] = _local_test_vars.at(ind)->ParFESpace()->GetVSize();
   }
-  true_offsets.PartialSum();
+  _true_offsets.PartialSum();
 
-  height = true_offsets[local_test_vars.size()];
-  width = true_offsets[local_test_vars.size()];
-  trueX.Update(block_trueOffsets);
-  trueRhs.Update(block_trueOffsets);
+  height = _true_offsets[_local_test_vars.size()];
+  width = _true_offsets[_local_test_vars.size()];
+  _true_x.Update(_block_true_offsets);
+  _true_rhs.Update(_block_true_offsets);
 
   // Populate vector of active auxiliary gridfunctions
-  active_aux_var_names.resize(0);
-  for (auto & aux_var_name : aux_var_names)
+  _active_aux_var_names.resize(0);
+  for (auto & aux_var_name : _aux_var_names)
   {
     if (_gridfunctions.Has(aux_var_name))
     {
-      active_aux_var_names.push_back(aux_var_name);
+      _active_aux_var_names.push_back(aux_var_name);
     }
   }
 };
@@ -45,10 +45,10 @@ void
 EquationSystemOperator::Init(mfem::Vector & X)
 {
   // Define material property coefficients
-  for (unsigned int ind = 0; ind < local_test_vars.size(); ++ind)
+  for (unsigned int ind = 0; ind < _local_test_vars.size(); ++ind)
   {
-    local_test_vars.at(ind)->MakeRef(
-        local_test_vars.at(ind)->ParFESpace(), const_cast<mfem::Vector &>(X), true_offsets[ind]);
+    _local_test_vars.at(ind)->MakeRef(
+        _local_test_vars.at(ind)->ParFESpace(), const_cast<mfem::Vector &>(X), _true_offsets[ind]);
   }
 }
 

--- a/src/formulations/equation_system_operator.hpp
+++ b/src/formulations/equation_system_operator.hpp
@@ -18,7 +18,7 @@ public:
                          hephaestus::Coefficients & coefficients,
                          hephaestus::Sources & sources,
                          hephaestus::InputParameters & solver_options)
-    : pmesh_(&pmesh),
+    : _pmesh(&pmesh),
       _fespaces(fespaces),
       _gridfunctions(gridfunctions),
       _bc_map(bc_map),
@@ -33,22 +33,22 @@ public:
   virtual void Solve(mfem::Vector & X);
   void Mult(const mfem::Vector & x, mfem::Vector & y) const override{};
 
-  mfem::Array<int> true_offsets, block_trueOffsets;
+  mfem::Array<int> _true_offsets, _block_true_offsets;
   // Vector of names of state gridfunctions used in formulation, ordered by
   // appearance in block vector during solve.
-  std::vector<std::string> state_var_names;
+  std::vector<std::string> _state_var_names;
   // Vector of names of recognised auxiliary gridfunctions that can be
   // calculated from formulation,
-  std::vector<std::string> aux_var_names;
+  std::vector<std::string> _aux_var_names;
   // Vector of names of active auxiliary gridfunctions that are being calculated
   // in formulation,
-  std::vector<std::string> active_aux_var_names;
+  std::vector<std::string> _active_aux_var_names;
 
-  std::vector<mfem::ParGridFunction *> local_test_vars;
+  std::vector<mfem::ParGridFunction *> _local_test_vars;
 
-  int myid_{0};
-  int num_procs_{1};
-  mfem::ParMesh * pmesh_;
+  int _myid{0};
+  int _num_procs{1};
+  mfem::ParMesh * _pmesh;
   hephaestus::FESpaces & _fespaces;
   hephaestus::GridFunctions & _gridfunctions;
   hephaestus::BCMap & _bc_map;
@@ -56,8 +56,8 @@ public:
   hephaestus::Coefficients & _coefficients;
   hephaestus::InputParameters & _solver_options;
 
-  mfem::OperatorHandle blockA;
-  mfem::BlockVector trueX, trueRhs;
+  mfem::OperatorHandle _block_a;
+  mfem::BlockVector _true_x, _true_rhs;
 };
 
 } // namespace hephaestus

--- a/src/formulations/frequency_domain_em_formulation.hpp
+++ b/src/formulations/frequency_domain_em_formulation.hpp
@@ -14,6 +14,6 @@ public:
   ~FrequencyDomainEMFormulation() override = default;
 
 protected:
-  mfem::ConstantCoefficient * freqCoef{nullptr};
+  mfem::ConstantCoefficient * _freq_coef{nullptr};
 };
 } // namespace hephaestus

--- a/src/formulations/time_domain_equation_system_operator.cpp
+++ b/src/formulations/time_domain_equation_system_operator.cpp
@@ -72,7 +72,7 @@ TimeDomainEquationSystemOperator::Init(mfem::Vector & X)
     *(local_trial_vars.at(ind)) = 0.0;
   }
 
-  _equation_system->buildEquationSystem(_bc_map, _sources);
+  _equation_system->BuildEquationSystem(_bc_map, _sources);
 };
 
 void
@@ -89,8 +89,8 @@ TimeDomainEquationSystemOperator::ImplicitSolve(const double dt,
         local_trial_vars.at(ind)->ParFESpace(), dX_dt, true_offsets[ind]);
   }
   _coefficients.SetTime(GetTime());
-  _equation_system->setTimeStep(dt);
-  _equation_system->updateEquationSystem(_bc_map, _sources);
+  _equation_system->SetTimeStep(dt);
+  _equation_system->UpdateEquationSystem(_bc_map, _sources);
 
   _equation_system->FormLinearSystem(blockA, trueX, trueRhs);
 

--- a/src/formulations/time_domain_equation_system_operator.hpp
+++ b/src/formulations/time_domain_equation_system_operator.hpp
@@ -65,7 +65,7 @@ public:
   hephaestus::InputParameters & _solver_options;
 
   mutable std::unique_ptr<hephaestus::DefaultGMRESSolver> solver{nullptr};
-  mutable std::unique_ptr<hephaestus::DefaultHCurlPCGSolver> a1_solver{nullptr};
+  mutable std::unique_ptr<hephaestus::DefaultHCurlPCGSolver> jacobian_solver{nullptr};
 
   mfem::OperatorHandle blockA;
   mfem::BlockVector trueX, trueRhs;

--- a/src/formulations/time_domain_equation_system_operator.hpp
+++ b/src/formulations/time_domain_equation_system_operator.hpp
@@ -24,7 +24,7 @@ public:
                                    hephaestus::Coefficients & coefficients,
                                    hephaestus::Sources & sources,
                                    hephaestus::InputParameters & solver_options)
-    : pmesh_(&pmesh),
+    : _pmesh(&pmesh),
       _fespaces(fespaces),
       _gridfunctions(gridfunctions),
       _bc_map(bc_map),
@@ -39,24 +39,24 @@ public:
   void ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
   void SetEquationSystem(hephaestus::TimeDependentEquationSystem * equation_system);
 
-  mfem::Array<int> true_offsets, block_trueOffsets;
+  mfem::Array<int> _true_offsets, _block_true_offsets;
   // Vector of names of state gridfunctions used in formulation, ordered by
   // appearance in block vector during solve.
-  std::vector<std::string> state_var_names;
+  std::vector<std::string> _state_var_names;
   // Vector of names of recognised auxiliary gridfunctions that can be
   // calculated from formulation,
-  std::vector<std::string> aux_var_names;
+  std::vector<std::string> _aux_var_names;
   // Vector of names of active auxiliary gridfunctions that are being calculated
   // in formulation,
-  std::vector<std::string> active_aux_var_names;
+  std::vector<std::string> _active_aux_var_names;
 
-  std::vector<mfem::ParGridFunction *> local_trial_vars, local_test_vars;
+  std::vector<mfem::ParGridFunction *> _local_trial_vars, _local_test_vars;
 
   hephaestus::TimeDependentEquationSystem * _equation_system;
 
-  int myid_{0};
-  int num_procs_{1};
-  mfem::ParMesh * pmesh_;
+  int _myid{0};
+  int _num_procs{1};
+  mfem::ParMesh * _pmesh;
   hephaestus::FESpaces & _fespaces;
   hephaestus::GridFunctions & _gridfunctions;
   hephaestus::BCMap & _bc_map;
@@ -64,11 +64,11 @@ public:
   hephaestus::Coefficients & _coefficients;
   hephaestus::InputParameters & _solver_options;
 
-  mutable std::unique_ptr<hephaestus::DefaultGMRESSolver> solver{nullptr};
-  mutable std::unique_ptr<hephaestus::DefaultHCurlPCGSolver> jacobian_solver{nullptr};
+  mutable std::unique_ptr<hephaestus::DefaultGMRESSolver> _solver{nullptr};
+  mutable std::unique_ptr<hephaestus::DefaultHCurlPCGSolver> _jacobian_solver{nullptr};
 
-  mfem::OperatorHandle blockA;
-  mfem::BlockVector trueX, trueRhs;
+  mfem::OperatorHandle _block_a;
+  mfem::BlockVector _true_x, _true_rhs;
 };
 
 } // namespace hephaestus

--- a/src/io/inputs.hpp
+++ b/src/io/inputs.hpp
@@ -16,19 +16,19 @@ class InputParameters
 {
 
 protected:
-  std::map<std::string, std::any> params;
+  std::map<std::string, std::any> _params;
 
 public:
   InputParameters() = default;
-  InputParameters(std::map<std::string, std::any> _params) : params(std::move(_params)){};
-  void SetParam(std::string param_name, std::any value) { params[param_name] = value; };
+  InputParameters(std::map<std::string, std::any> _params) : _params(std::move(_params)){};
+  void SetParam(std::string param_name, std::any value) { _params[param_name] = value; };
   template <typename T>
   [[nodiscard]] [[nodiscard]] T GetParam(std::string param_name) const
   {
     T param;
     try
     {
-      param = std::any_cast<T>(params.at(param_name));
+      param = std::any_cast<T>(_params.at(param_name));
     }
     catch (const std::exception & e)
     {
@@ -43,7 +43,7 @@ public:
     T param;
     try
     {
-      param = std::any_cast<T>(params.at(param_name));
+      param = std::any_cast<T>(_params.at(param_name));
     }
     catch (...)
     {

--- a/src/io/outputs.cpp
+++ b/src/io/outputs.cpp
@@ -17,7 +17,7 @@ Outputs::Outputs(hephaestus::GridFunctions & gridfunctions) : _gridfunctions(&gr
 
 Outputs::~Outputs()
 {
-  for (const auto & [name, socket_stream] : socks_)
+  for (const auto & [name, socket_stream] : _socks)
   {
     delete socket_stream;
   }

--- a/src/io/outputs.hpp
+++ b/src/io/outputs.hpp
@@ -72,7 +72,7 @@ public:
   }
 
 private:
-  std::map<std::string, mfem::socketstream *> socks_;
+  std::map<std::string, mfem::socketstream *> _socks;
   hephaestus::GridFunctions * _gridfunctions;
   std::vector<std::string> _output_field_names{};
   int _cycle{0};
@@ -152,8 +152,8 @@ private:
 
     for (auto & gridfunction : *_gridfunctions)
     {
-      socks_[gridfunction.first] = new mfem::socketstream;
-      socks_[gridfunction.first]->precision(8);
+      _socks[gridfunction.first] = new mfem::socketstream;
+      _socks[gridfunction.first]->precision(8);
     }
 
     if (_my_rank == 0)
@@ -174,7 +174,7 @@ private:
 
     for (auto & gridfunction : *_gridfunctions)
     {
-      mfem::common::VisualizeField(*socks_[gridfunction.first],
+      mfem::common::VisualizeField(*_socks[gridfunction.first],
                                    vishost,
                                    visport,
                                    *(gridfunction.second),

--- a/src/io/outputs.hpp
+++ b/src/io/outputs.hpp
@@ -97,22 +97,22 @@ private:
   {
     for (auto & output : *this)
     {
-      auto const & dc_(output.second);
-      mfem::ParMesh * pmesh_(_gridfunctions->begin()->second->ParFESpace()->GetParMesh());
-      dc_->SetMesh(pmesh_);
+      auto const & dc(output.second);
+      mfem::ParMesh * pmesh(_gridfunctions->begin()->second->ParFESpace()->GetParMesh());
+      dc->SetMesh(pmesh);
 
       if (_output_field_names.empty())
       {
-        for (auto & _gridfunction : *_gridfunctions)
+        for (auto & gridfunction : *_gridfunctions)
         {
-          dc_->RegisterField(_gridfunction.first, _gridfunction.second);
+          dc->RegisterField(gridfunction.first, gridfunction.second);
         }
       }
       else
       {
         for (auto field_name : _output_field_names)
         {
-          dc_->RegisterField(field_name, _gridfunctions->Get(field_name));
+          dc->RegisterField(field_name, _gridfunctions->Get(field_name));
         }
       }
     }
@@ -124,10 +124,10 @@ private:
     // Write fields to disk
     for (auto & output : *this)
     {
-      auto const & dc_(output.second);
-      dc_->SetCycle(_cycle);
-      dc_->SetTime(t);
-      dc_->Save();
+      auto const & dc(output.second);
+      dc->SetCycle(_cycle);
+      dc->SetTime(t);
+      dc->Save();
     }
   }
 
@@ -150,10 +150,10 @@ private:
       std::cout << "Opening GLVis sockets." << std::endl;
     }
 
-    for (auto & _gridfunction : *_gridfunctions)
+    for (auto & gridfunction : *_gridfunctions)
     {
-      socks_[_gridfunction.first] = new mfem::socketstream;
-      socks_[_gridfunction.first]->precision(8);
+      socks_[gridfunction.first] = new mfem::socketstream;
+      socks_[gridfunction.first]->precision(8);
     }
 
     if (_my_rank == 0)
@@ -168,22 +168,22 @@ private:
     char vishost[] = "localhost";
     int visport = 19916;
 
-    int Wx = 0, Wy = 0;                 // window position
-    int Ww = 350, Wh = 350;             // window size
-    int offx = Ww + 10, offy = Wh + 45; // window offsets
+    int wx = 0, wy = 0;                 // window position
+    int ww = 350, wh = 350;             // window size
+    int offx = ww + 10, offy = wh + 45; // window offsets
 
-    for (auto & _gridfunction : *_gridfunctions)
+    for (auto & gridfunction : *_gridfunctions)
     {
-      mfem::common::VisualizeField(*socks_[_gridfunction.first],
+      mfem::common::VisualizeField(*socks_[gridfunction.first],
                                    vishost,
                                    visport,
-                                   *(_gridfunction.second),
-                                   (_gridfunction.first).c_str(),
-                                   Wx,
-                                   Wy,
-                                   Ww,
-                                   Wh);
-      Wx += offx;
+                                   *(gridfunction.second),
+                                   (gridfunction.first).c_str(),
+                                   wx,
+                                   wy,
+                                   ww,
+                                   wh);
+      wx += offx;
     }
   }
 };

--- a/src/kernels/curl_curl_kernel.cpp
+++ b/src/kernels/curl_curl_kernel.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 CurlCurlKernel::CurlCurlKernel(const hephaestus::InputParameters & params)
-  : Kernel(params), coef_name(params.GetParam<std::string>("CoefficientName"))
+  : Kernel(params), _coef_name(params.GetParam<std::string>("CoefficientName"))
 {
 }
 
@@ -15,13 +15,13 @@ CurlCurlKernel::Init(hephaestus::GridFunctions & gridfunctions,
                      hephaestus::Coefficients & coefficients)
 {
 
-  coef = coefficients.scalars.Get(coef_name);
+  _coef = coefficients._scalars.Get(_coef_name);
 }
 
 void
 CurlCurlKernel::Apply(mfem::ParBilinearForm * blf)
 {
-  blf->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*coef));
+  blf->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*_coef));
 }
 
 } // namespace hephaestus

--- a/src/kernels/curl_curl_kernel.hpp
+++ b/src/kernels/curl_curl_kernel.hpp
@@ -19,8 +19,8 @@ public:
             hephaestus::BCMap & bc_map,
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParBilinearForm * blf) override;
-  std::string coef_name;
-  mfem::Coefficient * coef;
+  std::string _coef_name;
+  mfem::Coefficient * _coef;
 };
 
 }; // namespace hephaestus

--- a/src/kernels/diffusion_kernel.cpp
+++ b/src/kernels/diffusion_kernel.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 DiffusionKernel::DiffusionKernel(const hephaestus::InputParameters & params)
-  : Kernel(params), coef_name(params.GetParam<std::string>("CoefficientName"))
+  : Kernel(params), _coef_name(params.GetParam<std::string>("CoefficientName"))
 {
 }
 
@@ -15,13 +15,13 @@ DiffusionKernel::Init(hephaestus::GridFunctions & gridfunctions,
                       hephaestus::Coefficients & coefficients)
 {
 
-  coef = coefficients.scalars.Get(coef_name);
+  _coef = coefficients._scalars.Get(_coef_name);
 }
 
 void
 DiffusionKernel::Apply(mfem::ParBilinearForm * blf)
 {
-  blf->AddDomainIntegrator(new mfem::DiffusionIntegrator(*coef));
+  blf->AddDomainIntegrator(new mfem::DiffusionIntegrator(*_coef));
 }
 
 } // namespace hephaestus

--- a/src/kernels/diffusion_kernel.hpp
+++ b/src/kernels/diffusion_kernel.hpp
@@ -20,8 +20,8 @@ public:
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParBilinearForm * blf) override;
 
-  std::string coef_name;
-  mfem::Coefficient * coef{nullptr};
+  std::string _coef_name;
+  mfem::Coefficient * _coef{nullptr};
 };
 
 }; // namespace hephaestus

--- a/src/kernels/mixed_vector_gradient_kernel.cpp
+++ b/src/kernels/mixed_vector_gradient_kernel.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 MixedVectorGradientKernel::MixedVectorGradientKernel(const hephaestus::InputParameters & params)
-  : Kernel(params), coef_name(params.GetParam<std::string>("CoefficientName"))
+  : Kernel(params), _coef_name(params.GetParam<std::string>("CoefficientName"))
 {
 }
 
@@ -15,13 +15,13 @@ MixedVectorGradientKernel::Init(hephaestus::GridFunctions & gridfunctions,
                                 hephaestus::Coefficients & coefficients)
 {
 
-  coef = coefficients.scalars.Get(coef_name);
+  _coef = coefficients._scalars.Get(_coef_name);
 }
 
 void
 MixedVectorGradientKernel::Apply(mfem::ParMixedBilinearForm * mblf)
 {
-  mblf->AddDomainIntegrator(new mfem::MixedVectorGradientIntegrator(*coef));
+  mblf->AddDomainIntegrator(new mfem::MixedVectorGradientIntegrator(*_coef));
 }
 
 } // namespace hephaestus

--- a/src/kernels/mixed_vector_gradient_kernel.hpp
+++ b/src/kernels/mixed_vector_gradient_kernel.hpp
@@ -19,8 +19,8 @@ public:
             hephaestus::BCMap & bc_map,
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParMixedBilinearForm * mblf) override;
-  std::string coef_name;
-  mfem::Coefficient * coef;
+  std::string _coef_name;
+  mfem::Coefficient * _coef;
 };
 
 }; // namespace hephaestus

--- a/src/kernels/vector_fe_mass_kernel.cpp
+++ b/src/kernels/vector_fe_mass_kernel.cpp
@@ -4,7 +4,7 @@ namespace hephaestus
 {
 
 VectorFEMassKernel::VectorFEMassKernel(const hephaestus::InputParameters & params)
-  : Kernel(params), coef_name(params.GetParam<std::string>("CoefficientName"))
+  : Kernel(params), _coef_name(params.GetParam<std::string>("CoefficientName"))
 {
 }
 
@@ -15,13 +15,13 @@ VectorFEMassKernel::Init(hephaestus::GridFunctions & gridfunctions,
                          hephaestus::Coefficients & coefficients)
 {
 
-  coef = coefficients.scalars.Get(coef_name);
+  _coef = coefficients._scalars.Get(_coef_name);
 }
 
 void
 VectorFEMassKernel::Apply(mfem::ParBilinearForm * blf)
 {
-  blf->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*coef));
+  blf->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*_coef));
 };
 
 } // namespace hephaestus

--- a/src/kernels/vector_fe_mass_kernel.hpp
+++ b/src/kernels/vector_fe_mass_kernel.hpp
@@ -19,8 +19,8 @@ public:
             hephaestus::BCMap & bc_map,
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParBilinearForm * blf) override;
-  std::string coef_name;
-  mfem::Coefficient * coef;
+  std::string _coef_name;
+  mfem::Coefficient * _coef;
 };
 
 }; // namespace hephaestus

--- a/src/kernels/vector_fe_weak_divergence_kernel.cpp
+++ b/src/kernels/vector_fe_weak_divergence_kernel.cpp
@@ -5,7 +5,7 @@ namespace hephaestus
 
 VectorFEWeakDivergenceKernel::VectorFEWeakDivergenceKernel(
     const hephaestus::InputParameters & params)
-  : Kernel(params), coef_name(params.GetParam<std::string>("CoefficientName"))
+  : Kernel(params), _coef_name(params.GetParam<std::string>("CoefficientName"))
 {
 }
 
@@ -16,13 +16,13 @@ VectorFEWeakDivergenceKernel::Init(hephaestus::GridFunctions & gridfunctions,
                                    hephaestus::Coefficients & coefficients)
 {
 
-  coef = coefficients.scalars.Get(coef_name);
+  _coef = coefficients._scalars.Get(_coef_name);
 }
 
 void
 VectorFEWeakDivergenceKernel::Apply(mfem::ParMixedBilinearForm * mblf)
 {
-  mblf->AddDomainIntegrator(new mfem::VectorFEWeakDivergenceIntegrator(*coef));
+  mblf->AddDomainIntegrator(new mfem::VectorFEWeakDivergenceIntegrator(*_coef));
 };
 
 } // namespace hephaestus

--- a/src/kernels/vector_fe_weak_divergence_kernel.hpp
+++ b/src/kernels/vector_fe_weak_divergence_kernel.hpp
@@ -19,8 +19,8 @@ public:
             hephaestus::BCMap & bc_map,
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParMixedBilinearForm * mblf) override;
-  std::string coef_name;
-  mfem::Coefficient * coef;
+  std::string _coef_name;
+  mfem::Coefficient * _coef;
 };
 
 }; // namespace hephaestus

--- a/src/kernels/weak_curl_curl_kernel.cpp
+++ b/src/kernels/weak_curl_curl_kernel.cpp
@@ -5,8 +5,8 @@ namespace hephaestus
 
 WeakCurlCurlKernel::WeakCurlCurlKernel(const hephaestus::InputParameters & params)
   : Kernel(params),
-    coupled_gf_name(params.GetParam<std::string>("CoupledVariableName")),
-    coef_name(params.GetParam<std::string>("CoefficientName"))
+    _coupled_gf_name(params.GetParam<std::string>("CoupledVariableName")),
+    _coef_name(params.GetParam<std::string>("CoefficientName"))
 {
 }
 
@@ -17,18 +17,18 @@ WeakCurlCurlKernel::Init(hephaestus::GridFunctions & gridfunctions,
                          hephaestus::Coefficients & coefficients)
 {
 
-  u_ = gridfunctions.Get(coupled_gf_name);
-  coef = coefficients.scalars.Get(coef_name);
+  _u = gridfunctions.Get(_coupled_gf_name);
+  _coef = coefficients._scalars.Get(_coef_name);
 
-  curlCurl = std::make_unique<mfem::ParBilinearForm>(u_->ParFESpace());
-  curlCurl->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*coef));
-  curlCurl->Assemble();
+  _curl_curl = std::make_unique<mfem::ParBilinearForm>(_u->ParFESpace());
+  _curl_curl->AddDomainIntegrator(new mfem::CurlCurlIntegrator(*_coef));
+  _curl_curl->Assemble();
 }
 
 void
 WeakCurlCurlKernel::Apply(mfem::ParLinearForm * lf)
 {
-  curlCurl->AddMultTranspose(*u_, *lf, -1.0);
+  _curl_curl->AddMultTranspose(*_u, *lf, -1.0);
 }
 
 } // namespace hephaestus

--- a/src/kernels/weak_curl_curl_kernel.hpp
+++ b/src/kernels/weak_curl_curl_kernel.hpp
@@ -20,13 +20,13 @@ public:
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParLinearForm * lf) override;
 
-  std::string coupled_gf_name;
-  std::string coef_name;
-  mfem::ParGridFunction * u_; //
-  mfem::ParFiniteElementSpace * H1FESpace_;
-  mfem::Coefficient * coef;
+  std::string _coupled_gf_name;
+  std::string _coef_name;
+  mfem::ParGridFunction * _u; //
+  mfem::ParFiniteElementSpace * _h1_fe_space;
+  mfem::Coefficient * _coef;
 
-  std::unique_ptr<mfem::ParBilinearForm> curlCurl;
+  std::unique_ptr<mfem::ParBilinearForm> _curl_curl;
 };
 
 }; // namespace hephaestus

--- a/src/kernels/weak_curl_kernel.cpp
+++ b/src/kernels/weak_curl_kernel.cpp
@@ -5,9 +5,9 @@ namespace hephaestus
 
 WeakCurlKernel::WeakCurlKernel(const hephaestus::InputParameters & params)
   : Kernel(params),
-    hcurl_gf_name(params.GetParam<std::string>("HCurlVarName")),
-    hdiv_gf_name(params.GetParam<std::string>("HDivVarName")),
-    coef_name(params.GetParam<std::string>("CoefficientName"))
+    _hcurl_gf_name(params.GetParam<std::string>("HCurlVarName")),
+    _hdiv_gf_name(params.GetParam<std::string>("HDivVarName")),
+    _coef_name(params.GetParam<std::string>("CoefficientName"))
 {
 }
 
@@ -18,21 +18,21 @@ WeakCurlKernel::Init(hephaestus::GridFunctions & gridfunctions,
                      hephaestus::Coefficients & coefficients)
 {
 
-  u_ = gridfunctions.Get(hcurl_gf_name);
-  v_ = gridfunctions.Get(hdiv_gf_name);
+  _u = gridfunctions.Get(_hcurl_gf_name);
+  _v = gridfunctions.Get(_hdiv_gf_name);
 
-  coef = coefficients.scalars.Get(coef_name);
+  _coef = coefficients._scalars.Get(_coef_name);
 
-  weakCurl = std::make_unique<mfem::ParMixedBilinearForm>(u_->ParFESpace(), v_->ParFESpace());
-  weakCurl->AddDomainIntegrator(new mfem::VectorFECurlIntegrator(*coef));
+  _weak_curl = std::make_unique<mfem::ParMixedBilinearForm>(_u->ParFESpace(), _v->ParFESpace());
+  _weak_curl->AddDomainIntegrator(new mfem::VectorFECurlIntegrator(*_coef));
 }
 
 void
 WeakCurlKernel::Apply(mfem::ParLinearForm * lf)
 {
-  weakCurl->Update();
-  weakCurl->Assemble();
-  weakCurl->AddMultTranspose(*v_, *lf);
+  _weak_curl->Update();
+  _weak_curl->Assemble();
+  _weak_curl->AddMultTranspose(*_v, *lf);
 }
 
 } // namespace hephaestus

--- a/src/kernels/weak_curl_kernel.hpp
+++ b/src/kernels/weak_curl_kernel.hpp
@@ -20,12 +20,12 @@ public:
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParLinearForm * lf) override;
 
-  std::string hcurl_gf_name, hdiv_gf_name;
-  std::string coef_name;
-  mfem::ParGridFunction *u_, *v_; //
-  mfem::Coefficient * coef;
+  std::string _hcurl_gf_name, _hdiv_gf_name;
+  std::string _coef_name;
+  mfem::ParGridFunction *_u, *_v; //
+  mfem::Coefficient * _coef;
 
-  std::unique_ptr<mfem::ParMixedBilinearForm> weakCurl;
+  std::unique_ptr<mfem::ParMixedBilinearForm> _weak_curl;
 };
 
 }; // namespace hephaestus

--- a/src/named_fields_map/named_fields_map.hpp
+++ b/src/named_fields_map/named_fields_map.hpp
@@ -97,21 +97,27 @@ public:
   [[nodiscard]] inline const MapType & GetMap() const { return _field_map; }
 
   /// Returns a begin iterator to the registered fields.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   inline iterator begin() { return _field_map.begin(); }
 
   /// Returns a begin const iterator to the registered fields.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   [[nodiscard]] inline const_iterator begin() const { return _field_map.begin(); }
 
   /// Returns an end iterator to the registered fields.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   inline iterator end() { return _field_map.end(); }
 
   /// Returns an end const iterator to the registered fields.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   [[nodiscard]] inline const_iterator end() const { return _field_map.end(); }
 
   /// Returns an iterator to the field @a field_name.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   inline iterator find(const std::string & field_name) { return _field_map.find(field_name); }
 
   /// Returns a const iterator to the field @a field_name.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   [[nodiscard]] inline const_iterator find(const std::string & field_name) const
   {
     return _field_map.find(field_name);

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -6,110 +6,110 @@ namespace hephaestus
 Problem::~Problem()
 {
   // Ensure that all owned memory is properly freed!
-  F.reset();
-  ode_solver.reset();
+  _f.reset();
+  _ode_solver.reset();
 }
 
 void
 ProblemBuilder::SetMesh(std::shared_ptr<mfem::ParMesh> pmesh)
 {
-  GetProblem()->pmesh = pmesh;
-  MPI_Comm_rank(pmesh->GetComm(), &(GetProblem()->myid_));
+  GetProblem()->_pmesh = pmesh;
+  MPI_Comm_rank(pmesh->GetComm(), &(GetProblem()->_myid));
 }
 
 void
 ProblemBuilder::SetFESpaces(hephaestus::FESpaces & fespaces)
 {
-  GetProblem()->fespaces = fespaces;
+  GetProblem()->_fespaces = fespaces;
 }
 
 void
 ProblemBuilder::SetGridFunctions(hephaestus::GridFunctions & gridfunctions)
 {
-  GetProblem()->gridfunctions = gridfunctions;
+  GetProblem()->_gridfunctions = gridfunctions;
 }
 
 void
 ProblemBuilder::SetBoundaryConditions(hephaestus::BCMap & bc_map)
 {
-  GetProblem()->bc_map = bc_map;
+  GetProblem()->_bc_map = bc_map;
 }
 
 void
 ProblemBuilder::SetAuxSolvers(hephaestus::AuxSolvers & preprocessors)
 {
-  GetProblem()->preprocessors = preprocessors;
+  GetProblem()->_preprocessors = preprocessors;
 }
 
 void
 ProblemBuilder::SetPostprocessors(hephaestus::AuxSolvers & postprocessors)
 {
-  GetProblem()->postprocessors = postprocessors;
+  GetProblem()->_postprocessors = postprocessors;
 }
 
 void
 ProblemBuilder::SetSources(hephaestus::Sources & sources)
 {
-  GetProblem()->sources = sources;
+  GetProblem()->_sources = sources;
 }
 
 void
 ProblemBuilder::SetOutputs(hephaestus::Outputs & outputs)
 {
-  GetProblem()->outputs = outputs;
+  GetProblem()->_outputs = outputs;
 }
 
 void
 ProblemBuilder::SetSolverOptions(hephaestus::InputParameters & solver_options)
 {
-  GetProblem()->solver_options = solver_options;
+  GetProblem()->_solver_options = solver_options;
 }
 
 void
 ProblemBuilder::SetCoefficients(hephaestus::Coefficients & coefficients)
 {
-  GetProblem()->coefficients = coefficients;
+  GetProblem()->_coefficients = coefficients;
 }
 
 void
 ProblemBuilder::AddFESpace(std::string fespace_name, std::string fec_name, int vdim, int ordering)
 {
-  if (GetProblem()->fespaces.Has(fespace_name))
+  if (GetProblem()->_fespaces.Has(fespace_name))
   {
     const std::string error_message = "A fespace with the name " + fespace_name +
                                       " has already been added to the problem fespaces.";
     mfem::mfem_error(error_message.c_str());
   }
-  if (!GetProblem()->fecs.Has(fec_name))
+  if (!GetProblem()->_fecs.Has(fec_name))
   {
     mfem::FiniteElementCollection * fec = mfem::FiniteElementCollection::New(fec_name.c_str());
-    GetProblem()->fecs.Register(fec_name, fec, true);
+    GetProblem()->_fecs.Register(fec_name, fec, true);
   }
 
-  if (!GetProblem()->fespaces.Has(fespace_name))
+  if (!GetProblem()->_fespaces.Has(fespace_name))
   {
-    mfem::ParMesh * pmesh = GetProblem()->pmesh.get();
+    mfem::ParMesh * pmesh = GetProblem()->_pmesh.get();
     if (pmesh == nullptr)
     {
       MFEM_ABORT("ParMesh not found when trying to add " << fespace_name << " to fespaces.");
     }
     auto * pfes = new mfem::ParFiniteElementSpace(
-        GetProblem()->pmesh.get(), GetProblem()->fecs.Get(fec_name), vdim, ordering);
+        GetProblem()->_pmesh.get(), GetProblem()->_fecs.Get(fec_name), vdim, ordering);
 
-    GetProblem()->fespaces.Register(fespace_name, pfes, true);
+    GetProblem()->_fespaces.Register(fespace_name, pfes, true);
   }
 }
 
 void
 ProblemBuilder::AddGridFunction(std::string gridfunction_name, std::string fespace_name)
 {
-  if (GetProblem()->gridfunctions.Has(gridfunction_name))
+  if (GetProblem()->_gridfunctions.Has(gridfunction_name))
   {
     const std::string error_message = "A gridfunction with the name " + gridfunction_name +
                                       " has already been added to the problem gridfunctions.";
     mfem::mfem_error(error_message.c_str());
   }
-  mfem::ParFiniteElementSpace * fespace(GetProblem()->fespaces.Get(fespace_name));
+  mfem::ParFiniteElementSpace * fespace(GetProblem()->_fespaces.Get(fespace_name));
   if (fespace == nullptr)
   {
     MFEM_ABORT("FESpace " << fespace_name << " not found in fespaces when trying to add "
@@ -120,7 +120,7 @@ ProblemBuilder::AddGridFunction(std::string gridfunction_name, std::string fespa
   auto * gridfunc = new mfem::ParGridFunction(fespace);
   *gridfunc = 0.0;
 
-  GetProblem()->gridfunctions.Register(gridfunction_name, gridfunc, true);
+  GetProblem()->_gridfunctions.Register(gridfunction_name, gridfunc, true);
 }
 
 void
@@ -128,25 +128,25 @@ ProblemBuilder::AddBoundaryCondition(std::string bc_name,
                                      hephaestus::BoundaryCondition * bc,
                                      bool own_data)
 {
-  if (GetProblem()->bc_map.Has(bc_name))
+  if (GetProblem()->_bc_map.Has(bc_name))
   {
     const std::string error_message = "A boundary condition with the name " + bc_name +
                                       " has already been added to the problem boundary conditions.";
     mfem::mfem_error(error_message.c_str());
   }
-  GetProblem()->bc_map.Register(bc_name, bc, own_data);
+  GetProblem()->_bc_map.Register(bc_name, bc, own_data);
 }
 
 void
 ProblemBuilder::AddAuxSolver(std::string auxsolver_name, hephaestus::AuxSolver * aux, bool own_data)
 {
-  if (GetProblem()->preprocessors.Has(auxsolver_name))
+  if (GetProblem()->_preprocessors.Has(auxsolver_name))
   {
     const std::string error_message = "An auxsolver with the name " + auxsolver_name +
                                       " has already been added to the problem preprocessors.";
     mfem::mfem_error(error_message.c_str());
   }
-  GetProblem()->preprocessors.Register(auxsolver_name, aux, own_data);
+  GetProblem()->_preprocessors.Register(auxsolver_name, aux, own_data);
 }
 
 void
@@ -154,38 +154,38 @@ ProblemBuilder::AddPostprocessor(std::string auxsolver_name,
                                  hephaestus::AuxSolver * aux,
                                  bool own_data)
 {
-  if (GetProblem()->postprocessors.Has(auxsolver_name))
+  if (GetProblem()->_postprocessors.Has(auxsolver_name))
   {
     const std::string error_message = "An auxsolver with the name " + auxsolver_name +
                                       " has already been added to the problem postprocessors.";
     mfem::mfem_error(error_message.c_str());
   }
-  GetProblem()->postprocessors.Register(auxsolver_name, aux, own_data);
+  GetProblem()->_postprocessors.Register(auxsolver_name, aux, own_data);
 }
 
 void
 ProblemBuilder::AddSource(std::string source_name, hephaestus::Source * source, bool own_data)
 {
-  if (GetProblem()->sources.Has(source_name))
+  if (GetProblem()->_sources.Has(source_name))
   {
     const std::string error_message =
         "A source with the name " + source_name + " has already been added to the problem sources.";
     mfem::mfem_error(error_message.c_str());
   }
-  GetProblem()->sources.Register(source_name, source, own_data);
+  GetProblem()->_sources.Register(source_name, source, own_data);
 }
 
 void
 ProblemBuilder::InitializeAuxSolvers()
 {
-  GetProblem()->preprocessors.Init(GetProblem()->gridfunctions, GetProblem()->coefficients);
-  GetProblem()->postprocessors.Init(GetProblem()->gridfunctions, GetProblem()->coefficients);
+  GetProblem()->_preprocessors.Init(GetProblem()->_gridfunctions, GetProblem()->_coefficients);
+  GetProblem()->_postprocessors.Init(GetProblem()->_gridfunctions, GetProblem()->_coefficients);
 }
 
 void
 ProblemBuilder::InitializeOutputs()
 {
-  GetProblem()->outputs.Init(GetProblem()->gridfunctions);
+  GetProblem()->_outputs.Init(GetProblem()->_gridfunctions);
 }
 
 } // namespace hephaestus

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -71,15 +71,15 @@ public:
   template <class T>
   void AddKernel(std::string var_name, std::unique_ptr<hephaestus::Kernel<T>> && kernel)
   {
-    GetProblem()->GetEquationSystem()->addVariableNameIfMissing(var_name);
-    GetProblem()->GetEquationSystem()->addKernel(var_name, kernel);
+    GetProblem()->GetEquationSystem()->AddVariableNameIfMissing(var_name);
+    GetProblem()->GetEquationSystem()->AddKernel(var_name, kernel);
   }
 
   template <class T>
   void AddKernel(std::string var_name, hephaestus::Kernel<T> * kernel)
   {
-    GetProblem()->GetEquationSystem()->addVariableNameIfMissing(var_name);
-    GetProblem()->GetEquationSystem()->addKernel(var_name, std::unique_ptr<Kernel<T>>(kernel));
+    GetProblem()->GetEquationSystem()->AddVariableNameIfMissing(var_name);
+    GetProblem()->GetEquationSystem()->AddKernel(var_name, std::unique_ptr<Kernel<T>>(kernel));
   }
 
   void AddBoundaryCondition(std::string bc_name, hephaestus::BoundaryCondition * bc, bool own_data);

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -17,24 +17,24 @@ public:
   Problem() = default;
   virtual ~Problem();
 
-  std::shared_ptr<mfem::ParMesh> pmesh{nullptr};
-  hephaestus::BCMap bc_map;
-  hephaestus::Coefficients coefficients;
-  hephaestus::AuxSolvers preprocessors;
-  hephaestus::AuxSolvers postprocessors;
-  hephaestus::Sources sources;
-  hephaestus::Outputs outputs;
-  hephaestus::InputParameters solver_options;
+  std::shared_ptr<mfem::ParMesh> _pmesh{nullptr};
+  hephaestus::BCMap _bc_map;
+  hephaestus::Coefficients _coefficients;
+  hephaestus::AuxSolvers _preprocessors;
+  hephaestus::AuxSolvers _postprocessors;
+  hephaestus::Sources _sources;
+  hephaestus::Outputs _outputs;
+  hephaestus::InputParameters _solver_options;
 
-  std::unique_ptr<mfem::ODESolver> ode_solver{nullptr};
-  std::unique_ptr<mfem::BlockVector> F{nullptr};
+  std::unique_ptr<mfem::ODESolver> _ode_solver{nullptr};
+  std::unique_ptr<mfem::BlockVector> _f{nullptr};
 
-  hephaestus::FECollections fecs;
-  hephaestus::FESpaces fespaces;
-  hephaestus::GridFunctions gridfunctions;
+  hephaestus::FECollections _fecs;
+  hephaestus::FESpaces _fespaces;
+  hephaestus::GridFunctions _gridfunctions;
 
-  int myid_;
-  int num_procs_;
+  int _myid;
+  int _num_procs;
 
   virtual hephaestus::EquationSystem * GetEquationSystem() = 0;
   virtual mfem::Operator * GetOperator() = 0;

--- a/src/problem_builders/steady_state_problem_builder.cpp
+++ b/src/problem_builders/steady_state_problem_builder.cpp
@@ -6,30 +6,30 @@ namespace hephaestus
 void
 SteadyStateProblemBuilder::InitializeKernels()
 {
-  problem->preprocessors.Init(problem->gridfunctions, problem->coefficients);
-  problem->sources.Init(
-      problem->gridfunctions, problem->fespaces, problem->bc_map, problem->coefficients);
+  _problem->_preprocessors.Init(_problem->_gridfunctions, _problem->_coefficients);
+  _problem->_sources.Init(
+      _problem->_gridfunctions, _problem->_fespaces, _problem->_bc_map, _problem->_coefficients);
 }
 
 void
 SteadyStateProblemBuilder::ConstructOperator()
 {
-  problem->eq_sys_operator =
-      std::make_unique<hephaestus::EquationSystemOperator>(*(problem->pmesh),
-                                                           problem->fespaces,
-                                                           problem->gridfunctions,
-                                                           problem->bc_map,
-                                                           problem->coefficients,
-                                                           problem->sources,
-                                                           problem->solver_options);
-  problem->eq_sys_operator->SetGridFunctions();
+  _problem->_eq_sys_operator =
+      std::make_unique<hephaestus::EquationSystemOperator>(*(_problem->_pmesh),
+                                                           _problem->_fespaces,
+                                                           _problem->_gridfunctions,
+                                                           _problem->_bc_map,
+                                                           _problem->_coefficients,
+                                                           _problem->_sources,
+                                                           _problem->_solver_options);
+  _problem->_eq_sys_operator->SetGridFunctions();
 }
 
 void
 SteadyStateProblemBuilder::ConstructState()
 {
-  problem->F =
-      std::make_unique<mfem::BlockVector>(problem->eq_sys_operator->true_offsets); // Vector of dofs
-  problem->eq_sys_operator->Init(*(problem->F)); // Set up initial conditions
+  _problem->_f = std::make_unique<mfem::BlockVector>(
+      _problem->_eq_sys_operator->_true_offsets);    // Vector of dofs
+  _problem->_eq_sys_operator->Init(*(_problem->_f)); // Set up initial conditions
 }
 } // namespace hephaestus

--- a/src/problem_builders/steady_state_problem_builder.hpp
+++ b/src/problem_builders/steady_state_problem_builder.hpp
@@ -7,27 +7,27 @@ namespace hephaestus
 class SteadyStateProblem : public hephaestus::Problem
 {
 public:
-  std::unique_ptr<hephaestus::EquationSystem> eq_sys{nullptr};
-  std::unique_ptr<hephaestus::EquationSystemOperator> eq_sys_operator{nullptr};
+  std::unique_ptr<hephaestus::EquationSystem> _eq_sys{nullptr};
+  std::unique_ptr<hephaestus::EquationSystemOperator> _eq_sys_operator{nullptr};
 
   SteadyStateProblem() = default;
   ~SteadyStateProblem() override = default;
 
-  hephaestus::EquationSystem * GetEquationSystem() override { return eq_sys.get(); };
-  hephaestus::EquationSystemOperator * GetOperator() override { return eq_sys_operator.get(); };
+  hephaestus::EquationSystem * GetEquationSystem() override { return _eq_sys.get(); };
+  hephaestus::EquationSystemOperator * GetOperator() override { return _eq_sys_operator.get(); };
 };
 
 // Builder class of a frequency-domain problem.
 class SteadyStateProblemBuilder : public hephaestus::ProblemBuilder
 {
 public:
-  SteadyStateProblemBuilder() : problem(std::make_unique<hephaestus::SteadyStateProblem>()){};
+  SteadyStateProblemBuilder() : _problem(std::make_unique<hephaestus::SteadyStateProblem>()){};
 
   ~SteadyStateProblemBuilder() override = default;
 
   virtual std::unique_ptr<hephaestus::SteadyStateProblem> ReturnProblem()
   {
-    return std::move(problem);
+    return std::move(_problem);
   };
 
   void RegisterFESpaces() override{};
@@ -49,10 +49,10 @@ public:
   void ConstructSolver() override{};
 
 protected:
-  std::unique_ptr<hephaestus::SteadyStateProblem> problem{nullptr};
-  mfem::ConstantCoefficient oneCoef{1.0};
+  std::unique_ptr<hephaestus::SteadyStateProblem> _problem{nullptr};
+  mfem::ConstantCoefficient _one_coef{1.0};
 
-  hephaestus::SteadyStateProblem * GetProblem() override { return problem.get(); };
+  hephaestus::SteadyStateProblem * GetProblem() override { return _problem.get(); };
 };
 
 } // namespace hephaestus

--- a/src/problem_builders/time_domain_problem_builder.hpp
+++ b/src/problem_builders/time_domain_problem_builder.hpp
@@ -9,19 +9,19 @@ namespace hephaestus
 class TimeDomainProblem : public hephaestus::Problem
 {
 public:
-  std::unique_ptr<hephaestus::TimeDependentEquationSystem> td_equation_system;
-  std::unique_ptr<hephaestus::TimeDomainEquationSystemOperator> td_operator;
+  std::unique_ptr<hephaestus::TimeDependentEquationSystem> _td_equation_system;
+  std::unique_ptr<hephaestus::TimeDomainEquationSystemOperator> _td_operator;
 
   TimeDomainProblem() = default;
   ~TimeDomainProblem() override;
 
   hephaestus::TimeDependentEquationSystem * GetEquationSystem() override
   {
-    return td_equation_system.get();
+    return _td_equation_system.get();
   };
   hephaestus::TimeDomainEquationSystemOperator * GetOperator() override
   {
-    return td_operator.get();
+    return _td_operator.get();
   };
 };
 
@@ -29,13 +29,13 @@ public:
 class TimeDomainProblemBuilder : public hephaestus::ProblemBuilder
 {
 public:
-  TimeDomainProblemBuilder() : problem(std::make_unique<hephaestus::TimeDomainProblem>()){};
+  TimeDomainProblemBuilder() : _problem(std::make_unique<hephaestus::TimeDomainProblem>()){};
 
   ~TimeDomainProblemBuilder() override = default;
 
   virtual std::unique_ptr<hephaestus::TimeDomainProblem> ReturnProblem()
   {
-    return std::move(problem);
+    return std::move(_problem);
   };
 
   static std::vector<mfem::ParGridFunction *>
@@ -61,10 +61,10 @@ public:
   void ConstructSolver() override;
 
 protected:
-  std::unique_ptr<hephaestus::TimeDomainProblem> problem{nullptr};
-  mfem::ConstantCoefficient oneCoef{1.0};
+  std::unique_ptr<hephaestus::TimeDomainProblem> _problem{nullptr};
+  mfem::ConstantCoefficient _one_coef{1.0};
 
-  hephaestus::TimeDomainProblem * GetProblem() override { return problem.get(); };
+  hephaestus::TimeDomainProblem * GetProblem() override { return _problem.get(); };
 };
 
 } // namespace hephaestus

--- a/src/solvers/hephaestus_solvers.hpp
+++ b/src/solvers/hephaestus_solvers.hpp
@@ -10,25 +10,25 @@ class DefaultH1PCGSolver : public mfem::HyprePCG
 public:
   DefaultH1PCGSolver(const hephaestus::InputParameters & params, const mfem::HypreParMatrix & M)
     : mfem::HyprePCG(M),
-      amg(M),
-      tol(params.GetOptionalParam<float>("Tolerance", 1.0e-9)),
-      abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
-      max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
-      print_level(params.GetOptionalParam<int>("PrintLevel", 2))
+      _amg(M),
+      _tol(params.GetOptionalParam<float>("Tolerance", 1.0e-9)),
+      _abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
+      _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
+      _print_level(params.GetOptionalParam<int>("PrintLevel", 2))
   {
 
-    amg.SetPrintLevel(print_level);
-    SetTol(tol);
-    SetAbsTol(abstol);
-    SetMaxIter(max_iter);
-    SetPrintLevel(print_level);
-    SetPreconditioner(amg);
+    _amg.SetPrintLevel(_print_level);
+    SetTol(_tol);
+    SetAbsTol(_abstol);
+    SetMaxIter(_max_iter);
+    SetPrintLevel(_print_level);
+    SetPreconditioner(_amg);
   }
-  mfem::HypreBoomerAMG amg;
-  double tol;
-  double abstol;
-  int max_iter;
-  int print_level;
+  mfem::HypreBoomerAMG _amg;
+  double _tol;
+  double _abstol;
+  int _max_iter;
+  int _print_level;
 };
 
 class DefaultJacobiPCGSolver : public mfem::HyprePCG
@@ -36,24 +36,24 @@ class DefaultJacobiPCGSolver : public mfem::HyprePCG
 public:
   DefaultJacobiPCGSolver(const hephaestus::InputParameters & params, const mfem::HypreParMatrix & M)
     : mfem::HyprePCG(M),
-      jacobi(M),
-      tol(params.GetOptionalParam<float>("Tolerance", 1.0e-9)),
-      abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
-      max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
-      print_level(params.GetOptionalParam<int>("PrintLevel", 2))
+      _jacobi(M),
+      _tol(params.GetOptionalParam<float>("Tolerance", 1.0e-9)),
+      _abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
+      _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
+      _print_level(params.GetOptionalParam<int>("PrintLevel", 2))
   {
 
-    SetTol(tol);
-    SetAbsTol(abstol);
-    SetMaxIter(max_iter);
-    SetPrintLevel(print_level);
-    SetPreconditioner(jacobi);
+    SetTol(_tol);
+    SetAbsTol(_abstol);
+    SetMaxIter(_max_iter);
+    SetPrintLevel(_print_level);
+    SetPreconditioner(_jacobi);
   }
-  mfem::HypreDiagScale jacobi;
-  double tol;
-  double abstol;
-  int max_iter;
-  int print_level;
+  mfem::HypreDiagScale _jacobi;
+  double _tol;
+  double _abstol;
+  int _max_iter;
+  int _print_level;
 };
 
 class DefaultHCurlPCGSolver : public mfem::HyprePCG
@@ -63,26 +63,26 @@ public:
                         const mfem::HypreParMatrix & M,
                         mfem::ParFiniteElementSpace * edge_fespace)
     : mfem::HyprePCG(M),
-      ams(M, edge_fespace),
-      tol(params.GetOptionalParam<float>("Tolerance", 1.0e-16)),
-      abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
-      max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
-      print_level(params.GetOptionalParam<int>("PrintLevel", -1))
+      _ams(M, edge_fespace),
+      _tol(params.GetOptionalParam<float>("Tolerance", 1.0e-16)),
+      _abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
+      _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
+      _print_level(params.GetOptionalParam<int>("PrintLevel", -1))
   {
 
-    ams.SetSingularProblem();
-    ams.SetPrintLevel(print_level);
-    SetTol(tol);
-    SetAbsTol(abstol);
-    SetMaxIter(max_iter);
-    SetPrintLevel(print_level);
-    SetPreconditioner(ams);
+    _ams.SetSingularProblem();
+    _ams.SetPrintLevel(_print_level);
+    SetTol(_tol);
+    SetAbsTol(_abstol);
+    SetMaxIter(_max_iter);
+    SetPrintLevel(_print_level);
+    SetPreconditioner(_ams);
   }
-  mfem::HypreAMS ams;
-  double tol;
-  double abstol;
-  int max_iter;
-  int print_level;
+  mfem::HypreAMS _ams;
+  double _tol;
+  double _abstol;
+  int _max_iter;
+  int _print_level;
 };
 
 class DefaultHCurlFGMRESSolver : public mfem::HypreFGMRES
@@ -92,26 +92,26 @@ public:
                            const mfem::HypreParMatrix & M,
                            mfem::ParFiniteElementSpace * edge_fespace)
     : mfem::HypreFGMRES(M),
-      ams(M, edge_fespace),
-      tol(params.GetOptionalParam<float>("Tolerance", 1e-16)),
-      max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 100)),
-      k_dim(params.GetOptionalParam<unsigned int>("KDim", 10)),
-      print_level(params.GetOptionalParam<int>("PrintLevel", -1))
+      _ams(M, edge_fespace),
+      _tol(params.GetOptionalParam<float>("Tolerance", 1e-16)),
+      _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 100)),
+      _k_dim(params.GetOptionalParam<unsigned int>("KDim", 10)),
+      _print_level(params.GetOptionalParam<int>("PrintLevel", -1))
   {
 
-    ams.SetSingularProblem();
-    ams.SetPrintLevel(print_level);
-    SetTol(tol);
-    SetMaxIter(max_iter);
-    SetKDim(k_dim);
-    SetPrintLevel(print_level);
-    SetPreconditioner(ams);
+    _ams.SetSingularProblem();
+    _ams.SetPrintLevel(_print_level);
+    SetTol(_tol);
+    SetMaxIter(_max_iter);
+    SetKDim(_k_dim);
+    SetPrintLevel(_print_level);
+    SetPreconditioner(_ams);
   }
-  mfem::HypreAMS ams;
-  double tol;
-  int max_iter;
-  int k_dim;
-  int print_level;
+  mfem::HypreAMS _ams;
+  double _tol;
+  int _max_iter;
+  int _k_dim;
+  int _print_level;
 };
 
 class DefaultGMRESSolver : public mfem::HypreGMRES
@@ -119,25 +119,25 @@ class DefaultGMRESSolver : public mfem::HypreGMRES
 public:
   DefaultGMRESSolver(const hephaestus::InputParameters & params, const mfem::HypreParMatrix & M)
     : mfem::HypreGMRES(M),
-      amg(M),
-      tol(params.GetOptionalParam<float>("Tolerance", 1e-16)),
-      abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
-      max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
-      print_level(params.GetOptionalParam<int>("PrintLevel", -1))
+      _amg(M),
+      _tol(params.GetOptionalParam<float>("Tolerance", 1e-16)),
+      _abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
+      _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
+      _print_level(params.GetOptionalParam<int>("PrintLevel", -1))
   {
 
-    amg.SetPrintLevel(print_level);
-    SetTol(tol);
-    SetAbsTol(abstol);
-    SetMaxIter(max_iter);
-    SetPrintLevel(print_level);
-    SetPreconditioner(amg);
+    _amg.SetPrintLevel(_print_level);
+    SetTol(_tol);
+    SetAbsTol(_abstol);
+    SetMaxIter(_max_iter);
+    SetPrintLevel(_print_level);
+    SetPreconditioner(_amg);
   }
-  mfem::HypreBoomerAMG amg;
-  double tol;
-  double abstol;
-  int max_iter;
-  int print_level;
+  mfem::HypreBoomerAMG _amg;
+  double _tol;
+  double _abstol;
+  int _max_iter;
+  int _print_level;
 };
 
 } // namespace hephaestus

--- a/src/sources/closed_coil.cpp
+++ b/src/sources/closed_coil.cpp
@@ -143,11 +143,11 @@ ClosedCoilSolver::Init(hephaestus::GridFunctions & gridfunctions,
     *final_lf_ = 0.0;
   }
 
-  makeWedge();
-  prepareCoilSubmesh();
-  solveTransition();
-  solveCoil();
-  restoreAttributes();
+  MakeWedge();
+  PrepareCoilSubmesh();
+  SolveTransition();
+  SolveCoil();
+  RestoreAttributes();
 }
 
 void
@@ -178,7 +178,7 @@ ClosedCoilSolver::SubtractSource(mfem::ParGridFunction * gf)
 // ClosedCoilSolver main methods
 
 void
-ClosedCoilSolver::makeWedge()
+ClosedCoilSolver::MakeWedge()
 {
   std::vector<int> bdr_els;
 
@@ -203,7 +203,7 @@ ClosedCoilSolver::makeWedge()
 
   if (bdr_els.size() > 0)
   {
-    plane.make3DPlane(mesh_parent_, mesh_parent_->GetBdrElementFaceIndex(bdr_els[0]));
+    plane.Make3DPlane(mesh_parent_, mesh_parent_->GetBdrElementFaceIndex(bdr_els[0]));
   }
 
   std::vector<int> elec_vtx;
@@ -227,8 +227,8 @@ ClosedCoilSolver::makeWedge()
   for (int e = 0; e < mesh_parent_->GetNE(); ++e)
   {
 
-    if (!isInDomain(e, coil_domains_, mesh_parent_) ||
-        plane.side(elementCentre(e, mesh_parent_)) == 1)
+    if (!IsInDomain(e, coil_domains_, mesh_parent_) ||
+        plane.Side(ElementCentre(e, mesh_parent_)) == 1)
       continue;
 
     mfem::Array<int> elem_vtx;
@@ -268,8 +268,8 @@ ClosedCoilSolver::makeWedge()
     mesh_parent_->GetFaceElements(wf, &e1, &e2);
 
     // If the face is a coil boundary
-    if (!(isInDomain(e1, coil_domains_, mesh_parent_) &&
-          isInDomain(e2, coil_domains_, mesh_parent_)))
+    if (!(IsInDomain(e1, coil_domains_, mesh_parent_) &&
+          IsInDomain(e2, coil_domains_, mesh_parent_)))
     {
       continue;
     }
@@ -330,7 +330,7 @@ ClosedCoilSolver::makeWedge()
 }
 
 void
-ClosedCoilSolver::prepareCoilSubmesh()
+ClosedCoilSolver::PrepareCoilSubmesh()
 {
   mesh_coil_ = std::make_unique<mfem::ParSubMesh>(
       mfem::ParSubMesh::CreateFromDomain(*mesh_parent_, coil_domains_));
@@ -352,7 +352,7 @@ ClosedCoilSolver::prepareCoilSubmesh()
 }
 
 void
-ClosedCoilSolver::solveTransition()
+ClosedCoilSolver::SolveTransition()
 {
 
   mfem::ParGridFunction V_parent(H1FESpace_parent_);
@@ -384,7 +384,7 @@ ClosedCoilSolver::solveTransition()
 }
 
 void
-ClosedCoilSolver::solveCoil()
+ClosedCoilSolver::SolveCoil()
 {
   // -(σ∇Va,∇ψ) = (σ∇Vt,∇ψ)
   // where Va is Vaux_coil_, the auxiliary continuous "potential"
@@ -492,7 +492,7 @@ ClosedCoilSolver::solveCoil()
 }
 
 void
-ClosedCoilSolver::restoreAttributes()
+ClosedCoilSolver::RestoreAttributes()
 {
   // Domain attributes
   for (int e = 0; e < mesh_parent_->GetNE(); ++e)
@@ -508,7 +508,7 @@ ClosedCoilSolver::restoreAttributes()
 // Auxiliary methods
 
 bool
-ClosedCoilSolver::isInDomain(const int el, const mfem::Array<int> & dom, const mfem::ParMesh * mesh)
+ClosedCoilSolver::IsInDomain(const int el, const mfem::Array<int> & dom, const mfem::ParMesh * mesh)
 {
 
   // This is for ghost elements
@@ -527,7 +527,7 @@ ClosedCoilSolver::isInDomain(const int el, const mfem::Array<int> & dom, const m
 }
 
 bool
-ClosedCoilSolver::isInDomain(const int el, const int & sd, const mfem::ParMesh * mesh)
+ClosedCoilSolver::IsInDomain(const int el, const int & sd, const mfem::ParMesh * mesh)
 {
 
   // This is for ghost elements
@@ -538,7 +538,7 @@ ClosedCoilSolver::isInDomain(const int el, const int & sd, const mfem::ParMesh *
 }
 
 mfem::Vector
-ClosedCoilSolver::elementCentre(int el, mfem::ParMesh * pm)
+ClosedCoilSolver::ElementCentre(int el, mfem::ParMesh * pm)
 {
 
   mfem::Array<int> elem_vtx;
@@ -565,7 +565,7 @@ Plane3D::Plane3D()
 }
 
 void
-Plane3D::make3DPlane(const mfem::ParMesh * pm, const int face)
+Plane3D::Make3DPlane(const mfem::ParMesh * pm, const int face)
 {
 
   MFEM_ASSERT(pm->Dimension() == 3, "Plane3D only works in 3-dimensional meshes!");
@@ -594,7 +594,7 @@ Plane3D::make3DPlane(const mfem::ParMesh * pm, const int face)
 }
 
 int
-Plane3D::side(const mfem::Vector v)
+Plane3D::Side(const mfem::Vector v)
 {
   double val = *u * v - d;
 

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -32,29 +32,29 @@ public:
   // 1-element layer adjacent to it. Applies a different domain attribute to
   // other elements in the coil. Also applies different boundary attributes on
   // the two opposing faces of the layer, to act as Dirichlet BCs.
-  void makeWedge();
+  void MakeWedge();
 
   // Extracts the coil submesh and prepares the gridfunctions and FE spaces
   // for being passed to the OpenCoilSolver in the transition region
-  void prepareCoilSubmesh();
+  void PrepareCoilSubmesh();
 
   // Applies the OpenCoilSolver to the transition region
-  void solveTransition();
+  void SolveTransition();
 
   // Solves for the current in the coil region
-  void solveCoil();
+  void SolveCoil();
 
   // Resets the domain attributes on the parent mesh to what they were initially
-  void restoreAttributes();
+  void RestoreAttributes();
 
   // Finds the coordinates for the "centre of mass" of the vertices of an
   // element.
-  mfem::Vector elementCentre(int el, mfem::ParMesh * pm);
+  mfem::Vector ElementCentre(int el, mfem::ParMesh * pm);
 
   // Checks whether a given element is within a certain domain or vector of
   // domains.
-  bool isInDomain(const int el, const mfem::Array<int> & dom, const mfem::ParMesh * mesh);
-  bool isInDomain(const int el, const int & sd, const mfem::ParMesh * mesh);
+  bool IsInDomain(const int el, const mfem::Array<int> & dom, const mfem::ParMesh * mesh);
+  bool IsInDomain(const int el, const int & sd, const mfem::ParMesh * mesh);
 
 private:
   // Parameters
@@ -123,11 +123,11 @@ public:
   Plane3D();
 
   // Constructs a mathematical 3D plane from a mesh face
-  void make3DPlane(const mfem::ParMesh * pm, const int face);
+  void Make3DPlane(const mfem::ParMesh * pm, const int face);
 
   // Calculates on which side of the infinite 3D plane a point is.
   // Returns 1, -1, or 0, the latter meaning the point is on the plane
-  int side(const mfem::Vector v);
+  int Side(const mfem::Vector v);
 
 private:
   std::unique_ptr<mfem::Vector> u{nullptr};

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -58,23 +58,23 @@ public:
 
 private:
   // Parameters
-  int order_hcurl_;
-  int order_h1_;
-  int new_domain_attr_;
-  std::pair<int, int> elec_attrs_;
-  mfem::Array<int> coil_domains_;
-  mfem::Array<int> coil_markers_;
-  mfem::Array<int> transition_domain_;
-  mfem::Array<int> transition_markers_;
-  mfem::Coefficient * sigma_{nullptr};
-  mfem::Coefficient * Itotal_{nullptr};
-  std::vector<int> old_dom_attrs;
-  hephaestus::InputParameters solver_options_;
+  int _order_hcurl;
+  int _order_h1;
+  int _new_domain_attr;
+  std::pair<int, int> _elec_attrs;
+  mfem::Array<int> _coil_domains;
+  mfem::Array<int> _coil_markers;
+  mfem::Array<int> _transition_domain;
+  mfem::Array<int> _transition_markers;
+  mfem::Coefficient * _sigma{nullptr};
+  mfem::Coefficient * _itotal{nullptr};
+  std::vector<int> _old_dom_attrs;
+  hephaestus::InputParameters _solver_options;
 
-  bool owns_sigma{false};
-  bool owns_Itotal_{false};
-  bool owns_grad_phi_parent_{false};
-  bool owns_H1FESpace_parent_{false};
+  bool _owns_sigma{false};
+  bool _owns_itotal{false};
+  bool _owns_grad_phi_parent{false};
+  bool _owns_h1_fe_space_parent{false};
 
   // Here, we are solving for -(σ∇Va,∇ψ) = (σ∇Vt,∇ψ), where ∇Vt is grad_phi_t (within its relevant
   // mesh), ∇Va is grad_phi_aux, and their sum ∇Vt+∇Va is the full grad_phi, which is, up to an
@@ -82,38 +82,38 @@ private:
   // to true will negatively affect performance, but the final grad_phi function will be transferred
   // to a GridFunction for viewing purposes. Only set to true if you wish to visualise the final
   // grad_phi.
-  bool grad_phi_transfer_{false};
+  bool _grad_phi_transfer{false};
 
   // Names
-  std::string hcurl_fespace_name_;
-  std::string cond_coef_name_;
-  std::string h1_fespace_name_;
-  std::string grad_phi_name_;
-  std::string I_coef_name_;
+  std::string _hcurl_fespace_name;
+  std::string _cond_coef_name;
+  std::string _h1_fespace_name;
+  std::string _grad_phi_name;
+  std::string _i_coef_name;
 
   // Parent mesh, FE space, and current
-  mfem::ParMesh * mesh_parent_{nullptr};
-  mfem::ParGridFunction * grad_phi_parent_{nullptr};
-  mfem::ParFiniteElementSpace * HCurlFESpace_parent_{nullptr};
-  mfem::ParFiniteElementSpace * H1FESpace_parent_{nullptr};
+  mfem::ParMesh * _mesh_parent{nullptr};
+  mfem::ParGridFunction * _grad_phi_parent{nullptr};
+  mfem::ParFiniteElementSpace * _h_curl_fe_space_parent{nullptr};
+  mfem::ParFiniteElementSpace * _h1_fe_space_parent{nullptr};
 
-  std::unique_ptr<mfem::H1_FECollection> H1FESpace_parent_fec_{nullptr};
+  std::unique_ptr<mfem::H1_FECollection> _h1_fe_space_parent_fec{nullptr};
 
   // In case J transfer is true
-  std::unique_ptr<mfem::ParGridFunction> grad_phi_t_parent_{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _grad_phi_t_parent{nullptr};
 
   // Coil mesh, FE Space, and current
-  std::unique_ptr<mfem::ParSubMesh> mesh_coil_{nullptr};
-  std::unique_ptr<mfem::ParSubMesh> mesh_t_{nullptr};
-  std::unique_ptr<mfem::ParFiniteElementSpace> H1FESpace_coil_{nullptr};
-  std::unique_ptr<mfem::ParGridFunction> grad_phi_aux_coil_{nullptr};
-  std::unique_ptr<mfem::ParGridFunction> V_coil_{nullptr};
+  std::unique_ptr<mfem::ParSubMesh> _mesh_coil{nullptr};
+  std::unique_ptr<mfem::ParSubMesh> _mesh_t{nullptr};
+  std::unique_ptr<mfem::ParFiniteElementSpace> _h1_fe_space_coil{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _grad_phi_aux_coil{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _v_coil{nullptr};
 
-  std::unique_ptr<mfem::ND_FECollection> grad_phi_aux_coil_fec_{nullptr};
-  std::unique_ptr<mfem::ParFiniteElementSpace> grad_phi_aux_coil_fes{nullptr};
+  std::unique_ptr<mfem::ND_FECollection> _grad_phi_aux_coil_fec{nullptr};
+  std::unique_ptr<mfem::ParFiniteElementSpace> _grad_phi_aux_coil_fes{nullptr};
 
   // Final LinearForm
-  std::unique_ptr<mfem::ParLinearForm> final_lf_{nullptr};
+  std::unique_ptr<mfem::ParLinearForm> _final_lf{nullptr};
 };
 
 class Plane3D
@@ -130,8 +130,8 @@ public:
   int Side(const mfem::Vector v);
 
 private:
-  std::unique_ptr<mfem::Vector> u{nullptr};
-  double d{0};
+  std::unique_ptr<mfem::Vector> _u{nullptr};
+  double _d{0};
 };
 
 } // namespace hephaestus

--- a/src/sources/div_free_source.cpp
+++ b/src/sources/div_free_source.cpp
@@ -89,19 +89,19 @@ DivFreeSource::Apply(mfem::ParLinearForm * lf)
 {
   // Find an averaged representation of current density in H(curl)*
   g->ProjectCoefficient(*sourceVecCoef);
-  mfem::ParLinearForm J(HCurlFESpace_);
-  J.AddDomainIntegrator(new mfem::VectorFEDomainLFIntegrator(*sourceVecCoef));
-  J.Assemble();
+  mfem::ParLinearForm j(HCurlFESpace_);
+  j.AddDomainIntegrator(new mfem::VectorFEDomainLFIntegrator(*sourceVecCoef));
+  j.Assemble();
   {
-    mfem::HypreParMatrix M;
-    mfem::Vector X, RHS;
+    mfem::HypreParMatrix m;
+    mfem::Vector x, rhs;
     mfem::Array<int> ess_tdof_list;
-    h_curl_mass->FormLinearSystem(ess_tdof_list, *g, J, M, X, RHS);
+    h_curl_mass->FormLinearSystem(ess_tdof_list, *g, j, m, x, rhs);
 
-    DefaultGMRESSolver solver(solver_options, M);
-    solver.Mult(RHS, X);
+    DefaultGMRESSolver solver(solver_options, m);
+    solver.Mult(rhs, x);
 
-    h_curl_mass->RecoverFEMSolution(X, J, *g);
+    h_curl_mass->RecoverFEMSolution(x, j, *g);
   }
 
   *div_free_src_gf = *g;

--- a/src/sources/div_free_source.cpp
+++ b/src/sources/div_free_source.cpp
@@ -16,16 +16,16 @@ via the weak form:
 (g, ∇q) - (∇Q, ∇q) - <P(g).n, q> = 0
 */
 DivFreeSource::DivFreeSource(const hephaestus::InputParameters & params)
-  : src_coef_name(params.GetParam<std::string>("SourceName")),
-    src_gf_name(params.GetParam<std::string>("SourceName")),
-    hcurl_fespace_name(params.GetParam<std::string>("HCurlFESpaceName")),
-    h1_fespace_name(params.GetParam<std::string>("H1FESpaceName")),
-    potential_gf_name(
+  : _src_coef_name(params.GetParam<std::string>("SourceName")),
+    _src_gf_name(params.GetParam<std::string>("SourceName")),
+    _hcurl_fespace_name(params.GetParam<std::string>("HCurlFESpaceName")),
+    _h1_fespace_name(params.GetParam<std::string>("H1FESpaceName")),
+    _potential_gf_name(
         params.GetOptionalParam<std::string>("PotentialName", std::string("_source_potential"))),
-    solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+    _solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
         "SolverOptions", hephaestus::InputParameters())),
-    perform_helmholtz_projection(params.GetOptionalParam<bool>("HelmholtzProjection", true)),
-    h_curl_mass(nullptr)
+    _perform_helmholtz_projection(params.GetOptionalParam<bool>("HelmholtzProjection", true)),
+    _h_curl_mass(nullptr)
 {
 }
 
@@ -35,23 +35,23 @@ DivFreeSource::Init(hephaestus::GridFunctions & gridfunctions,
                     hephaestus::BCMap & bc_map,
                     hephaestus::Coefficients & coefficients)
 {
-  H1FESpace_ = fespaces.Get(h1_fespace_name);
-  if (H1FESpace_ == nullptr)
+  _h1_fe_space = fespaces.Get(_h1_fespace_name);
+  if (_h1_fe_space == nullptr)
   {
-    const std::string error_message = h1_fespace_name + " not found in fespaces when "
-                                                        "creating DivFreeSource\n";
+    const std::string error_message = _h1_fespace_name + " not found in fespaces when "
+                                                         "creating DivFreeSource\n";
     mfem::mfem_error(error_message.c_str());
   }
-  HCurlFESpace_ = fespaces.Get(hcurl_fespace_name);
-  if (HCurlFESpace_ == nullptr)
+  _h_curl_fe_space = fespaces.Get(_hcurl_fespace_name);
+  if (_h_curl_fe_space == nullptr)
   {
-    const std::string error_message = hcurl_fespace_name + " not found in fespaces when "
-                                                           "creating DivFreeSource\n";
+    const std::string error_message = _hcurl_fespace_name + " not found in fespaces when "
+                                                            "creating DivFreeSource\n";
     mfem::mfem_error(error_message.c_str());
   }
-  if (coefficients.vectors.Has(src_coef_name))
+  if (coefficients._vectors.Has(_src_coef_name))
   {
-    sourceVecCoef = coefficients.vectors.Get(src_coef_name);
+    _source_vec_coef = coefficients._vectors.Get(_src_coef_name);
   }
   else
   {
@@ -59,18 +59,18 @@ DivFreeSource::Init(hephaestus::GridFunctions & gridfunctions,
   }
 
   // NB: Register must be false to avoid double-free.
-  div_free_src_gf = std::make_unique<mfem::ParGridFunction>(HCurlFESpace_);
-  gridfunctions.Register(src_gf_name, div_free_src_gf.get(), false);
+  _div_free_src_gf = std::make_unique<mfem::ParGridFunction>(_h_curl_fe_space);
+  gridfunctions.Register(_src_gf_name, _div_free_src_gf.get(), false);
 
-  g = std::make_unique<mfem::ParGridFunction>(HCurlFESpace_);
-  gridfunctions.Register("_user_source", g.get(), false);
+  _g = std::make_unique<mfem::ParGridFunction>(_h_curl_fe_space);
+  gridfunctions.Register("_user_source", _g.get(), false);
 
-  q_ = std::make_unique<mfem::ParGridFunction>(H1FESpace_);
-  gridfunctions.Register(potential_gf_name, q_.get(), false);
+  _q = std::make_unique<mfem::ParGridFunction>(_h1_fe_space);
+  gridfunctions.Register(_potential_gf_name, _q.get(), false);
 
-  bc_map_ = &bc_map;
-  gridfunctions_ = &gridfunctions;
-  fespaces_ = &fespaces;
+  _bc_map = &bc_map;
+  _gridfunctions = &gridfunctions;
+  _fespaces = &fespaces;
 
   BuildHCurlMass();
 }
@@ -78,61 +78,61 @@ DivFreeSource::Init(hephaestus::GridFunctions & gridfunctions,
 void
 DivFreeSource::BuildHCurlMass()
 {
-  h_curl_mass = std::make_unique<mfem::ParBilinearForm>(HCurlFESpace_);
-  h_curl_mass->AddDomainIntegrator(new mfem::VectorFEMassIntegrator);
-  h_curl_mass->Assemble();
-  h_curl_mass->Finalize();
+  _h_curl_mass = std::make_unique<mfem::ParBilinearForm>(_h_curl_fe_space);
+  _h_curl_mass->AddDomainIntegrator(new mfem::VectorFEMassIntegrator);
+  _h_curl_mass->Assemble();
+  _h_curl_mass->Finalize();
 }
 
 void
 DivFreeSource::Apply(mfem::ParLinearForm * lf)
 {
   // Find an averaged representation of current density in H(curl)*
-  g->ProjectCoefficient(*sourceVecCoef);
-  mfem::ParLinearForm j(HCurlFESpace_);
-  j.AddDomainIntegrator(new mfem::VectorFEDomainLFIntegrator(*sourceVecCoef));
+  _g->ProjectCoefficient(*_source_vec_coef);
+  mfem::ParLinearForm j(_h_curl_fe_space);
+  j.AddDomainIntegrator(new mfem::VectorFEDomainLFIntegrator(*_source_vec_coef));
   j.Assemble();
   {
     mfem::HypreParMatrix m;
     mfem::Vector x, rhs;
     mfem::Array<int> ess_tdof_list;
-    h_curl_mass->FormLinearSystem(ess_tdof_list, *g, j, m, x, rhs);
+    _h_curl_mass->FormLinearSystem(ess_tdof_list, *_g, j, m, x, rhs);
 
-    DefaultGMRESSolver solver(solver_options, m);
+    DefaultGMRESSolver solver(_solver_options, m);
     solver.Mult(rhs, x);
 
-    h_curl_mass->RecoverFEMSolution(x, j, *g);
+    _h_curl_mass->RecoverFEMSolution(x, j, *_g);
   }
 
-  *div_free_src_gf = *g;
+  *_div_free_src_gf = *_g;
 
-  if (perform_helmholtz_projection)
+  if (_perform_helmholtz_projection)
   {
 
     hephaestus::InputParameters projector_pars;
-    projector_pars.SetParam("VectorGridFunctionName", src_gf_name);
-    projector_pars.SetParam("ScalarGridFunctionName", potential_gf_name);
-    projector_pars.SetParam("H1FESpaceName", h1_fespace_name);
-    projector_pars.SetParam("HCurlFESpaceName", hcurl_fespace_name);
+    projector_pars.SetParam("VectorGridFunctionName", _src_gf_name);
+    projector_pars.SetParam("ScalarGridFunctionName", _potential_gf_name);
+    projector_pars.SetParam("H1FESpaceName", _h1_fespace_name);
+    projector_pars.SetParam("HCurlFESpaceName", _hcurl_fespace_name);
 
     hephaestus::BCMap bcs;
 
     hephaestus::HelmholtzProjector projector(projector_pars);
-    projector.Project(*gridfunctions_, *fespaces_, bcs);
+    projector.Project(*_gridfunctions, *_fespaces, bcs);
   }
 
   // Add divergence free source to target linear form
-  h_curl_mass->Update();
-  h_curl_mass->Assemble();
-  h_curl_mass->Finalize();
+  _h_curl_mass->Update();
+  _h_curl_mass->Assemble();
+  _h_curl_mass->Finalize();
 
-  h_curl_mass->AddMult(*div_free_src_gf, *lf, 1.0);
+  _h_curl_mass->AddMult(*_div_free_src_gf, *lf, 1.0);
 }
 
 void
 DivFreeSource::SubtractSource(mfem::ParGridFunction * gf)
 {
-  h_curl_mass->AddMult(*div_free_src_gf, *gf, -1.0);
+  _h_curl_mass->AddMult(*_div_free_src_gf, *gf, -1.0);
 }
 
 } // namespace hephaestus

--- a/src/sources/div_free_source.cpp
+++ b/src/sources/div_free_source.cpp
@@ -72,11 +72,11 @@ DivFreeSource::Init(hephaestus::GridFunctions & gridfunctions,
   gridfunctions_ = &gridfunctions;
   fespaces_ = &fespaces;
 
-  buildHCurlMass();
+  BuildHCurlMass();
 }
 
 void
-DivFreeSource::buildHCurlMass()
+DivFreeSource::BuildHCurlMass()
 {
   h_curl_mass = std::make_unique<mfem::ParBilinearForm>(HCurlFESpace_);
   h_curl_mass->AddDomainIntegrator(new mfem::VectorFEMassIntegrator);

--- a/src/sources/div_free_source.hpp
+++ b/src/sources/div_free_source.hpp
@@ -20,34 +20,34 @@ public:
   void SubtractSource(mfem::ParGridFunction * gf) override;
   void BuildHCurlMass();
 
-  std::string src_gf_name;
-  std::string src_coef_name;
-  std::string potential_gf_name;
-  std::string hcurl_fespace_name;
-  std::string h1_fespace_name;
-  const hephaestus::InputParameters solver_options;
-  bool perform_helmholtz_projection;
+  std::string _src_gf_name;
+  std::string _src_coef_name;
+  std::string _potential_gf_name;
+  std::string _hcurl_fespace_name;
+  std::string _h1_fespace_name;
+  const hephaestus::InputParameters _solver_options;
+  bool _perform_helmholtz_projection;
 
-  mfem::ParFiniteElementSpace * H1FESpace_{nullptr};
-  mfem::ParFiniteElementSpace * HCurlFESpace_{nullptr};
+  mfem::ParFiniteElementSpace * _h1_fe_space{nullptr};
+  mfem::ParFiniteElementSpace * _h_curl_fe_space{nullptr};
 
-  std::unique_ptr<mfem::ParGridFunction> q_; // Potential
+  std::unique_ptr<mfem::ParGridFunction> _q; // Potential
 
-  hephaestus::BCMap * bc_map_{nullptr};
-  hephaestus::GridFunctions * gridfunctions_{nullptr};
-  const hephaestus::FESpaces * fespaces_{nullptr};
+  hephaestus::BCMap * _bc_map{nullptr};
+  hephaestus::GridFunctions * _gridfunctions{nullptr};
+  const hephaestus::FESpaces * _fespaces{nullptr};
 
-  std::unique_ptr<mfem::ParBilinearForm> h_curl_mass;
+  std::unique_ptr<mfem::ParBilinearForm> _h_curl_mass;
 
-  mfem::VectorCoefficient * sourceVecCoef{nullptr};
+  mfem::VectorCoefficient * _source_vec_coef{nullptr};
 
   // H(Curl) projection of user specified source
-  std::unique_ptr<mfem::ParGridFunction> g;
+  std::unique_ptr<mfem::ParGridFunction> _g;
 
   // Divergence free projected source
-  std::unique_ptr<mfem::ParGridFunction> div_free_src_gf;
+  std::unique_ptr<mfem::ParGridFunction> _div_free_src_gf;
 
-  mfem::Solver * solver{nullptr};
+  mfem::Solver * _solver{nullptr};
 };
 
 }; // namespace hephaestus

--- a/src/sources/div_free_source.hpp
+++ b/src/sources/div_free_source.hpp
@@ -18,7 +18,7 @@ public:
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParLinearForm * lf) override;
   void SubtractSource(mfem::ParGridFunction * gf) override;
-  void buildHCurlMass();
+  void BuildHCurlMass();
 
   std::string src_gf_name;
   std::string src_coef_name;

--- a/src/sources/open_coil.cpp
+++ b/src/sources/open_coil.cpp
@@ -93,14 +93,14 @@ SubdomainToArray(const std::vector<hephaestus::Subdomain> & sd, mfem::Array<int>
 {
   arr.DeleteAll();
   for (auto s : sd)
-    arr.Append(s.id);
+    arr.Append(s._id);
 }
 
 void
 SubdomainToArray(const hephaestus::Subdomain & sd, mfem::Array<int> & arr)
 {
   arr.DeleteAll();
-  arr.Append(sd.id);
+  arr.Append(sd._id);
 }
 
 void
@@ -178,17 +178,17 @@ cleanDivergence(hephaestus::GridFunctions & gfs,
 OpenCoilSolver::OpenCoilSolver(const hephaestus::InputParameters & params,
                                mfem::Array<int> coil_dom,
                                const std::pair<int, int> electrodes)
-  : grad_phi_name_(params.GetParam<std::string>("GradPotentialName")),
-    V_gf_name_(params.GetParam<std::string>("PotentialName")),
-    I_coef_name_(params.GetParam<std::string>("IFuncCoefName")),
-    cond_coef_name_(params.GetParam<std::string>("ConductivityCoefName")),
-    grad_phi_transfer_(params.GetOptionalParam<bool>("GradPhiTransfer", true)),
-    coil_domains_(std::move(coil_dom)),
-    elec_attrs_(electrodes),
-    high_src_(highV),
-    low_src_(lowV),
-    high_terminal_(1),
-    low_terminal_(1)
+  : _grad_phi_name(params.GetParam<std::string>("GradPotentialName")),
+    _v_gf_name(params.GetParam<std::string>("PotentialName")),
+    _i_coef_name(params.GetParam<std::string>("IFuncCoefName")),
+    _cond_coef_name(params.GetParam<std::string>("ConductivityCoefName")),
+    _grad_phi_transfer(params.GetOptionalParam<bool>("GradPhiTransfer", true)),
+    _coil_domains(std::move(coil_dom)),
+    _elec_attrs(electrodes),
+    _high_src(highV),
+    _low_src(lowV),
+    _high_terminal(1),
+    _low_terminal(1)
 {
 
   hephaestus::InputParameters default_pars;
@@ -197,18 +197,18 @@ OpenCoilSolver::OpenCoilSolver(const hephaestus::InputParameters & params,
   default_pars.SetParam("MaxIter", (unsigned int)1000);
   default_pars.SetParam("PrintLevel", 1);
 
-  solver_options_ =
+  _solver_options =
       params.GetOptionalParam<hephaestus::InputParameters>("SolverOptions", default_pars);
 
-  ref_face_ = elec_attrs_.first;
+  _ref_face = _elec_attrs.first;
 }
 
 OpenCoilSolver::~OpenCoilSolver()
 {
-  if (owns_sigma_)
-    delete sigma_;
-  if (owns_Itotal_)
-    delete Itotal_;
+  if (_owns_sigma)
+    delete _sigma;
+  if (_owns_itotal)
+    delete _itotal;
 }
 
 void
@@ -218,65 +218,65 @@ OpenCoilSolver::Init(hephaestus::GridFunctions & gridfunctions,
                      hephaestus::Coefficients & coefficients)
 {
 
-  Itotal_ = coefficients.scalars.Get(I_coef_name_);
-  if (Itotal_ == nullptr)
+  _itotal = coefficients._scalars.Get(_i_coef_name);
+  if (_itotal == nullptr)
   {
-    std::cout << I_coef_name_ + " not found in coefficients when "
+    std::cout << _i_coef_name + " not found in coefficients when "
                                 "creating OpenCoilSolver. "
                                 "Assuming unit current.\n";
-    Itotal_ = new mfem::ConstantCoefficient(1.0);
-    owns_Itotal_ = true;
+    _itotal = new mfem::ConstantCoefficient(1.0);
+    _owns_itotal = true;
   }
 
-  sigma_ = coefficients.scalars.Get(cond_coef_name_);
-  if (sigma_ == nullptr)
+  _sigma = coefficients._scalars.Get(_cond_coef_name);
+  if (_sigma == nullptr)
   {
-    std::cout << cond_coef_name_ + " not found in coefficients when "
+    std::cout << _cond_coef_name + " not found in coefficients when "
                                    "creating OpenCoilSolver. "
                                    "Assuming unit conductivity.\n";
     std::cout << "Warning: GradPhi field undefined. The GridFunction "
                  "associated with it will be set to zero.\n";
 
-    sigma_ = new mfem::ConstantCoefficient(1.0);
-    owns_sigma_ = true;
+    _sigma = new mfem::ConstantCoefficient(1.0);
+    _owns_sigma = true;
 
-    grad_phi_transfer_ = false;
+    _grad_phi_transfer = false;
   }
 
-  grad_phi_parent_ = gridfunctions.Get(grad_phi_name_);
-  if (grad_phi_parent_ == nullptr)
+  _grad_phi_parent = gridfunctions.Get(_grad_phi_name);
+  if (_grad_phi_parent == nullptr)
   {
-    const std::string error_message = grad_phi_name_ + " not found in gridfunctions when "
+    const std::string error_message = _grad_phi_name + " not found in gridfunctions when "
                                                        "creating OpenCoilSolver\n";
     mfem::mfem_error(error_message.c_str());
   }
-  else if (grad_phi_parent_->ParFESpace()->FEColl()->GetContType() !=
+  else if (_grad_phi_parent->ParFESpace()->FEColl()->GetContType() !=
            mfem::FiniteElementCollection::TANGENTIAL)
   {
     mfem::mfem_error("GradPhi GridFunction must be of HCurl type.");
   }
 
-  order_hcurl_ = grad_phi_parent_->ParFESpace()->FEColl()->GetOrder();
+  _order_hcurl = _grad_phi_parent->ParFESpace()->FEColl()->GetOrder();
 
-  V_parent_ = gridfunctions.Get(V_gf_name_);
-  if (V_parent_ == nullptr)
+  _v_parent = gridfunctions.Get(_v_gf_name);
+  if (_v_parent == nullptr)
   {
-    std::cout << V_gf_name_ + " not found in gridfunctions when "
+    std::cout << _v_gf_name + " not found in gridfunctions when "
                               "creating OpenCoilSolver.\n";
-    order_h1_ = order_hcurl_;
+    _order_h1 = _order_hcurl;
   }
-  else if (V_parent_->ParFESpace()->FEColl()->GetContType() !=
+  else if (_v_parent->ParFESpace()->FEColl()->GetContType() !=
            mfem::FiniteElementCollection::CONTINUOUS)
   {
     mfem::mfem_error("V GridFunction must be of H1 type.");
   }
   else
   {
-    order_h1_ = V_parent_->ParFESpace()->FEColl()->GetOrder();
-    Vt_parent_ = std::make_unique<mfem::ParGridFunction>(*V_parent_);
+    _order_h1 = _v_parent->ParFESpace()->FEColl()->GetOrder();
+    _vt_parent = std::make_unique<mfem::ParGridFunction>(*_v_parent);
   }
 
-  mesh_parent_ = grad_phi_parent_->ParFESpace()->GetParMesh();
+  _mesh_parent = _grad_phi_parent->ParFESpace()->GetParMesh();
 
   InitChildMesh();
   MakeFESpaces();
@@ -291,23 +291,23 @@ OpenCoilSolver::Apply(mfem::ParLinearForm * lf)
 
   // The transformation and integration points themselves are not relevant, it's
   // just so we can call Eval
-  mfem::ElementTransformation * tr = mesh_parent_->GetElementTransformation(0);
+  mfem::ElementTransformation * tr = _mesh_parent->GetElementTransformation(0);
   const mfem::IntegrationPoint & ip =
-      mfem::IntRules.Get(grad_phi_parent_->ParFESpace()->GetFE(0)->GetGeomType(), 1).IntPoint(0);
+      mfem::IntRules.Get(_grad_phi_parent->ParFESpace()->GetFE(0)->GetGeomType(), 1).IntPoint(0);
 
-  double i = Itotal_->Eval(*tr, ip);
+  double i = _itotal->Eval(*tr, ip);
 
-  *grad_phi_parent_ = 0.0;
-  if (grad_phi_transfer_)
-    grad_phi_parent_->Add(i, *grad_phi_t_parent_);
+  *_grad_phi_parent = 0.0;
+  if (_grad_phi_transfer)
+    _grad_phi_parent->Add(i, *_grad_phi_t_parent);
 
-  if (V_parent_ != nullptr)
+  if (_v_parent != nullptr)
   {
-    *V_parent_ = 0.0;
-    V_parent_->Add(i, *Vt_parent_);
+    *_v_parent = 0.0;
+    _v_parent->Add(i, *_vt_parent);
   }
 
-  lf->Add(i, *final_lf_);
+  lf->Add(i, *_final_lf);
 }
 
 void
@@ -318,25 +318,27 @@ OpenCoilSolver::SubtractSource(mfem::ParGridFunction * gf)
 void
 OpenCoilSolver::InitChildMesh()
 {
-  if (mesh_ == nullptr)
-    mesh_ = std::make_unique<mfem::ParSubMesh>(
-        mfem::ParSubMesh::CreateFromDomain(*mesh_parent_, coil_domains_));
+  if (_mesh == nullptr)
+    _mesh = std::make_unique<mfem::ParSubMesh>(
+        mfem::ParSubMesh::CreateFromDomain(*_mesh_parent, _coil_domains));
 }
 
 void
 OpenCoilSolver::MakeFESpaces()
 {
-  if (H1FESpace_ == nullptr)
+  if (_h1_fe_space == nullptr)
   {
-    H1FESpace_fec_ = std::make_unique<mfem::H1_FECollection>(order_h1_, mesh_->Dimension());
-    H1FESpace_ = std::make_unique<mfem::ParFiniteElementSpace>(mesh_.get(), H1FESpace_fec_.get());
+    _h1_fe_space_fec = std::make_unique<mfem::H1_FECollection>(_order_h1, _mesh->Dimension());
+    _h1_fe_space =
+        std::make_unique<mfem::ParFiniteElementSpace>(_mesh.get(), _h1_fe_space_fec.get());
   }
 
-  if (HCurlFESpace_ == nullptr)
+  if (_h_curl_fe_space == nullptr)
   {
-    HCurlFESpace_fec = std::make_unique<mfem::ND_FECollection>(order_hcurl_, mesh_->Dimension());
-    HCurlFESpace_ =
-        std::make_unique<mfem::ParFiniteElementSpace>(mesh_.get(), HCurlFESpace_fec.get());
+    _h_curl_fe_space_fec =
+        std::make_unique<mfem::ND_FECollection>(_order_hcurl, _mesh->Dimension());
+    _h_curl_fe_space =
+        std::make_unique<mfem::ParFiniteElementSpace>(_mesh.get(), _h_curl_fe_space_fec.get());
   }
 }
 
@@ -344,100 +346,100 @@ void
 OpenCoilSolver::MakeGridFunctions()
 {
 
-  if (V_ == nullptr)
-    V_ = std::make_unique<mfem::ParGridFunction>(H1FESpace_.get());
+  if (_v == nullptr)
+    _v = std::make_unique<mfem::ParGridFunction>(_h1_fe_space.get());
 
-  if (grad_phi_ == nullptr)
-    grad_phi_ = std::make_unique<mfem::ParGridFunction>(HCurlFESpace_.get());
+  if (_grad_phi == nullptr)
+    _grad_phi = std::make_unique<mfem::ParGridFunction>(_h_curl_fe_space.get());
 
-  if (grad_phi_t_parent_ == nullptr)
-    grad_phi_t_parent_ = std::make_unique<mfem::ParGridFunction>(*grad_phi_parent_);
+  if (_grad_phi_t_parent == nullptr)
+    _grad_phi_t_parent = std::make_unique<mfem::ParGridFunction>(*_grad_phi_parent);
 
-  *V_ = 0.0;
-  *grad_phi_ = 0.0;
-  *grad_phi_t_parent_ = 0.0;
+  *_v = 0.0;
+  *_grad_phi = 0.0;
+  *_grad_phi_t_parent = 0.0;
 }
 
 void
 OpenCoilSolver::SetBCs()
 {
 
-  high_terminal_[0] = elec_attrs_.first;
-  low_terminal_[0] = elec_attrs_.second;
+  _high_terminal[0] = _elec_attrs.first;
+  _low_terminal[0] = _elec_attrs.second;
 }
 
 void
 OpenCoilSolver::SPSCurrent()
 {
-  bc_maps.Register("high_potential",
-                   new hephaestus::ScalarDirichletBC(std::string("V"), high_terminal_, &high_src_),
-                   true);
+  _bc_maps.Register("high_potential",
+                    new hephaestus::ScalarDirichletBC(std::string("V"), _high_terminal, &_high_src),
+                    true);
 
-  bc_maps.Register("low_potential",
-                   new hephaestus::ScalarDirichletBC(std::string("V"), low_terminal_, &low_src_),
-                   true);
+  _bc_maps.Register("low_potential",
+                    new hephaestus::ScalarDirichletBC(std::string("V"), _low_terminal, &_low_src),
+                    true);
 
   // NB: register false to avoid double-free.
   hephaestus::FESpaces fespaces;
-  fespaces.Register(std::string("HCurl"), HCurlFESpace_.get(), false);
-  fespaces.Register(std::string("H1"), H1FESpace_.get(), false);
+  fespaces.Register(std::string("HCurl"), _h_curl_fe_space.get(), false);
+  fespaces.Register(std::string("H1"), _h1_fe_space.get(), false);
 
   // NB: register false to avoid double-free.
   hephaestus::GridFunctions gridfunctions;
-  gridfunctions.Register(std::string("GradPhi"), grad_phi_.get(), false);
-  gridfunctions.Register(std::string("V"), V_.get(), false);
+  gridfunctions.Register(std::string("GradPhi"), _grad_phi.get(), false);
+  gridfunctions.Register(std::string("V"), _v.get(), false);
 
   hephaestus::InputParameters sps_params;
   sps_params.SetParam("GradPotentialName", std::string("GradPhi"));
   sps_params.SetParam("PotentialName", std::string("V"));
   sps_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
   sps_params.SetParam("H1FESpaceName", std::string("H1"));
-  sps_params.SetParam("SolverOptions", solver_options_);
+  sps_params.SetParam("SolverOptions", _solver_options);
   sps_params.SetParam("ConductivityCoefName", std::string("electric_conductivity"));
 
   hephaestus::Coefficients coefs;
-  coefs.scalars.Register("electric_conductivity", sigma_, false);
+  coefs._scalars.Register("electric_conductivity", _sigma, false);
 
   hephaestus::ScalarPotentialSource sps(sps_params);
-  sps.Init(gridfunctions, fespaces, bc_maps, coefs);
+  sps.Init(gridfunctions, fespaces, _bc_maps, coefs);
 
-  mfem::ParLinearForm dummy(HCurlFESpace_.get());
+  mfem::ParLinearForm dummy(_h_curl_fe_space.get());
   sps.Apply(&dummy);
 
   // Normalise the current through the wedges and use them as a reference
-  double flux = calcFlux(grad_phi_.get(), ref_face_, *sigma_);
-  *grad_phi_ /= abs(flux);
-  if (V_)
-    *V_ /= abs(flux);
+  double flux = calcFlux(_grad_phi.get(), _ref_face, *_sigma);
+  *_grad_phi /= abs(flux);
+  if (_v)
+    *_v /= abs(flux);
 
-  mesh_->Transfer(*grad_phi_, *grad_phi_t_parent_);
-  if (V_parent_)
-    mesh_->Transfer(*V_, *Vt_parent_);
+  _mesh->Transfer(*_grad_phi, *_grad_phi_t_parent);
+  if (_v_parent)
+    _mesh->Transfer(*_v, *_vt_parent);
 
   BuildM1();
 
-  final_lf_ = std::make_unique<mfem::ParLinearForm>(grad_phi_t_parent_->ParFESpace());
-  *final_lf_ = 0.0;
-  m1_->AddMult(*grad_phi_t_parent_, *final_lf_, 1.0);
+  _final_lf = std::make_unique<mfem::ParLinearForm>(_grad_phi_t_parent->ParFESpace());
+  *_final_lf = 0.0;
+  _m1->AddMult(*_grad_phi_t_parent, *_final_lf, 1.0);
 }
 
 void
 OpenCoilSolver::BuildM1()
 {
-  if (m1_ == nullptr)
+  if (_m1 == nullptr)
   {
-    m1_ = std::make_unique<mfem::ParBilinearForm>(grad_phi_parent_->ParFESpace());
-    hephaestus::attrToMarker(coil_domains_, coil_markers_, mesh_parent_->attributes.Max());
-    m1_->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(sigma_), coil_markers_);
-    m1_->Assemble();
-    m1_->Finalize();
+    _m1 = std::make_unique<mfem::ParBilinearForm>(_grad_phi_parent->ParFESpace());
+    hephaestus::attrToMarker(_coil_domains, _coil_markers, _mesh_parent->attributes.Max());
+    _m1->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(_sigma), _coil_markers);
+    _m1->Assemble();
+    _m1->Finalize();
   }
 }
 
 void
 OpenCoilSolver::SetRefFace(const int face)
 {
-  ref_face_ = face;
+  _ref_face = face;
 }
 
 } // namespace hephaestus

--- a/src/sources/open_coil.cpp
+++ b/src/sources/open_coil.cpp
@@ -278,10 +278,10 @@ OpenCoilSolver::Init(hephaestus::GridFunctions & gridfunctions,
 
   mesh_parent_ = grad_phi_parent_->ParFESpace()->GetParMesh();
 
-  initChildMesh();
-  makeFESpaces();
-  makeGridFunctions();
-  setBCs();
+  InitChildMesh();
+  MakeFESpaces();
+  MakeGridFunctions();
+  SetBCs();
   SPSCurrent();
 }
 
@@ -316,7 +316,7 @@ OpenCoilSolver::SubtractSource(mfem::ParGridFunction * gf)
 }
 
 void
-OpenCoilSolver::initChildMesh()
+OpenCoilSolver::InitChildMesh()
 {
   if (mesh_ == nullptr)
     mesh_ = std::make_unique<mfem::ParSubMesh>(
@@ -324,7 +324,7 @@ OpenCoilSolver::initChildMesh()
 }
 
 void
-OpenCoilSolver::makeFESpaces()
+OpenCoilSolver::MakeFESpaces()
 {
   if (H1FESpace_ == nullptr)
   {
@@ -341,7 +341,7 @@ OpenCoilSolver::makeFESpaces()
 }
 
 void
-OpenCoilSolver::makeGridFunctions()
+OpenCoilSolver::MakeGridFunctions()
 {
 
   if (V_ == nullptr)
@@ -359,7 +359,7 @@ OpenCoilSolver::makeGridFunctions()
 }
 
 void
-OpenCoilSolver::setBCs()
+OpenCoilSolver::SetBCs()
 {
 
   high_terminal_[0] = elec_attrs_.first;
@@ -414,7 +414,7 @@ OpenCoilSolver::SPSCurrent()
   if (V_parent_)
     mesh_->Transfer(*V_, *Vt_parent_);
 
-  buildM1();
+  BuildM1();
 
   final_lf_ = std::make_unique<mfem::ParLinearForm>(grad_phi_t_parent_->ParFESpace());
   *final_lf_ = 0.0;
@@ -422,7 +422,7 @@ OpenCoilSolver::SPSCurrent()
 }
 
 void
-OpenCoilSolver::buildM1()
+OpenCoilSolver::BuildM1()
 {
   if (m1_ == nullptr)
   {
@@ -435,7 +435,7 @@ OpenCoilSolver::buildM1()
 }
 
 void
-OpenCoilSolver::setRefFace(const int face)
+OpenCoilSolver::SetRefFace(const int face)
 {
   ref_face_ = face;
 }

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -72,65 +72,65 @@ public:
 
 private:
   // Parameters
-  int order_h1_;
-  int order_hcurl_;
-  int ref_face_;
-  bool grad_phi_transfer_;
+  int _order_h1;
+  int _order_hcurl;
+  int _ref_face;
+  bool _grad_phi_transfer;
 
-  std::pair<int, int> elec_attrs_;
-  mfem::Array<int> coil_domains_;
-  mfem::Array<int> coil_markers_;
-  hephaestus::InputParameters solver_options_;
+  std::pair<int, int> _elec_attrs;
+  mfem::Array<int> _coil_domains;
+  mfem::Array<int> _coil_markers;
+  hephaestus::InputParameters _solver_options;
 
-  mfem::Coefficient * sigma_{nullptr};
-  mfem::Coefficient * Itotal_{nullptr};
+  mfem::Coefficient * _sigma{nullptr};
+  mfem::Coefficient * _itotal{nullptr};
 
-  bool owns_sigma_{false};
-  bool owns_Itotal_{false};
+  bool _owns_sigma{false};
+  bool _owns_itotal{false};
 
   // Names
-  std::string grad_phi_name_;
-  std::string V_gf_name_;
-  std::string I_coef_name_;
-  std::string cond_coef_name_;
+  std::string _grad_phi_name;
+  std::string _v_gf_name;
+  std::string _i_coef_name;
+  std::string _cond_coef_name;
 
   // Parent mesh, FE space, and current
-  mfem::ParMesh * mesh_parent_{nullptr};
+  mfem::ParMesh * _mesh_parent{nullptr};
 
-  mfem::ParGridFunction * grad_phi_parent_{nullptr};
-  std::unique_ptr<mfem::ParGridFunction> grad_phi_t_parent_{nullptr};
+  mfem::ParGridFunction * _grad_phi_parent{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _grad_phi_t_parent{nullptr};
 
-  mfem::ParGridFunction * V_parent_{nullptr};
-  std::unique_ptr<mfem::ParGridFunction> Vt_parent_{nullptr};
+  mfem::ParGridFunction * _v_parent{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _vt_parent{nullptr};
 
   // Child mesh and FE spaces
-  std::unique_ptr<mfem::ParSubMesh> mesh_{nullptr};
+  std::unique_ptr<mfem::ParSubMesh> _mesh{nullptr};
 
-  std::unique_ptr<mfem::ParFiniteElementSpace> H1FESpace_{nullptr};
-  std::unique_ptr<mfem::H1_FECollection> H1FESpace_fec_{nullptr};
+  std::unique_ptr<mfem::ParFiniteElementSpace> _h1_fe_space{nullptr};
+  std::unique_ptr<mfem::H1_FECollection> _h1_fe_space_fec{nullptr};
 
-  std::unique_ptr<mfem::ParFiniteElementSpace> HCurlFESpace_{nullptr};
-  std::unique_ptr<mfem::ND_FECollection> HCurlFESpace_fec{nullptr};
+  std::unique_ptr<mfem::ParFiniteElementSpace> _h_curl_fe_space{nullptr};
+  std::unique_ptr<mfem::ND_FECollection> _h_curl_fe_space_fec{nullptr};
 
   // Child GridFunctions
-  std::unique_ptr<mfem::ParGridFunction> grad_phi_{nullptr};
-  std::unique_ptr<mfem::ParGridFunction> V_{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _grad_phi{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _v{nullptr};
 
   // Child boundary condition objects
-  mfem::FunctionCoefficient high_src_;
-  mfem::FunctionCoefficient low_src_;
+  mfem::FunctionCoefficient _high_src;
+  mfem::FunctionCoefficient _low_src;
 
-  mfem::Array<int> high_terminal_;
-  mfem::Array<int> low_terminal_;
+  mfem::Array<int> _high_terminal;
+  mfem::Array<int> _low_terminal;
 
   // Mass Matrix
-  std::unique_ptr<mfem::ParBilinearForm> m1_{nullptr};
+  std::unique_ptr<mfem::ParBilinearForm> _m1{nullptr};
 
   // BC Map
-  hephaestus::BCMap bc_maps;
+  hephaestus::BCMap _bc_maps;
 
   // Final LinearForm
-  std::unique_ptr<mfem::ParLinearForm> final_lf_{nullptr};
+  std::unique_ptr<mfem::ParLinearForm> _final_lf{nullptr};
 };
 
 } // namespace hephaestus

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -46,17 +46,17 @@ public:
   void SubtractSource(mfem::ParGridFunction * gf) override;
 
   // Initialises the child submesh.
-  void initChildMesh();
+  void InitChildMesh();
 
   // Creates the relevant FE Collections and Spaces for the child submesh.
-  void makeFESpaces();
+  void MakeFESpaces();
 
   // Creates the relevant GridFunctions for the child submesh.
-  void makeGridFunctions();
+  void MakeGridFunctions();
 
   // Sets up the boundary conditions to be used in the ScalarPotentialSource.
   // calculation.
-  void setBCs();
+  void SetBCs();
 
   // Solves for the divergence-free Hodge dual of the electric current based on
   // Dirichlet BCs.
@@ -64,11 +64,11 @@ public:
 
   // Creates a mass matrix with basis functions that will be used in the Apply()
   // method
-  void buildM1();
+  void BuildM1();
 
   // Sets the boundary attribute for the face to be used as reference in flux
   // calculation
-  void setRefFace(const int face);
+  void SetRefFace(const int face);
 
 private:
   // Parameters

--- a/src/sources/scalar_potential_source.cpp
+++ b/src/sources/scalar_potential_source.cpp
@@ -106,18 +106,18 @@ ScalarPotentialSource::Apply(mfem::ParLinearForm * lf)
   // a0(p_{n+1}, p') = b0(p')
   // a0(p, p') = (β ∇ p, ∇ p')
   // b0(p') = <n.s0, p'>
-  mfem::ParGridFunction Phi_gf(H1FESpace_);
+  mfem::ParGridFunction phi_gf(H1FESpace_);
   mfem::Array<int> poisson_ess_tdof_list;
-  Phi_gf = 0.0;
+  phi_gf = 0.0;
   *b0 = 0.0;
   _bc_map->ApplyEssentialBCs(
-      potential_gf_name, poisson_ess_tdof_list, Phi_gf, (H1FESpace_->GetParMesh()));
+      potential_gf_name, poisson_ess_tdof_list, phi_gf, (H1FESpace_->GetParMesh()));
   _bc_map->ApplyIntegratedBCs(potential_gf_name, *b0, (H1FESpace_->GetParMesh()));
   b0->Assemble();
 
   a0->Update();
   a0->Assemble();
-  a0->FormLinearSystem(poisson_ess_tdof_list, Phi_gf, *b0, *A0, *X0, *B0);
+  a0->FormLinearSystem(poisson_ess_tdof_list, phi_gf, *b0, *A0, *X0, *B0);
 
   if (a0_solver == nullptr)
   {

--- a/src/sources/scalar_potential_source.cpp
+++ b/src/sources/scalar_potential_source.cpp
@@ -7,16 +7,13 @@ namespace hephaestus
 // J0_{n+1} ∈ H(div) source field, where J0 = -β∇p and β is a conductivity
 // coefficient.
 ScalarPotentialSource::ScalarPotentialSource(const hephaestus::InputParameters & params)
-  : grad_phi_name_(params.GetParam<std::string>("GradPotentialName")),
-    potential_gf_name(params.GetParam<std::string>("PotentialName")),
-    hcurl_fespace_name(params.GetParam<std::string>("HCurlFESpaceName")),
-    h1_fespace_name(params.GetParam<std::string>("H1FESpaceName")),
-    beta_coef_name(params.GetParam<std::string>("ConductivityCoefName")),
-    solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
-        "SolverOptions", hephaestus::InputParameters())),
-    grad(nullptr),
-    m1(nullptr),
-    a0_solver(nullptr)
+  : _grad_phi_name(params.GetParam<std::string>("GradPotentialName")),
+    _potential_gf_name(params.GetParam<std::string>("PotentialName")),
+    _hcurl_fespace_name(params.GetParam<std::string>("HCurlFESpaceName")),
+    _h1_fespace_name(params.GetParam<std::string>("H1FESpaceName")),
+    _beta_coef_name(params.GetParam<std::string>("ConductivityCoefName")),
+    _solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
+        "SolverOptions", hephaestus::InputParameters()))
 {
 }
 
@@ -26,55 +23,55 @@ ScalarPotentialSource::Init(hephaestus::GridFunctions & gridfunctions,
                             hephaestus::BCMap & bc_map,
                             hephaestus::Coefficients & coefficients)
 {
-  H1FESpace_ = fespaces.Get(h1_fespace_name);
-  if (H1FESpace_ == nullptr)
+  _h1_fe_space = fespaces.Get(_h1_fespace_name);
+  if (_h1_fe_space == nullptr)
   {
-    const std::string error_message = h1_fespace_name + " not found in fespaces when "
-                                                        "creating ScalarPotentialSource\n";
+    const std::string error_message = _h1_fespace_name + " not found in fespaces when "
+                                                         "creating ScalarPotentialSource\n";
     mfem::mfem_error(error_message.c_str());
   }
 
-  HCurlFESpace_ = fespaces.Get(hcurl_fespace_name);
-  if (HCurlFESpace_ == nullptr)
+  _h_curl_fe_space = fespaces.Get(_hcurl_fespace_name);
+  if (_h_curl_fe_space == nullptr)
   {
-    const std::string error_message = hcurl_fespace_name + " not found in fespaces when "
-                                                           "creating ScalarPotentialSource\n";
+    const std::string error_message = _hcurl_fespace_name + " not found in fespaces when "
+                                                            "creating ScalarPotentialSource\n";
     mfem::mfem_error(error_message.c_str());
   }
 
-  p_ = gridfunctions.Get(potential_gf_name);
-  if (p_ == nullptr)
+  _p = gridfunctions.Get(_potential_gf_name);
+  if (_p == nullptr)
   {
-    std::cout << potential_gf_name + " not found in gridfunctions when "
-                                     "creating ScalarPotentialSource. "
-                                     "Creating new ParGridFunction\n";
-    p_ = new mfem::ParGridFunction(H1FESpace_);
-    gridfunctions.Register(potential_gf_name, p_, true);
+    std::cout << _potential_gf_name + " not found in gridfunctions when "
+                                      "creating ScalarPotentialSource. "
+                                      "Creating new ParGridFunction\n";
+    _p = new mfem::ParGridFunction(_h1_fe_space);
+    gridfunctions.Register(_potential_gf_name, _p, true);
   }
 
-  grad_p_ = gridfunctions.Get(grad_phi_name_);
-  if (grad_p_ == nullptr)
+  _grad_p = gridfunctions.Get(_grad_phi_name);
+  if (_grad_p == nullptr)
   {
-    grad_p_ = new mfem::ParGridFunction(HCurlFESpace_);
-    gridfunctions.Register(grad_phi_name_, grad_p_, true);
+    _grad_p = new mfem::ParGridFunction(_h_curl_fe_space);
+    gridfunctions.Register(_grad_phi_name, _grad_p, true);
   }
 
   _bc_map = &bc_map;
 
-  betaCoef = coefficients.scalars.Get(beta_coef_name);
+  _beta_coef = coefficients._scalars.Get(_beta_coef_name);
 
-  a0 = std::make_unique<mfem::ParBilinearForm>(H1FESpace_);
-  a0->AddDomainIntegrator(new mfem::DiffusionIntegrator(*betaCoef));
-  a0->Assemble();
+  _a0 = std::make_unique<mfem::ParBilinearForm>(_h1_fe_space);
+  _a0->AddDomainIntegrator(new mfem::DiffusionIntegrator(*_beta_coef));
+  _a0->Assemble();
 
   BuildGrad();
-  BuildM1(betaCoef);
+  BuildM1(_beta_coef);
   // a0(p, p') = (β ∇ p, ∇ p')
 
-  b0 = std::make_unique<mfem::ParLinearForm>(H1FESpace_);
-  A0 = std::make_unique<mfem::HypreParMatrix>();
-  X0 = std::make_unique<mfem::Vector>();
-  B0 = std::make_unique<mfem::Vector>();
+  _b0 = std::make_unique<mfem::ParLinearForm>(_h1_fe_space);
+  _diffusion_mat = std::make_unique<mfem::HypreParMatrix>();
+  _p_tdofs = std::make_unique<mfem::Vector>();
+  _b0_tdofs = std::make_unique<mfem::Vector>();
 }
 
 ScalarPotentialSource::~ScalarPotentialSource() = default;
@@ -82,9 +79,9 @@ ScalarPotentialSource::~ScalarPotentialSource() = default;
 void
 ScalarPotentialSource::BuildM1(mfem::Coefficient * Sigma)
 {
-  m1 = std::make_unique<mfem::ParBilinearForm>(HCurlFESpace_);
-  m1->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*Sigma));
-  m1->Assemble();
+  _m1 = std::make_unique<mfem::ParBilinearForm>(_h_curl_fe_space);
+  _m1->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*Sigma));
+  _m1->Assemble();
 
   // Don't finalize or parallel assemble this is done in FormLinearSystem.
 }
@@ -92,9 +89,9 @@ ScalarPotentialSource::BuildM1(mfem::Coefficient * Sigma)
 void
 ScalarPotentialSource::BuildGrad()
 {
-  grad = std::make_unique<mfem::ParDiscreteLinearOperator>(H1FESpace_, HCurlFESpace_);
-  grad->AddDomainInterpolator(new mfem::GradientInterpolator());
-  grad->Assemble();
+  _grad = std::make_unique<mfem::ParDiscreteLinearOperator>(_h1_fe_space, _h_curl_fe_space);
+  _grad->AddDomainInterpolator(new mfem::GradientInterpolator());
+  _grad->Assemble();
 
   // no ParallelAssemble since this will be applied to GridFunctions
 }
@@ -106,40 +103,41 @@ ScalarPotentialSource::Apply(mfem::ParLinearForm * lf)
   // a0(p_{n+1}, p') = b0(p')
   // a0(p, p') = (β ∇ p, ∇ p')
   // b0(p') = <n.s0, p'>
-  mfem::ParGridFunction phi_gf(H1FESpace_);
+  mfem::ParGridFunction phi_gf(_h1_fe_space);
   mfem::Array<int> poisson_ess_tdof_list;
   phi_gf = 0.0;
-  *b0 = 0.0;
+  *_b0 = 0.0;
   _bc_map->ApplyEssentialBCs(
-      potential_gf_name, poisson_ess_tdof_list, phi_gf, (H1FESpace_->GetParMesh()));
-  _bc_map->ApplyIntegratedBCs(potential_gf_name, *b0, (H1FESpace_->GetParMesh()));
-  b0->Assemble();
+      _potential_gf_name, poisson_ess_tdof_list, phi_gf, (_h1_fe_space->GetParMesh()));
+  _bc_map->ApplyIntegratedBCs(_potential_gf_name, *_b0, (_h1_fe_space->GetParMesh()));
+  _b0->Assemble();
 
-  a0->Update();
-  a0->Assemble();
-  a0->FormLinearSystem(poisson_ess_tdof_list, phi_gf, *b0, *A0, *X0, *B0);
+  _a0->Update();
+  _a0->Assemble();
+  _a0->FormLinearSystem(
+      poisson_ess_tdof_list, phi_gf, *_b0, *_diffusion_mat, *_p_tdofs, *_b0_tdofs);
 
-  if (a0_solver == nullptr)
+  if (_a0_solver == nullptr)
   {
-    a0_solver = std::make_unique<hephaestus::DefaultH1PCGSolver>(solver_options, *A0);
+    _a0_solver = std::make_unique<hephaestus::DefaultH1PCGSolver>(_solver_options, *_diffusion_mat);
   }
   // Solve
-  a0_solver->Mult(*B0, *X0);
+  _a0_solver->Mult(*_b0_tdofs, *_p_tdofs);
 
   // "undo" the static condensation saving result in grid function dP
-  a0->RecoverFEMSolution(*X0, *b0, *p_);
+  _a0->RecoverFEMSolution(*_p_tdofs, *_b0, *_p);
 
-  grad->Mult(*p_, *grad_p_);
+  _grad->Mult(*_p, *_grad_p);
 
-  m1->Update();
-  m1->Assemble();
-  m1->AddMult(*grad_p_, *lf, 1.0);
+  _m1->Update();
+  _m1->Assemble();
+  _m1->AddMult(*_grad_p, *lf, 1.0);
 }
 
 void
 ScalarPotentialSource::SubtractSource(mfem::ParGridFunction * gf)
 {
-  grad->AddMult(*p_, *gf, -1.0);
+  _grad->AddMult(*_p, *gf, -1.0);
 }
 
 } // namespace hephaestus

--- a/src/sources/scalar_potential_source.cpp
+++ b/src/sources/scalar_potential_source.cpp
@@ -67,8 +67,8 @@ ScalarPotentialSource::Init(hephaestus::GridFunctions & gridfunctions,
   a0->AddDomainIntegrator(new mfem::DiffusionIntegrator(*betaCoef));
   a0->Assemble();
 
-  buildGrad();
-  buildM1(betaCoef);
+  BuildGrad();
+  BuildM1(betaCoef);
   // a0(p, p') = (β ∇ p, ∇ p')
 
   b0 = std::make_unique<mfem::ParLinearForm>(H1FESpace_);
@@ -80,7 +80,7 @@ ScalarPotentialSource::Init(hephaestus::GridFunctions & gridfunctions,
 ScalarPotentialSource::~ScalarPotentialSource() = default;
 
 void
-ScalarPotentialSource::buildM1(mfem::Coefficient * Sigma)
+ScalarPotentialSource::BuildM1(mfem::Coefficient * Sigma)
 {
   m1 = std::make_unique<mfem::ParBilinearForm>(HCurlFESpace_);
   m1->AddDomainIntegrator(new mfem::VectorFEMassIntegrator(*Sigma));
@@ -90,7 +90,7 @@ ScalarPotentialSource::buildM1(mfem::Coefficient * Sigma)
 }
 
 void
-ScalarPotentialSource::buildGrad()
+ScalarPotentialSource::BuildGrad()
 {
   grad = std::make_unique<mfem::ParDiscreteLinearOperator>(H1FESpace_, HCurlFESpace_);
   grad->AddDomainInterpolator(new mfem::GradientInterpolator());
@@ -110,9 +110,9 @@ ScalarPotentialSource::Apply(mfem::ParLinearForm * lf)
   mfem::Array<int> poisson_ess_tdof_list;
   Phi_gf = 0.0;
   *b0 = 0.0;
-  _bc_map->applyEssentialBCs(
+  _bc_map->ApplyEssentialBCs(
       potential_gf_name, poisson_ess_tdof_list, Phi_gf, (H1FESpace_->GetParMesh()));
-  _bc_map->applyIntegratedBCs(potential_gf_name, *b0, (H1FESpace_->GetParMesh()));
+  _bc_map->ApplyIntegratedBCs(potential_gf_name, *b0, (H1FESpace_->GetParMesh()));
   b0->Assemble();
 
   a0->Update();

--- a/src/sources/scalar_potential_source.hpp
+++ b/src/sources/scalar_potential_source.hpp
@@ -24,49 +24,45 @@ public:
   void BuildWeakDiv();
   void BuildGrad();
 
-  std::string grad_phi_name_;
-  std::string src_coef_name;
-  std::string potential_gf_name;
-  std::string hcurl_fespace_name;
-  std::string h1_fespace_name;
-  std::string beta_coef_name;
+  std::string _grad_phi_name;
+  std::string _src_coef_name;
+  std::string _potential_gf_name;
+  std::string _hcurl_fespace_name;
+  std::string _h1_fespace_name;
+  std::string _beta_coef_name;
 
-  const hephaestus::InputParameters solver_options;
+  const hephaestus::InputParameters _solver_options;
 
-  mfem::ParFiniteElementSpace * H1FESpace_;
-  mfem::ParFiniteElementSpace * HCurlFESpace_;
-  mfem::ParGridFunction * p_; // Potential
+  mfem::ParFiniteElementSpace * _h1_fe_space;
+  mfem::ParFiniteElementSpace * _h_curl_fe_space;
+  mfem::ParGridFunction * _p; // Potential
   hephaestus::BCMap * _bc_map;
-  mfem::Coefficient * betaCoef;
+  mfem::Coefficient * _beta_coef;
 
-  std::unique_ptr<mfem::ParBilinearForm> a0{nullptr};
-  mfem::ParBilinearForm * s0_;
+  std::unique_ptr<mfem::ParBilinearForm> _a0{nullptr};
 
-  std::unique_ptr<mfem::ParBilinearForm> m1{nullptr};
+  std::unique_ptr<mfem::ParBilinearForm> _m1{nullptr};
 
-  mfem::ParBilinearForm * h_curl_mass;
-  mfem::ParMixedBilinearForm * weakDiv_;
+  mfem::ParBilinearForm * _h_curl_mass;
+  mfem::ParMixedBilinearForm * _weak_div;
 
-  std::unique_ptr<mfem::ParDiscreteLinearOperator> grad{nullptr};
-  mfem::ParDiscreteLinearOperator * grad_;
+  std::unique_ptr<mfem::ParDiscreteLinearOperator> _grad{nullptr};
 
-  std::unique_ptr<mfem::HypreParMatrix> A0{nullptr};
-  mfem::HypreParMatrix * S0_;
+  std::unique_ptr<mfem::HypreParMatrix> _diffusion_mat{nullptr};
+  std::unique_ptr<mfem::Vector> _p_tdofs{nullptr};
+  std::unique_ptr<mfem::Vector> _b0_tdofs{nullptr};
 
-  std::unique_ptr<mfem::Vector> X0{nullptr};
-  std::unique_ptr<mfem::Vector> B0{nullptr};
+  mutable mfem::HypreSolver * _amg_a0;
+  mutable std::unique_ptr<hephaestus::DefaultH1PCGSolver> _a0_solver{nullptr};
 
-  mutable mfem::HypreSolver * amg_a0;
-  mutable std::unique_ptr<hephaestus::DefaultH1PCGSolver> a0_solver{nullptr};
+  std::unique_ptr<mfem::ParLinearForm> _b0{nullptr};
+  mfem::ParGridFunction *_grad_p, *_x_div;
 
-  std::unique_ptr<mfem::ParLinearForm> b0{nullptr};
-  mfem::ParGridFunction *grad_p_, *xDiv_;
+  mfem::VectorCoefficient * _source_vec_coef;
+  mfem::ParGridFunction * _div_free_src_gf; // Source field
 
-  mfem::VectorCoefficient * sourceVecCoef;
-  mfem::ParGridFunction * div_free_src_gf; // Source field
-
-  mfem::Solver * solver;
-  int irOrder, geom;
+  mfem::Solver * _solver;
+  int _ir_order, _geom;
 };
 
 }; // namespace hephaestus

--- a/src/sources/scalar_potential_source.hpp
+++ b/src/sources/scalar_potential_source.hpp
@@ -18,11 +18,11 @@ public:
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParLinearForm * lf) override;
   void SubtractSource(mfem::ParGridFunction * gf) override;
-  void buildH1Diffusion(mfem::Coefficient * Sigma);
-  void buildM1(mfem::Coefficient * Sigma);
-  void buildHCurlMass();
-  void buildWeakDiv();
-  void buildGrad();
+  void BuildH1Diffusion(mfem::Coefficient * Sigma);
+  void BuildM1(mfem::Coefficient * Sigma);
+  void BuildHCurlMass();
+  void BuildWeakDiv();
+  void BuildGrad();
 
   std::string grad_phi_name_;
   std::string src_coef_name;

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -50,15 +50,15 @@ protected:
   hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain wire("wire", 1);
-    wire.scalar_coefficients.Register(
+    wire._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
     hephaestus::Subdomain air("air", 2);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::FunctionCoefficient(MuExpr), true);
 
     hephaestus::BCMap bc_map;
@@ -68,10 +68,10 @@ protected:
                                                       mfem::Array<int>({1, 2, 3}),
                                                       adot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dAdt", adot_vec_coef, true);
+    coefficients._vectors.Register("surface_tangential_dAdt", adot_vec_coef, true);
 
     auto * a_exact = new mfem::VectorFunctionCoefficient(3, AExactExpr);
-    coefficients.vectors.Register("a_exact_coeff", a_exact, true);
+    coefficients._vectors.Register("a_exact_coeff", a_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
 
@@ -93,7 +93,7 @@ protected:
 
     hephaestus::Sources sources;
     auto * j_src_coef = new mfem::VectorFunctionCoefficient(3, SourceField);
-    coefficients.vectors.Register("source", j_src_coef, true);
+    coefficients._vectors.Register("source", j_src_coef, true);
     hephaestus::InputParameters div_free_source_params;
     div_free_source_params.SetParam("SourceName", std::string("source"));
     div_free_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));
@@ -189,12 +189,12 @@ TEST_CASE_METHOD(TestAFormSource, "TestAForm", "[CheckRun]")
           params.GetParam<hephaestus::AuxSolvers>("PostProcessors").Get("L2ErrorPostprocessor")));
 
   double r;
-  for (std::size_t i = 1; i < l2errpostprocessor.ndofs.Size(); ++i)
+  for (std::size_t i = 1; i < l2errpostprocessor._ndofs.Size(); ++i)
   {
-    r = EstimateConvergenceRate(l2errpostprocessor.ndofs[i],
-                                l2errpostprocessor.ndofs[i - 1],
-                                l2errpostprocessor.l2_errs[i],
-                                l2errpostprocessor.l2_errs[i - 1],
+    r = EstimateConvergenceRate(l2errpostprocessor._ndofs[i],
+                                l2errpostprocessor._ndofs[i - 1],
+                                l2errpostprocessor._l2_errs[i],
+                                l2errpostprocessor._l2_errs[i - 1],
                                 3);
     std::cout << r << std::endl;
     REQUIRE(r > 2 - 0.15);

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -62,16 +62,16 @@ protected:
         "magnetic_permeability", new mfem::FunctionCoefficient(MuExpr), true);
 
     hephaestus::BCMap bc_map;
-    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, AdotBC);
+    auto * adot_vec_coef = new mfem::VectorFunctionCoefficient(3, AdotBC);
     bc_map.Register("tangential_dAdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_vector_potential_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
-                                                      adotVecCoef),
+                                                      adot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dAdt", adotVecCoef, true);
+    coefficients.vectors.Register("surface_tangential_dAdt", adot_vec_coef, true);
 
-    auto * A_exact = new mfem::VectorFunctionCoefficient(3, AExactExpr);
-    coefficients.vectors.Register("a_exact_coeff", A_exact, true);
+    auto * a_exact = new mfem::VectorFunctionCoefficient(3, AExactExpr);
+    coefficients.vectors.Register("a_exact_coeff", a_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
 
@@ -92,8 +92,8 @@ protected:
     postprocessors.Register("VectorCoefficientAux", vec_coef_aux, true);
 
     hephaestus::Sources sources;
-    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, SourceField);
-    coefficients.vectors.Register("source", JSrcCoef, true);
+    auto * j_src_coef = new mfem::VectorFunctionCoefficient(3, SourceField);
+    coefficients.vectors.Register("source", j_src_coef, true);
     hephaestus::InputParameters div_free_source_params;
     div_free_source_params.SetParam("SourceName", std::string("source"));
     div_free_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -7,36 +7,36 @@ extern const char * DATA_DIR;
 class TestAFormSource
 {
 protected:
-  static double estimate_convergence_rate(
+  static double EstimateConvergenceRate(
       HYPRE_BigInt n_i, HYPRE_BigInt n_imo, double error_i, double error_imo, int dim)
   {
     return std::log(error_i / error_imo) /
            std::log(std::pow(n_imo / static_cast<double>(n_i), 1.0 / dim));
   }
 
-  static double potential_ground(const mfem::Vector & x, double t) { return 0.0; }
+  static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
 
-  static void adot_bc(const mfem::Vector & x, double t, mfem::Vector & A)
+  static void AdotBC(const mfem::Vector & x, double t, mfem::Vector & A)
   {
     A(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI);
     A(1) = 0;
     A(2) = 0;
   }
 
-  static void A_exact_expr(const mfem::Vector & x, double t, mfem::Vector & A_exact)
+  static void AExactExpr(const mfem::Vector & x, double t, mfem::Vector & A_exact)
   {
     A_exact(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI) * t;
     A_exact(1) = 0;
     A_exact(2) = 0;
   }
-  static double mu_expr(const mfem::Vector & x)
+  static double MuExpr(const mfem::Vector & x)
   {
     double variation_scale = 0.5;
     double mu = 1.0 / (1.0 + variation_scale * cos(M_PI * x(0)) * cos(M_PI * x(1)));
     return mu;
   }
   // Source field
-  static void source_field(const mfem::Vector & x, double t, mfem::Vector & f)
+  static void SourceField(const mfem::Vector & x, double t, mfem::Vector & f)
   {
     double variation_scale = 0.5;
     f(0) = t * M_PI * M_PI * sin(M_PI * x(1)) * sin(M_PI * x(2)) *
@@ -47,7 +47,7 @@ protected:
     f(2) = -0.5 * variation_scale * M_PI * M_PI * t * sin(M_PI * x(0)) * sin(2 * M_PI * x(1)) *
            cos(M_PI * x(2));
   }
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain wire("wire", 1);
     wire.scalar_coefficients.Register(
@@ -59,10 +59,10 @@ protected:
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
     coefficients.scalars.Register(
-        "magnetic_permeability", new mfem::FunctionCoefficient(mu_expr), true);
+        "magnetic_permeability", new mfem::FunctionCoefficient(MuExpr), true);
 
     hephaestus::BCMap bc_map;
-    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, adot_bc);
+    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, AdotBC);
     bc_map.Register("tangential_dAdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_vector_potential_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -70,7 +70,7 @@ protected:
                     true);
     coefficients.vectors.Register("surface_tangential_dAdt", adotVecCoef, true);
 
-    auto * A_exact = new mfem::VectorFunctionCoefficient(3, A_exact_expr);
+    auto * A_exact = new mfem::VectorFunctionCoefficient(3, AExactExpr);
     coefficients.vectors.Register("a_exact_coeff", A_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
@@ -92,7 +92,7 @@ protected:
     postprocessors.Register("VectorCoefficientAux", vec_coef_aux, true);
 
     hephaestus::Sources sources;
-    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, source_field);
+    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, SourceField);
     coefficients.vectors.Register("source", JSrcCoef, true);
     hephaestus::InputParameters div_free_source_params;
     div_free_source_params.SetParam("SourceName", std::string("source"));
@@ -126,7 +126,7 @@ protected:
 
 TEST_CASE_METHOD(TestAFormSource, "TestAForm", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
   auto unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
 
   int num_conv_refinements = 3;
@@ -191,11 +191,11 @@ TEST_CASE_METHOD(TestAFormSource, "TestAForm", "[CheckRun]")
   double r;
   for (std::size_t i = 1; i < l2errpostprocessor.ndofs.Size(); ++i)
   {
-    r = estimate_convergence_rate(l2errpostprocessor.ndofs[i],
-                                  l2errpostprocessor.ndofs[i - 1],
-                                  l2errpostprocessor.l2_errs[i],
-                                  l2errpostprocessor.l2_errs[i - 1],
-                                  3);
+    r = EstimateConvergenceRate(l2errpostprocessor.ndofs[i],
+                                l2errpostprocessor.ndofs[i - 1],
+                                l2errpostprocessor.l2_errs[i],
+                                l2errpostprocessor.l2_errs[i - 1],
+                                3);
     std::cout << r << std::endl;
     REQUIRE(r > 2 - 0.15);
     REQUIRE(r < 2 + 1.0);

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -26,16 +26,16 @@ protected:
     sigma_air = 1.0e-6 * sigma;
 
     hephaestus::Subdomain wire("wire", 1);
-    wire.scalar_coefficients.Register(
+    wire._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(sigma), true);
 
     hephaestus::Subdomain air("air", 2);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
     hephaestus::BCMap bc_map;
@@ -45,7 +45,7 @@ protected:
                                                       mfem::Array<int>({1, 2, 3}),
                                                       adot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dAdt", adot_vec_coef, true);
+    coefficients._vectors.Register("surface_tangential_dAdt", adot_vec_coef, true);
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -6,18 +6,18 @@ extern const char * DATA_DIR;
 class TestAVFormRod
 {
 protected:
-  static double potential_high(const mfem::Vector & x, double t)
+  static double PotentialHigh(const mfem::Vector & x, double t)
   {
     double wj_(2.0 * M_PI / 60.0);
     return 2 * cos(wj_ * t);
   }
-  static double potential_ground(const mfem::Vector & x, double t) { return 0.0; }
+  static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
 
-  static void adot_bc(const mfem::Vector & x, double t, mfem::Vector & dAdt) { dAdt = 0.0; }
+  static void AdotBc(const mfem::Vector & x, double t, mfem::Vector & dAdt) { dAdt = 0.0; }
 
-  static void source_current(const mfem::Vector & x, double t, mfem::Vector & J) { J = 0.0; }
+  static void SourceCurrent(const mfem::Vector & x, double t, mfem::Vector & J) { J = 0.0; }
 
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     double sigma = 2.0 * M_PI * 10;
 
@@ -39,7 +39,7 @@ protected:
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
     hephaestus::BCMap bc_map;
-    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, adot_bc);
+    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, AdotBc);
     bc_map.Register("tangential_dAdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_vector_potential_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -49,12 +49,11 @@ protected:
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
-    bc_map.Register(
-        "high_potential",
-        new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
-                                          high_terminal,
-                                          new mfem::FunctionCoefficient(potential_high)),
-        true);
+    bc_map.Register("high_potential",
+                    new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
+                                                      high_terminal,
+                                                      new mfem::FunctionCoefficient(PotentialHigh)),
+                    true);
 
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;
@@ -62,10 +61,10 @@ protected:
         "ground_potential",
         new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
                                           ground_terminal,
-                                          new mfem::FunctionCoefficient(potential_ground)),
+                                          new mfem::FunctionCoefficient(PotentialGround)),
         true);
 
-    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, source_current);
+    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, SourceCurrent);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(), 1, 1);
 
@@ -97,7 +96,7 @@ protected:
 
 TEST_CASE_METHOD(TestAVFormRod, "TestAVFormRod", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 

--- a/test/integration/test_avform_rod.cpp
+++ b/test/integration/test_avform_rod.cpp
@@ -8,8 +8,8 @@ class TestAVFormRod
 protected:
   static double PotentialHigh(const mfem::Vector & x, double t)
   {
-    double wj_(2.0 * M_PI / 60.0);
-    return 2 * cos(wj_ * t);
+    double wj(2.0 * M_PI / 60.0);
+    return 2 * cos(wj * t);
   }
   static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
 
@@ -21,9 +21,9 @@ protected:
   {
     double sigma = 2.0 * M_PI * 10;
 
-    double sigmaAir;
+    double sigma_air;
 
-    sigmaAir = 1.0e-6 * sigma;
+    sigma_air = 1.0e-6 * sigma;
 
     hephaestus::Subdomain wire("wire", 1);
     wire.scalar_coefficients.Register(
@@ -31,7 +31,7 @@ protected:
 
     hephaestus::Subdomain air("air", 2);
     air.scalar_coefficients.Register(
-        "electrical_conductivity", new mfem::ConstantCoefficient(sigmaAir), true);
+        "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
@@ -39,13 +39,13 @@ protected:
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
     hephaestus::BCMap bc_map;
-    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, AdotBc);
+    auto * adot_vec_coef = new mfem::VectorFunctionCoefficient(3, AdotBc);
     bc_map.Register("tangential_dAdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_vector_potential_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
-                                                      adotVecCoef),
+                                                      adot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dAdt", adotVecCoef, true);
+    coefficients.vectors.Register("surface_tangential_dAdt", adot_vec_coef, true);
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
@@ -64,7 +64,7 @@ protected:
                                           new mfem::FunctionCoefficient(PotentialGround)),
         true);
 
-    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, SourceCurrent);
+    auto * j_src_coef = new mfem::VectorFunctionCoefficient(3, SourceCurrent);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(), 1, 1);
 

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -59,13 +59,13 @@ protected:
         "magnetic_permeability", new mfem::FunctionCoefficient(MuExpr), true);
 
     hephaestus::BCMap bc_map;
-    auto * adotVecCoef = new mfem::VectorFunctionCoefficient(3, AdotBC);
+    auto * adot_vec_coef = new mfem::VectorFunctionCoefficient(3, AdotBC);
     bc_map.Register("tangential_dAdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_vector_potential_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
-                                                      adotVecCoef),
+                                                      adot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dAdt", adotVecCoef, true);
+    coefficients.vectors.Register("surface_tangential_dAdt", adot_vec_coef, true);
     coefficients.scalars.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
 
@@ -79,8 +79,8 @@ protected:
                     true);
     coefficients.scalars.Register("ground_potential", ground_coeff, true);
 
-    auto * A_exact = new mfem::VectorFunctionCoefficient(3, AExactExpr);
-    coefficients.vectors.Register("a_exact_coeff", A_exact, true);
+    auto * a_exact = new mfem::VectorFunctionCoefficient(3, AExactExpr);
+    coefficients.vectors.Register("a_exact_coeff", a_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
 
@@ -103,8 +103,8 @@ protected:
     hephaestus::AuxSolvers preprocessors;
 
     hephaestus::Sources sources;
-    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, SourceField);
-    coefficients.vectors.Register("source", JSrcCoef, true);
+    auto * j_src_coef = new mfem::VectorFunctionCoefficient(3, SourceField);
+    coefficients.vectors.Register("source", j_src_coef, true);
     hephaestus::InputParameters div_free_source_params;
     div_free_source_params.SetParam("SourceName", std::string("source"));
     div_free_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -7,7 +7,7 @@ extern const char * DATA_DIR;
 class TestAVFormSource
 {
 protected:
-  const int var_order{2};
+  const int _var_order{2};
   static double EstimateConvergenceRate(
       HYPRE_BigInt n_i, HYPRE_BigInt n_imo, double error_i, double error_imo, int dim)
   {
@@ -47,15 +47,15 @@ protected:
   hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain wire("wire", 1);
-    wire.scalar_coefficients.Register(
+    wire._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
     hephaestus::Subdomain air("air", 2);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::FunctionCoefficient(MuExpr), true);
 
     hephaestus::BCMap bc_map;
@@ -65,8 +65,8 @@ protected:
                                                       mfem::Array<int>({1, 2, 3}),
                                                       adot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dAdt", adot_vec_coef, true);
-    coefficients.scalars.Register(
+    coefficients._vectors.Register("surface_tangential_dAdt", adot_vec_coef, true);
+    coefficients._scalars.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
 
     mfem::Array<int> ground_terminal(1);
@@ -77,10 +77,10 @@ protected:
                                                       mfem::Array<int>({1, 2, 3}),
                                                       ground_coeff),
                     true);
-    coefficients.scalars.Register("ground_potential", ground_coeff, true);
+    coefficients._scalars.Register("ground_potential", ground_coeff, true);
 
     auto * a_exact = new mfem::VectorFunctionCoefficient(3, AExactExpr);
-    coefficients.vectors.Register("a_exact_coeff", a_exact, true);
+    coefficients._vectors.Register("a_exact_coeff", a_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
 
@@ -104,7 +104,7 @@ protected:
 
     hephaestus::Sources sources;
     auto * j_src_coef = new mfem::VectorFunctionCoefficient(3, SourceField);
-    coefficients.vectors.Register("source", j_src_coef, true);
+    coefficients._vectors.Register("source", j_src_coef, true);
     hephaestus::InputParameters div_free_source_params;
     div_free_source_params.SetParam("SourceName", std::string("source"));
     div_free_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));
@@ -200,15 +200,15 @@ TEST_CASE_METHOD(TestAVFormSource, "TestAVFormSource", "[CheckRun]")
           params.GetParam<hephaestus::AuxSolvers>("PostProcessors").Get("L2ErrorPostprocessor")));
 
   double r;
-  for (std::size_t i = 1; i < l2errpostprocessor.ndofs.Size(); ++i)
+  for (std::size_t i = 1; i < l2errpostprocessor._ndofs.Size(); ++i)
   {
-    r = EstimateConvergenceRate(l2errpostprocessor.ndofs[i],
-                                l2errpostprocessor.ndofs[i - 1],
-                                l2errpostprocessor.l2_errs[i],
-                                l2errpostprocessor.l2_errs[i - 1],
+    r = EstimateConvergenceRate(l2errpostprocessor._ndofs[i],
+                                l2errpostprocessor._ndofs[i - 1],
+                                l2errpostprocessor._l2_errs[i],
+                                l2errpostprocessor._l2_errs[i - 1],
                                 3);
     std::cout << r << std::endl;
-    REQUIRE(r > var_order - 0.15);
-    REQUIRE(r < var_order + 1.0);
+    REQUIRE(r > _var_order - 0.15);
+    REQUIRE(r < _var_order + 1.0);
   }
 }

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -33,19 +33,19 @@ protected:
     sigma_air = 1.0e-6 * sigma;
 
     hephaestus::Subdomain wire("wire", 1);
-    wire.scalar_coefficients.Register(
+    wire._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(sigma), true);
 
     hephaestus::Subdomain air("air", 2);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
-    coefficients.scalars.Register("frequency", new mfem::ConstantCoefficient(1.0 / 60.0), true);
-    coefficients.scalars.Register(
+    coefficients._scalars.Register("frequency", new mfem::ConstantCoefficient(1.0 / 60.0), true);
+    coefficients._scalars.Register(
         "dielectric_permittivity", new mfem::ConstantCoefficient(0.0), true);
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
     hephaestus::BCMap bc_map;
@@ -64,7 +64,7 @@ protected:
                     new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal, potential_src),
                     true);
-    coefficients.scalars.Register("source_potential", potential_src, true);
+    coefficients._scalars.Register("source_potential", potential_src, true);
 
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -6,25 +6,25 @@ extern const char * DATA_DIR;
 class TestComplexAFormRod
 {
 protected:
-  static double potential_high(const mfem::Vector & x, double t)
+  static double PotentialHigh(const mfem::Vector & x, double t)
   {
     // double wj_(2.0 * M_PI / 60.0);
     // return 2 * cos(wj_ * t);
     return 2.0;
   }
-  static double potential_ground(const mfem::Vector & x, double t) { return 0.0; }
-  static void a_bc_r(const mfem::Vector & x, mfem::Vector & A)
+  static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
+  static void ABcR(const mfem::Vector & x, mfem::Vector & A)
   {
     A.SetSize(3);
     A = 0.0;
   }
-  static void a_bc_i(const mfem::Vector & x, mfem::Vector & A)
+  static void ABcI(const mfem::Vector & x, mfem::Vector & A)
   {
     A.SetSize(3);
     A = 0.0;
   }
 
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     double sigma = 2.0 * M_PI * 10;
 
@@ -50,17 +50,16 @@ protected:
 
     hephaestus::BCMap bc_map;
 
-    bc_map.Register(
-        "tangential_A",
-        new hephaestus::VectorDirichletBC(std::string("magnetic_vector_potential"),
-                                          mfem::Array<int>({1, 2, 3}),
-                                          new mfem::VectorFunctionCoefficient(3, a_bc_r),
-                                          new mfem::VectorFunctionCoefficient(3, a_bc_i)),
-        true);
+    bc_map.Register("tangential_A",
+                    new hephaestus::VectorDirichletBC(std::string("magnetic_vector_potential"),
+                                                      mfem::Array<int>({1, 2, 3}),
+                                                      new mfem::VectorFunctionCoefficient(3, ABcR),
+                                                      new mfem::VectorFunctionCoefficient(3, ABcI)),
+                    true);
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
-    auto * potential_src = new mfem::FunctionCoefficient(potential_high);
+    auto * potential_src = new mfem::FunctionCoefficient(PotentialHigh);
     bc_map.Register("high_potential",
                     new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal, potential_src),
@@ -73,7 +72,7 @@ protected:
         "ground_potential",
         new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
                                           ground_terminal,
-                                          new mfem::FunctionCoefficient(potential_ground)),
+                                          new mfem::FunctionCoefficient(PotentialGround)),
         true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(), 1, 1);
@@ -125,7 +124,7 @@ protected:
 
 TEST_CASE_METHOD(TestComplexAFormRod, "TestComplexAFormRod", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
@@ -162,19 +161,19 @@ TEST_CASE_METHOD(TestComplexAFormRod, "TestComplexAFormRod", "[CheckRun]")
 
   problem_builder->AddGridFunction("electric_field_real", "HCurl");
   problem_builder->AddGridFunction("electric_field_imag", "HCurl");
-  problem_builder->registerElectricFieldAux("electric_field_real", "electric_field_imag");
+  problem_builder->RegisterElectricFieldAux("electric_field_real", "electric_field_imag");
 
   problem_builder->AddGridFunction("magnetic_flux_density_real", "HDiv");
   problem_builder->AddGridFunction("magnetic_flux_density_imag", "HDiv");
-  problem_builder->registerMagneticFluxDensityAux("magnetic_flux_density_real",
+  problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density_real",
                                                   "magnetic_flux_density_imag");
 
   problem_builder->AddGridFunction("current_density_real", "HDiv");
   problem_builder->AddGridFunction("current_density_imag", "HDiv");
-  problem_builder->registerCurrentDensityAux("current_density_real", "current_density_imag");
+  problem_builder->RegisterCurrentDensityAux("current_density_real", "current_density_imag");
 
   problem_builder->AddGridFunction("joule_heating_density", "Scalar_L2");
-  problem_builder->registerJouleHeatingDensityAux("joule_heating_density",
+  problem_builder->RegisterJouleHeatingDensityAux("joule_heating_density",
                                                   "electric_field_real",
                                                   "electric_field_imag",
                                                   "electrical_conductivity");

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -28,9 +28,9 @@ protected:
   {
     double sigma = 2.0 * M_PI * 10;
 
-    double sigmaAir;
+    double sigma_air;
 
-    sigmaAir = 1.0e-6 * sigma;
+    sigma_air = 1.0e-6 * sigma;
 
     hephaestus::Subdomain wire("wire", 1);
     wire.scalar_coefficients.Register(
@@ -38,7 +38,7 @@ protected:
 
     hephaestus::Subdomain air("air", 2);
     air.scalar_coefficients.Register(
-        "electrical_conductivity", new mfem::ConstantCoefficient(sigmaAir), true);
+        "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -25,8 +25,8 @@ protected:
   inline static const double epsilon0_ = 8.8541878176e-12; // F/m;
   inline static const double mu0_ = 4.0e-7 * M_PI;         // H/m;
   inline static const double freq_ = 900e6;                // 10/2pi
-  double port_length_vector[3] = {24.76e-2, 0.0, 0.0};
-  double port_width_vector[3] = {0.0, 12.38e-2, 0.0};
+  double _port_length_vector[3] = {24.76e-2, 0.0, 0.0};
+  double _port_width_vector[3] = {0.0, 12.38e-2, 0.0};
   //   double port_length_vector[3] = {0.0, 22.86e-3, 0.0};
   //   double port_width_vector[3] = {0.0, 0.0, 10.16e-3};
 
@@ -35,23 +35,23 @@ protected:
     hephaestus::Subdomain mouse("mouse", 1);
     hephaestus::Subdomain air("air", 2);
 
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(0.0), true);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "dielectric_permittivity", new mfem::ConstantCoefficient(epsilon0_), true);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(mu0_), true);
 
-    mouse.scalar_coefficients.Register(
+    mouse._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(0.97), true);
-    mouse.scalar_coefficients.Register(
+    mouse._scalar_coefficients.Register(
         "dielectric_permittivity", new mfem::ConstantCoefficient(43 * epsilon0_), true);
-    mouse.scalar_coefficients.Register(
+    mouse._scalar_coefficients.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(mu0_), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({air, mouse}));
 
-    coefficients.scalars.Register("frequency", new mfem::ConstantCoefficient(freq_), true);
+    coefficients._scalars.Register("frequency", new mfem::ConstantCoefficient(freq_), true);
 
     hephaestus::BCMap bc_map;
     mfem::Array<int> dirichlet_attr({2, 3, 4});
@@ -68,8 +68,8 @@ protected:
                     new hephaestus::RWTE10PortRBC(std::string("electric_field"),
                                                   wgi_in_attr,
                                                   freq_,
-                                                  port_length_vector,
-                                                  port_width_vector,
+                                                  _port_length_vector,
+                                                  _port_width_vector,
                                                   true),
                     true);
 
@@ -79,8 +79,8 @@ protected:
                     new hephaestus::RWTE10PortRBC(std::string("electric_field"),
                                                   wgi_out_attr,
                                                   freq_,
-                                                  port_length_vector,
-                                                  port_width_vector,
+                                                  _port_length_vector,
+                                                  _port_width_vector,
                                                   false),
                     true);
 
@@ -177,9 +177,9 @@ TEST_CASE_METHOD(TestComplexERMESMouse, "TestComplexERMESMouse", "[CheckRun]")
   mfem::VectorConstantCoefficient zero_coef(zero_vec);
 
   double norm_r =
-      executioner->problem->gridfunctions.Get("electric_field_real")->ComputeMaxError(zero_coef);
+      executioner->_problem->_gridfunctions.Get("electric_field_real")->ComputeMaxError(zero_coef);
   double norm_i =
-      executioner->problem->gridfunctions.Get("electric_field_imag")->ComputeMaxError(zero_coef);
+      executioner->_problem->_gridfunctions.Get("electric_field_imag")->ComputeMaxError(zero_coef);
   REQUIRE_THAT(norm_r, Catch::Matchers::WithinAbs(480, 15));
   REQUIRE_THAT(norm_i, Catch::Matchers::WithinAbs(180, 5));
 }

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -172,14 +172,14 @@ TEST_CASE_METHOD(TestComplexERMESMouse, "TestComplexERMESMouse", "[CheckRun]")
 
   executioner->Execute();
 
-  mfem::Vector zeroVec(3);
-  zeroVec = 0.0;
-  mfem::VectorConstantCoefficient zeroCoef(zeroVec);
+  mfem::Vector zero_vec(3);
+  zero_vec = 0.0;
+  mfem::VectorConstantCoefficient zero_coef(zero_vec);
 
   double norm_r =
-      executioner->problem->gridfunctions.Get("electric_field_real")->ComputeMaxError(zeroCoef);
+      executioner->problem->gridfunctions.Get("electric_field_real")->ComputeMaxError(zero_coef);
   double norm_i =
-      executioner->problem->gridfunctions.Get("electric_field_imag")->ComputeMaxError(zeroCoef);
+      executioner->problem->gridfunctions.Get("electric_field_imag")->ComputeMaxError(zero_coef);
   REQUIRE_THAT(norm_r, Catch::Matchers::WithinAbs(480, 15));
   REQUIRE_THAT(norm_i, Catch::Matchers::WithinAbs(180, 5));
 }

--- a/test/integration/test_complex_ermes_mouse.cpp
+++ b/test/integration/test_complex_ermes_mouse.cpp
@@ -10,13 +10,13 @@ extern const char * DATA_DIR;
 class TestComplexERMESMouse
 {
 protected:
-  static void e_bc_r(const mfem::Vector & x, mfem::Vector & E)
+  static void EBcR(const mfem::Vector & x, mfem::Vector & E)
   {
     E.SetSize(3);
     E = 0.0;
   }
 
-  static void e_bc_i(const mfem::Vector & x, mfem::Vector & E)
+  static void EBcI(const mfem::Vector & x, mfem::Vector & E)
   {
     E.SetSize(3);
     E = 0.0;
@@ -30,7 +30,7 @@ protected:
   //   double port_length_vector[3] = {0.0, 22.86e-3, 0.0};
   //   double port_width_vector[3] = {0.0, 0.0, 10.16e-3};
 
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain mouse("mouse", 1);
     hephaestus::Subdomain air("air", 2);
@@ -55,13 +55,12 @@ protected:
 
     hephaestus::BCMap bc_map;
     mfem::Array<int> dirichlet_attr({2, 3, 4});
-    bc_map.Register(
-        "tangential_E",
-        new hephaestus::VectorDirichletBC(std::string("electric_field"),
-                                          dirichlet_attr,
-                                          new mfem::VectorFunctionCoefficient(3, e_bc_r),
-                                          new mfem::VectorFunctionCoefficient(3, e_bc_i)),
-        true);
+    bc_map.Register("tangential_E",
+                    new hephaestus::VectorDirichletBC(std::string("electric_field"),
+                                                      dirichlet_attr,
+                                                      new mfem::VectorFunctionCoefficient(3, EBcR),
+                                                      new mfem::VectorFunctionCoefficient(3, EBcI)),
+                    true);
 
     mfem::Array<int> wgi_in_attr(1);
     wgi_in_attr[0] = 5;
@@ -131,7 +130,7 @@ protected:
 
 TEST_CASE_METHOD(TestComplexERMESMouse, "TestComplexERMESMouse", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -182,14 +182,14 @@ TEST_CASE_METHOD(TestComplexIrisWaveguide, "TestComplexIrisWaveguide", "[CheckRu
 
   executioner->Execute();
 
-  mfem::Vector zeroVec(3);
-  zeroVec = 0.0;
-  mfem::VectorConstantCoefficient zeroCoef(zeroVec);
+  mfem::Vector zero_vec(3);
+  zero_vec = 0.0;
+  mfem::VectorConstantCoefficient zero_coef(zero_vec);
 
   double norm_r =
-      executioner->problem->gridfunctions.Get("electric_field_real")->ComputeMaxError(zeroCoef);
+      executioner->problem->gridfunctions.Get("electric_field_real")->ComputeMaxError(zero_coef);
   double norm_i =
-      executioner->problem->gridfunctions.Get("electric_field_imag")->ComputeMaxError(zeroCoef);
+      executioner->problem->gridfunctions.Get("electric_field_imag")->ComputeMaxError(zero_coef);
   REQUIRE_THAT(norm_r, Catch::Matchers::WithinAbs(4896.771, 0.001));
   REQUIRE_THAT(norm_i, Catch::Matchers::WithinAbs(5357.650, 0.001));
 }

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -22,34 +22,34 @@ protected:
   inline static const double epsilon0_ = 8.8541878176e-12; // F/m;
   inline static const double mu0_ = 4.0e-7 * M_PI;         // H/m;
   inline static const double freq_ = 9.3e9;                // 10/2pi
-  double port_length_vector[3] = {0.0, 22.86e-3, 0.0};
-  double port_width_vector[3] = {0.0, 0.0, 10.16e-3};
+  double _port_length_vector[3] = {0.0, 22.86e-3, 0.0};
+  double _port_width_vector[3] = {0.0, 0.0, 10.16e-3};
 
   hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain air("air", 1);
 
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "real_electrical_conductivity", new mfem::ConstantCoefficient(0.0), true);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "imag_electrical_conductivity", new mfem::ConstantCoefficient(0.0), true);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "real_rel_permittivity", new mfem::ConstantCoefficient(1.0), true);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "imag_rel_permittivity", new mfem::ConstantCoefficient(0.0), true);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "real_rel_permeability", new mfem::ConstantCoefficient(1.0), true);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "imag_rel_permeability", new mfem::ConstantCoefficient(0.0), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({air}));
 
-    coefficients.scalars.Register("frequency", new mfem::ConstantCoefficient(freq_), true);
-    coefficients.scalars.Register(
+    coefficients._scalars.Register("frequency", new mfem::ConstantCoefficient(freq_), true);
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(mu0_), true);
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "dielectric_permittivity", new mfem::ConstantCoefficient(epsilon0_), true);
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(0.0), true);
 
     hephaestus::BCMap bc_map;
@@ -68,8 +68,8 @@ protected:
                     new hephaestus::RWTE10PortRBC(std::string("electric_field"),
                                                   wgi_in_attr,
                                                   freq_,
-                                                  port_length_vector,
-                                                  port_width_vector,
+                                                  _port_length_vector,
+                                                  _port_width_vector,
                                                   true),
                     true);
 
@@ -79,8 +79,8 @@ protected:
                     new hephaestus::RWTE10PortRBC(std::string("electric_field"),
                                                   wgi_out_attr,
                                                   freq_,
-                                                  port_length_vector,
-                                                  port_width_vector,
+                                                  _port_length_vector,
+                                                  _port_width_vector,
                                                   false),
                     true);
 
@@ -187,9 +187,9 @@ TEST_CASE_METHOD(TestComplexIrisWaveguide, "TestComplexIrisWaveguide", "[CheckRu
   mfem::VectorConstantCoefficient zero_coef(zero_vec);
 
   double norm_r =
-      executioner->problem->gridfunctions.Get("electric_field_real")->ComputeMaxError(zero_coef);
+      executioner->_problem->_gridfunctions.Get("electric_field_real")->ComputeMaxError(zero_coef);
   double norm_i =
-      executioner->problem->gridfunctions.Get("electric_field_imag")->ComputeMaxError(zero_coef);
+      executioner->_problem->_gridfunctions.Get("electric_field_imag")->ComputeMaxError(zero_coef);
   REQUIRE_THAT(norm_r, Catch::Matchers::WithinAbs(4896.771, 0.001));
   REQUIRE_THAT(norm_i, Catch::Matchers::WithinAbs(5357.650, 0.001));
 }

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -7,13 +7,13 @@ extern const char * DATA_DIR;
 class TestComplexIrisWaveguide
 {
 protected:
-  static void e_bc_r(const mfem::Vector & x, mfem::Vector & E)
+  static void EBCR(const mfem::Vector & x, mfem::Vector & E)
   {
     E.SetSize(3);
     E = 0.0;
   }
 
-  static void e_bc_i(const mfem::Vector & x, mfem::Vector & E)
+  static void EBCI(const mfem::Vector & x, mfem::Vector & E)
   {
     E.SetSize(3);
     E = 0.0;
@@ -25,7 +25,7 @@ protected:
   double port_length_vector[3] = {0.0, 22.86e-3, 0.0};
   double port_width_vector[3] = {0.0, 0.0, 10.16e-3};
 
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain air("air", 1);
 
@@ -55,13 +55,12 @@ protected:
     hephaestus::BCMap bc_map;
     mfem::Array<int> dirichlet_attr(1);
     dirichlet_attr[0] = 1;
-    bc_map.Register(
-        "tangential_E",
-        new hephaestus::VectorDirichletBC(std::string("electric_field"),
-                                          dirichlet_attr,
-                                          new mfem::VectorFunctionCoefficient(3, e_bc_r),
-                                          new mfem::VectorFunctionCoefficient(3, e_bc_i)),
-        true);
+    bc_map.Register("tangential_E",
+                    new hephaestus::VectorDirichletBC(std::string("electric_field"),
+                                                      dirichlet_attr,
+                                                      new mfem::VectorFunctionCoefficient(3, EBCR),
+                                                      new mfem::VectorFunctionCoefficient(3, EBCI)),
+                    true);
 
     mfem::Array<int> wgi_in_attr(1);
     wgi_in_attr[0] = 2;
@@ -122,7 +121,7 @@ protected:
 
 TEST_CASE_METHOD(TestComplexIrisWaveguide, "TestComplexIrisWaveguide", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
@@ -153,15 +152,15 @@ TEST_CASE_METHOD(TestComplexIrisWaveguide, "TestComplexIrisWaveguide", "[CheckRu
 
   problem_builder->AddGridFunction("magnetic_flux_density_real", "HDiv");
   problem_builder->AddGridFunction("magnetic_flux_density_imag", "HDiv");
-  problem_builder->registerMagneticFluxDensityAux("magnetic_flux_density_real",
+  problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density_real",
                                                   "magnetic_flux_density_imag");
 
   problem_builder->AddGridFunction("current_density_real", "HDiv");
   problem_builder->AddGridFunction("current_density_imag", "HDiv");
-  problem_builder->registerCurrentDensityAux("current_density_real", "current_density_imag");
+  problem_builder->RegisterCurrentDensityAux("current_density_real", "current_density_imag");
 
   problem_builder->AddGridFunction("joule_heating_density", "Scalar_L2");
-  problem_builder->registerJouleHeatingDensityAux("joule_heating_density",
+  problem_builder->RegisterJouleHeatingDensityAux("joule_heating_density",
                                                   "electric_field_real",
                                                   "electric_field_imag",
                                                   "electrical_conductivity");

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -15,15 +15,15 @@ protected:
     double x0(194e-3);  // Coil centre x coordinate
     double y0(100e-3);  // Coil centre y coordinate
     double a(50e-3);    // Coil thickness
-    double I0(2742);    // Coil current in Ampere-turns
-    double S(2.5e-3);   // Coil cross sectional area
+    double i0(2742);    // Coil current in Ampere-turns
+    double s(2.5e-3);   // Coil cross sectional area
     double freq(200.0); // Frequency in Hz
 
     double x = xv(0);
     double y = xv(1);
 
     // Current density magnitude
-    double Jmag = (I0 / S);
+    double jmag = (i0 / s);
 
     // Calculate x component of current density unit vector
     if (abs(x - x0) < a)
@@ -61,7 +61,7 @@ protected:
     J(2) = 0.0;
 
     // Scale by current density magnitude
-    J *= Jmag;
+    J *= jmag;
   }
 
   hephaestus::InputParameters TestParams()
@@ -109,19 +109,19 @@ protected:
     hephaestus::AuxSolvers preprocessors;
 
     hephaestus::Sources sources;
-    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, SourceCurrent);
+    auto * j_src_coef = new mfem::VectorFunctionCoefficient(3, SourceCurrent);
     mfem::Array<mfem::VectorCoefficient *> sourcecoefs(4);
-    sourcecoefs[0] = JSrcCoef;
-    sourcecoefs[1] = JSrcCoef;
-    sourcecoefs[2] = JSrcCoef;
-    sourcecoefs[3] = JSrcCoef;
+    sourcecoefs[0] = j_src_coef;
+    sourcecoefs[1] = j_src_coef;
+    sourcecoefs[2] = j_src_coef;
+    sourcecoefs[3] = j_src_coef;
     mfem::Array<int> coilsegments(4);
     coilsegments[0] = 3;
     coilsegments[1] = 4;
     coilsegments[2] = 5;
     coilsegments[3] = 6;
-    auto * JSrcRestricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
-    coefficients.vectors.Register("source", JSrcRestricted, true);
+    auto * j_src_restricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
+    coefficients.vectors.Register("source", j_src_restricted, true);
 
     hephaestus::InputParameters div_free_source_params;
     div_free_source_params.SetParam("SourceName", std::string("source"));

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -10,7 +10,7 @@ extern const char * DATA_DIR;
 class TestComplexTeam7
 {
 protected:
-  static void source_current(const mfem::Vector & xv, mfem::Vector & J)
+  static void SourceCurrent(const mfem::Vector & xv, mfem::Vector & J)
   {
     double x0(194e-3);  // Coil centre x coordinate
     double y0(100e-3);  // Coil centre y coordinate
@@ -64,7 +64,7 @@ protected:
     J *= Jmag;
   }
 
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain air("air", 1);
     air.scalar_coefficients.Register(
@@ -109,7 +109,7 @@ protected:
     hephaestus::AuxSolvers preprocessors;
 
     hephaestus::Sources sources;
-    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, source_current);
+    auto * JSrcCoef = new mfem::VectorFunctionCoefficient(3, SourceCurrent);
     mfem::Array<mfem::VectorCoefficient *> sourcecoefs(4);
     sourcecoefs[0] = JSrcCoef;
     sourcecoefs[1] = JSrcCoef;
@@ -159,7 +159,7 @@ protected:
 
 TEST_CASE_METHOD(TestComplexTeam7, "TestComplexTeam7", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
   auto pmesh = std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 
   auto bc_map(params.GetParam<hephaestus::BCMap>("BoundaryConditions"));

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -67,31 +67,31 @@ protected:
   hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain air("air", 1);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
     hephaestus::Subdomain plate("plate", 2);
-    plate.scalar_coefficients.Register(
+    plate._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(3.526e7), true);
     hephaestus::Subdomain coil1("coil1", 3);
-    coil1.scalar_coefficients.Register(
+    coil1._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
     hephaestus::Subdomain coil2("coil2", 4);
-    coil2.scalar_coefficients.Register(
+    coil2._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
     hephaestus::Subdomain coil3("coil3", 5);
-    coil3.scalar_coefficients.Register(
+    coil3._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
     hephaestus::Subdomain coil4("coil4", 6);
-    coil4.scalar_coefficients.Register(
+    coil4._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
 
     hephaestus::Coefficients coefficients(
         std::vector<hephaestus::Subdomain>({air, plate, coil1, coil2, coil3, coil4}));
 
-    coefficients.scalars.Register("frequency", new mfem::ConstantCoefficient(200.0), true);
-    coefficients.scalars.Register(
+    coefficients._scalars.Register("frequency", new mfem::ConstantCoefficient(200.0), true);
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(M_PI * 4.0e-7), true);
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "dielectric_permittivity", new mfem::ConstantCoefficient(0.0), true);
 
     hephaestus::BCMap bc_map;
@@ -121,7 +121,7 @@ protected:
     coilsegments[2] = 5;
     coilsegments[3] = 6;
     auto * j_src_restricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
-    coefficients.vectors.Register("source", j_src_restricted, true);
+    coefficients._vectors.Register("source", j_src_restricted, true);
 
     hephaestus::InputParameters div_free_source_params;
     div_free_source_params.SetParam("SourceName", std::string("source"));

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -17,14 +17,14 @@ public:
 class TestEBFormCoupled
 {
 protected:
-  static double potential_high(const mfem::Vector & x, double t)
+  static double PotentialHigh(const mfem::Vector & x, double t)
   {
     double wj_(2.0 * M_PI / 60.0);
     return 2 * cos(wj_ * t);
   }
-  static double potential_ground(const mfem::Vector & x, double t) { return 0.0; }
-  static void edot_bc(const mfem::Vector & x, mfem::Vector & E) { E = 0.0; }
-  static void j_src(const mfem::Vector & x, double t, mfem::Vector & j)
+  static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
+  static void EdotBc(const mfem::Vector & x, mfem::Vector & E) { E = 0.0; }
+  static void JSrc(const mfem::Vector & x, double t, mfem::Vector & j)
   {
     double wj_(2.0 * M_PI / 60.0);
     j[0] = 0.0;
@@ -32,7 +32,7 @@ protected:
     j[2] = 2 * sin(wj_ * t);
   }
 
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     double sigma = 2.0 * M_PI * 10;
 
@@ -70,7 +70,7 @@ protected:
     preprocessors.Register("CoupledCoefficient", wireConductivity, false);
 
     hephaestus::BCMap bc_map;
-    auto * edotVecCoef = new mfem::VectorFunctionCoefficient(3, edot_bc);
+    auto * edotVecCoef = new mfem::VectorFunctionCoefficient(3, EdotBc);
     bc_map.Register("tangential_dEdt",
                     new hephaestus::VectorDirichletBC(
                         std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edotVecCoef),
@@ -81,7 +81,7 @@ protected:
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
-    auto * potential_src = new mfem::FunctionCoefficient(potential_high);
+    auto * potential_src = new mfem::FunctionCoefficient(PotentialHigh);
     bc_map.Register("high_potential",
                     new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal, potential_src),
@@ -94,7 +94,7 @@ protected:
         "ground_potential",
         new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
                                           ground_terminal,
-                                          new mfem::FunctionCoefficient(potential_ground)),
+                                          new mfem::FunctionCoefficient(PotentialGround)),
         true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(), 1, 1);
@@ -153,7 +153,7 @@ protected:
 
 TEST_CASE_METHOD(TestEBFormCoupled, "TestEBFormCoupled", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
 
   auto problem_builder = std::make_unique<hephaestus::EBDualFormulation>("magnetic_reluctivity",
                                                                          "magnetic_permeability",

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -19,26 +19,26 @@ class TestEBFormCoupled
 protected:
   static double PotentialHigh(const mfem::Vector & x, double t)
   {
-    double wj_(2.0 * M_PI / 60.0);
-    return 2 * cos(wj_ * t);
+    double wj(2.0 * M_PI / 60.0);
+    return 2 * cos(wj * t);
   }
   static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
   static void EdotBc(const mfem::Vector & x, mfem::Vector & E) { E = 0.0; }
   static void JSrc(const mfem::Vector & x, double t, mfem::Vector & j)
   {
-    double wj_(2.0 * M_PI / 60.0);
+    double wj(2.0 * M_PI / 60.0);
     j[0] = 0.0;
     j[1] = 0.0;
-    j[2] = 2 * sin(wj_ * t);
+    j[2] = 2 * sin(wj * t);
   }
 
   hephaestus::InputParameters TestParams()
   {
     double sigma = 2.0 * M_PI * 10;
 
-    double sigmaAir;
+    double sigma_air;
 
-    sigmaAir = 1.0e-6 * sigma;
+    sigma_air = 1.0e-6 * sigma;
 
     hephaestus::FESpaces fespaces;
     hephaestus::GridFunctions gridfunctions;
@@ -48,15 +48,15 @@ protected:
     // CoupledCoefficients must also be added to AuxSolvers
     hephaestus::InputParameters copper_conductivity_params;
     copper_conductivity_params.SetParam("CoupledVariableName", std::string("temperature"));
-    hephaestus::CoupledCoefficient * wireConductivity =
+    hephaestus::CoupledCoefficient * wire_conductivity =
         new CopperConductivityCoefficient(copper_conductivity_params);
 
     hephaestus::Subdomain wire("wire", 1);
-    wire.scalar_coefficients.Register("electrical_conductivity", wireConductivity, true);
+    wire.scalar_coefficients.Register("electrical_conductivity", wire_conductivity, true);
 
     hephaestus::Subdomain air("air", 2);
     air.scalar_coefficients.Register(
-        "electrical_conductivity", new mfem::ConstantCoefficient(sigmaAir), true);
+        "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
@@ -67,17 +67,17 @@ protected:
     //     true);
 
     hephaestus::AuxSolvers preprocessors;
-    preprocessors.Register("CoupledCoefficient", wireConductivity, false);
+    preprocessors.Register("CoupledCoefficient", wire_conductivity, false);
 
     hephaestus::BCMap bc_map;
-    auto * edotVecCoef = new mfem::VectorFunctionCoefficient(3, EdotBc);
+    auto * edot_vec_coef = new mfem::VectorFunctionCoefficient(3, EdotBc);
     bc_map.Register("tangential_dEdt",
                     new hephaestus::VectorDirichletBC(
-                        std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edotVecCoef),
+                        std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edot_vec_coef),
                     true);
     coefficients.scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
-    coefficients.vectors.Register("surface_tangential_dEdt", edotVecCoef, true);
+    coefficients.vectors.Register("surface_tangential_dEdt", edot_vec_coef, true);
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -10,7 +10,7 @@ public:
     : hephaestus::CoupledCoefficient(params){};
   double Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip) override
   {
-    return 2.0 * M_PI * 10 + 0.001 * (gf->GetValue(T, ip));
+    return 2.0 * M_PI * 10 + 0.001 * (_gf->GetValue(T, ip));
   }
 };
 
@@ -52,10 +52,10 @@ protected:
         new CopperConductivityCoefficient(copper_conductivity_params);
 
     hephaestus::Subdomain wire("wire", 1);
-    wire.scalar_coefficients.Register("electrical_conductivity", wire_conductivity, true);
+    wire._scalar_coefficients.Register("electrical_conductivity", wire_conductivity, true);
 
     hephaestus::Subdomain air("air", 2);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
@@ -75,9 +75,9 @@ protected:
                     new hephaestus::VectorDirichletBC(
                         std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edot_vec_coef),
                     true);
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
-    coefficients.vectors.Register("surface_tangential_dEdt", edot_vec_coef, true);
+    coefficients._vectors.Register("surface_tangential_dEdt", edot_vec_coef, true);
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
@@ -86,7 +86,7 @@ protected:
                     new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal, potential_src),
                     true);
-    coefficients.scalars.Register("source_potential", potential_src, true);
+    coefficients._scalars.Register("source_potential", potential_src, true);
 
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -30,11 +30,11 @@ protected:
     sigma_air = 1.0e-6 * sigma;
 
     hephaestus::Subdomain wire("wire", 1);
-    wire.scalar_coefficients.Register(
+    wire._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(sigma), true);
 
     hephaestus::Subdomain air("air", 2);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
@@ -51,9 +51,9 @@ protected:
                     new hephaestus::VectorDirichletBC(
                         std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edot_vec_coef),
                     true);
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
-    coefficients.vectors.Register("surface_tangential_dEdt", edot_vec_coef, true);
+    coefficients._vectors.Register("surface_tangential_dEdt", edot_vec_coef, true);
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
@@ -62,7 +62,7 @@ protected:
                     new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal, potential_src),
                     true);
-    coefficients.scalars.Register("source_potential", potential_src, true);
+    coefficients._scalars.Register("source_potential", potential_src, true);
 
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -6,14 +6,14 @@ extern const char * DATA_DIR;
 class TestEBFormRod
 {
 protected:
-  static double potential_high(const mfem::Vector & x, double t)
+  static double PotentialHigh(const mfem::Vector & x, double t)
   {
     double wj_(2.0 * M_PI / 60.0);
     return 2 * cos(wj_ * t);
   }
-  static double potential_ground(const mfem::Vector & x, double t) { return 0.0; }
-  static void edot_bc(const mfem::Vector & x, mfem::Vector & E) { E = 0.0; }
-  static void j_src(const mfem::Vector & x, double t, mfem::Vector & j)
+  static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
+  static void EdotBc(const mfem::Vector & x, mfem::Vector & E) { E = 0.0; }
+  static void JSrc(const mfem::Vector & x, double t, mfem::Vector & j)
   {
     double wj_(2.0 * M_PI / 60.0);
     j[0] = 0.0;
@@ -21,7 +21,7 @@ protected:
     j[2] = 2 * sin(wj_ * t);
   }
 
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     double sigma = 2.0 * M_PI * 10;
 
@@ -46,7 +46,7 @@ protected:
     //     true);
 
     hephaestus::BCMap bc_map;
-    auto * edotVecCoef = new mfem::VectorFunctionCoefficient(3, edot_bc);
+    auto * edotVecCoef = new mfem::VectorFunctionCoefficient(3, EdotBc);
     bc_map.Register("tangential_dEdt",
                     new hephaestus::VectorDirichletBC(
                         std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edotVecCoef),
@@ -57,7 +57,7 @@ protected:
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
-    auto * potential_src = new mfem::FunctionCoefficient(potential_high);
+    auto * potential_src = new mfem::FunctionCoefficient(PotentialHigh);
     bc_map.Register("high_potential",
                     new hephaestus::ScalarDirichletBC(
                         std::string("electric_potential"), high_terminal, potential_src),
@@ -70,7 +70,7 @@ protected:
         "ground_potential",
         new hephaestus::ScalarDirichletBC(std::string("electric_potential"),
                                           ground_terminal,
-                                          new mfem::FunctionCoefficient(potential_ground)),
+                                          new mfem::FunctionCoefficient(PotentialGround)),
         true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(), 1, 1);
@@ -121,7 +121,7 @@ protected:
 
 TEST_CASE_METHOD(TestEBFormRod, "TestEBFormRod", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
 
   auto problem_builder = std::make_unique<hephaestus::EBDualFormulation>("magnetic_reluctivity",
                                                                          "magnetic_permeability",

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -8,26 +8,26 @@ class TestEBFormRod
 protected:
   static double PotentialHigh(const mfem::Vector & x, double t)
   {
-    double wj_(2.0 * M_PI / 60.0);
-    return 2 * cos(wj_ * t);
+    double wj(2.0 * M_PI / 60.0);
+    return 2 * cos(wj * t);
   }
   static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
   static void EdotBc(const mfem::Vector & x, mfem::Vector & E) { E = 0.0; }
   static void JSrc(const mfem::Vector & x, double t, mfem::Vector & j)
   {
-    double wj_(2.0 * M_PI / 60.0);
+    double wj(2.0 * M_PI / 60.0);
     j[0] = 0.0;
     j[1] = 0.0;
-    j[2] = 2 * sin(wj_ * t);
+    j[2] = 2 * sin(wj * t);
   }
 
   hephaestus::InputParameters TestParams()
   {
     double sigma = 2.0 * M_PI * 10;
 
-    double sigmaAir;
+    double sigma_air;
 
-    sigmaAir = 1.0e-6 * sigma;
+    sigma_air = 1.0e-6 * sigma;
 
     hephaestus::Subdomain wire("wire", 1);
     wire.scalar_coefficients.Register(
@@ -35,7 +35,7 @@ protected:
 
     hephaestus::Subdomain air("air", 2);
     air.scalar_coefficients.Register(
-        "electrical_conductivity", new mfem::ConstantCoefficient(sigmaAir), true);
+        "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
@@ -46,14 +46,14 @@ protected:
     //     true);
 
     hephaestus::BCMap bc_map;
-    auto * edotVecCoef = new mfem::VectorFunctionCoefficient(3, EdotBc);
+    auto * edot_vec_coef = new mfem::VectorFunctionCoefficient(3, EdotBc);
     bc_map.Register("tangential_dEdt",
                     new hephaestus::VectorDirichletBC(
-                        std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edotVecCoef),
+                        std::string("electric_field"), mfem::Array<int>({1, 2, 3}), edot_vec_coef),
                     true);
     coefficients.scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
-    coefficients.vectors.Register("surface_tangential_dEdt", edotVecCoef, true);
+    coefficients.vectors.Register("surface_tangential_dEdt", edot_vec_coef, true);
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -30,11 +30,11 @@ protected:
     sigma_air = 1.0e-6 * sigma;
 
     hephaestus::Subdomain wire("wire", 1);
-    wire.scalar_coefficients.Register(
+    wire._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(sigma), true);
 
     hephaestus::Subdomain air("air", 2);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
@@ -52,8 +52,8 @@ protected:
                                                       mfem::Array<int>({1, 2, 3}),
                                                       hdot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dHdt", hdot_vec_coef, true);
-    coefficients.scalars.Register(
+    coefficients._vectors.Register("surface_tangential_dHdt", hdot_vec_coef, true);
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
     mfem::Array<int> high_terminal(1);

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -8,26 +8,26 @@ class TestHFormRod
 protected:
   static double PotentialHigh(const mfem::Vector & x, double t)
   {
-    double wj_(2.0 * M_PI / 60.0);
-    return cos(wj_ * t);
+    double wj(2.0 * M_PI / 60.0);
+    return cos(wj * t);
   }
   static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
   static void HdotBc(const mfem::Vector & x, mfem::Vector & H) { H = 0.0; }
   static void BSrc(const mfem::Vector & x, double t, mfem::Vector & b)
   {
-    double wj_(2.0 * M_PI / 60.0);
+    double wj(2.0 * M_PI / 60.0);
     b[0] = 0.0;
     b[1] = 0.0;
-    b[2] = 2 * sin(wj_ * t);
+    b[2] = 2 * sin(wj * t);
   }
 
   hephaestus::InputParameters TestParams()
   {
     double sigma = 2.0 * M_PI * 10;
 
-    double sigmaAir;
+    double sigma_air;
 
-    sigmaAir = 1.0e-6 * sigma;
+    sigma_air = 1.0e-6 * sigma;
 
     hephaestus::Subdomain wire("wire", 1);
     wire.scalar_coefficients.Register(
@@ -35,7 +35,7 @@ protected:
 
     hephaestus::Subdomain air("air", 2);
     air.scalar_coefficients.Register(
-        "electrical_conductivity", new mfem::ConstantCoefficient(sigmaAir), true);
+        "electrical_conductivity", new mfem::ConstantCoefficient(sigma_air), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
@@ -46,13 +46,13 @@ protected:
     //     true);
 
     hephaestus::BCMap bc_map;
-    auto * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, HdotBc);
+    auto * hdot_vec_coef = new mfem::VectorFunctionCoefficient(3, HdotBc);
     bc_map.Register("tangential_dHdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_field_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
-                                                      hdotVecCoef),
+                                                      hdot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dHdt", hdotVecCoef, true);
+    coefficients.vectors.Register("surface_tangential_dHdt", hdot_vec_coef, true);
     coefficients.scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -6,14 +6,14 @@ extern const char * DATA_DIR;
 class TestHFormRod
 {
 protected:
-  static double potential_high(const mfem::Vector & x, double t)
+  static double PotentialHigh(const mfem::Vector & x, double t)
   {
     double wj_(2.0 * M_PI / 60.0);
     return cos(wj_ * t);
   }
-  static double potential_ground(const mfem::Vector & x, double t) { return 0.0; }
-  static void hdot_bc(const mfem::Vector & x, mfem::Vector & H) { H = 0.0; }
-  static void b_src(const mfem::Vector & x, double t, mfem::Vector & b)
+  static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
+  static void HdotBc(const mfem::Vector & x, mfem::Vector & H) { H = 0.0; }
+  static void BSrc(const mfem::Vector & x, double t, mfem::Vector & b)
   {
     double wj_(2.0 * M_PI / 60.0);
     b[0] = 0.0;
@@ -21,7 +21,7 @@ protected:
     b[2] = 2 * sin(wj_ * t);
   }
 
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     double sigma = 2.0 * M_PI * 10;
 
@@ -46,7 +46,7 @@ protected:
     //     true);
 
     hephaestus::BCMap bc_map;
-    auto * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, hdot_bc);
+    auto * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, HdotBc);
     bc_map.Register("tangential_dHdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_field_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -58,12 +58,11 @@ protected:
 
     mfem::Array<int> high_terminal(1);
     high_terminal[0] = 1;
-    bc_map.Register(
-        "high_potential",
-        new hephaestus::ScalarDirichletBC(std::string("magnetic_potential"),
-                                          high_terminal,
-                                          new mfem::FunctionCoefficient(potential_high)),
-        true);
+    bc_map.Register("high_potential",
+                    new hephaestus::ScalarDirichletBC(std::string("magnetic_potential"),
+                                                      high_terminal,
+                                                      new mfem::FunctionCoefficient(PotentialHigh)),
+                    true);
 
     mfem::Array<int> ground_terminal(1);
     ground_terminal[0] = 2;
@@ -71,7 +70,7 @@ protected:
         "ground_potential",
         new hephaestus::ScalarDirichletBC(std::string("magnetic_potential"),
                                           ground_terminal,
-                                          new mfem::FunctionCoefficient(potential_ground)),
+                                          new mfem::FunctionCoefficient(PotentialGround)),
         true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./cylinder-hex-q2.gen")).c_str(), 1, 1);
@@ -122,7 +121,7 @@ protected:
 
 TEST_CASE_METHOD(TestHFormRod, "TestHFormRod", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(params.GetParam<mfem::ParMesh>("Mesh"));
 

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -7,7 +7,7 @@ extern const char * DATA_DIR;
 class TestHFormSource
 {
 protected:
-  const int var_order{2};
+  const int _var_order{2};
   static double EstimateConvergenceRate(
       HYPRE_BigInt n_i, HYPRE_BigInt n_imo, double error_i, double error_imo, int dim)
   {
@@ -52,15 +52,15 @@ protected:
   hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain wire("wire", 1);
-    wire.scalar_coefficients.Register(
+    wire._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
     hephaestus::Subdomain air("air", 2);
-    air.scalar_coefficients.Register(
+    air._scalar_coefficients.Register(
         "electrical_conductivity", new mfem::ConstantCoefficient(1.0), true);
 
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
-    coefficients.scalars.Register(
+    coefficients._scalars.Register(
         "electrical_conductivity", new mfem::FunctionCoefficient(SigmaExpr), true);
 
     hephaestus::BCMap bc_map;
@@ -70,15 +70,15 @@ protected:
                                                       mfem::Array<int>({1, 2, 3}),
                                                       hdot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dHdt", hdot_vec_coef, true);
-    coefficients.scalars.Register(
+    coefficients._vectors.Register("surface_tangential_dHdt", hdot_vec_coef, true);
+    coefficients._scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
     auto * d_bdt_src_coef = new mfem::VectorFunctionCoefficient(3, SourceField);
-    coefficients.vectors.Register("source", d_bdt_src_coef, true);
+    coefficients._vectors.Register("source", d_bdt_src_coef, true);
 
     auto * h_exact = new mfem::VectorFunctionCoefficient(3, HExactExpr);
-    coefficients.vectors.Register("h_exact_coeff", h_exact, true);
+    coefficients._vectors.Register("h_exact_coeff", h_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
 
@@ -208,15 +208,15 @@ TEST_CASE_METHOD(TestHFormSource, "TestHFormSource", "[CheckRun]")
           params.GetParam<hephaestus::AuxSolvers>("PostProcessors").Get("L2ErrorPostprocessor")));
 
   double r;
-  for (std::size_t i = 1; i < l2errpostprocessor.ndofs.Size(); ++i)
+  for (std::size_t i = 1; i < l2errpostprocessor._ndofs.Size(); ++i)
   {
-    r = EstimateConvergenceRate(l2errpostprocessor.ndofs[i],
-                                l2errpostprocessor.ndofs[i - 1],
-                                l2errpostprocessor.l2_errs[i],
-                                l2errpostprocessor.l2_errs[i - 1],
+    r = EstimateConvergenceRate(l2errpostprocessor._ndofs[i],
+                                l2errpostprocessor._ndofs[i - 1],
+                                l2errpostprocessor._l2_errs[i],
+                                l2errpostprocessor._l2_errs[i - 1],
                                 3);
     std::cout << r << std::endl;
-    REQUIRE(r > var_order - 0.15);
-    REQUIRE(r < var_order + 1.0);
+    REQUIRE(r > _var_order - 0.15);
+    REQUIRE(r < _var_order + 1.0);
   }
 }

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -64,21 +64,21 @@ protected:
         "electrical_conductivity", new mfem::FunctionCoefficient(SigmaExpr), true);
 
     hephaestus::BCMap bc_map;
-    auto * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, HdotBc);
+    auto * hdot_vec_coef = new mfem::VectorFunctionCoefficient(3, HdotBc);
     bc_map.Register("tangential_dHdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_field_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
-                                                      hdotVecCoef),
+                                                      hdot_vec_coef),
                     true);
-    coefficients.vectors.Register("surface_tangential_dHdt", hdotVecCoef, true);
+    coefficients.vectors.Register("surface_tangential_dHdt", hdot_vec_coef, true);
     coefficients.scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
-    auto * dBdtSrcCoef = new mfem::VectorFunctionCoefficient(3, SourceField);
-    coefficients.vectors.Register("source", dBdtSrcCoef, true);
+    auto * d_bdt_src_coef = new mfem::VectorFunctionCoefficient(3, SourceField);
+    coefficients.vectors.Register("source", d_bdt_src_coef, true);
 
-    auto * H_exact = new mfem::VectorFunctionCoefficient(3, HExactExpr);
-    coefficients.vectors.Register("h_exact_coeff", H_exact, true);
+    auto * h_exact = new mfem::VectorFunctionCoefficient(3, HExactExpr);
+    coefficients.vectors.Register("h_exact_coeff", h_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
 

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -8,36 +8,36 @@ class TestHFormSource
 {
 protected:
   const int var_order{2};
-  static double estimate_convergence_rate(
+  static double EstimateConvergenceRate(
       HYPRE_BigInt n_i, HYPRE_BigInt n_imo, double error_i, double error_imo, int dim)
   {
     return std::log(error_i / error_imo) /
            std::log(std::pow(n_imo / static_cast<double>(n_i), 1.0 / dim));
   }
 
-  static double potential_ground(const mfem::Vector & x, double t) { return 0.0; }
+  static double PotentialGround(const mfem::Vector & x, double t) { return 0.0; }
 
-  static void hdot_bc(const mfem::Vector & x, double t, mfem::Vector & H)
+  static void HdotBc(const mfem::Vector & x, double t, mfem::Vector & H)
   {
     H(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI);
     H(1) = 0;
     H(2) = 0;
   }
 
-  static void H_exact_expr(const mfem::Vector & x, double t, mfem::Vector & H_exact)
+  static void HExactExpr(const mfem::Vector & x, double t, mfem::Vector & H_exact)
   {
     H_exact(0) = sin(x(1) * M_PI) * sin(x(2) * M_PI) * t;
     H_exact(1) = 0;
     H_exact(2) = 0;
   }
-  static double sigma_expr(const mfem::Vector & x)
+  static double SigmaExpr(const mfem::Vector & x)
   {
     double variation_scale = 0.5;
     double sigma = 1.0 / (1.0 + variation_scale * cos(M_PI * x(0)) * cos(M_PI * x(1)));
     return sigma;
   }
   // Source field
-  static void source_field(const mfem::Vector & x, double t, mfem::Vector & f)
+  static void SourceField(const mfem::Vector & x, double t, mfem::Vector & f)
   {
     double variation_scale = 0.5;
     f(0) = t * M_PI * M_PI * sin(M_PI * x(1)) * sin(M_PI * x(2)) *
@@ -49,7 +49,7 @@ protected:
            cos(M_PI * x(2));
   }
 
-  hephaestus::InputParameters test_params()
+  hephaestus::InputParameters TestParams()
   {
     hephaestus::Subdomain wire("wire", 1);
     wire.scalar_coefficients.Register(
@@ -61,10 +61,10 @@ protected:
     hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
     coefficients.scalars.Register(
-        "electrical_conductivity", new mfem::FunctionCoefficient(sigma_expr), true);
+        "electrical_conductivity", new mfem::FunctionCoefficient(SigmaExpr), true);
 
     hephaestus::BCMap bc_map;
-    auto * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, hdot_bc);
+    auto * hdotVecCoef = new mfem::VectorFunctionCoefficient(3, HdotBc);
     bc_map.Register("tangential_dHdt",
                     new hephaestus::VectorDirichletBC(std::string("dmagnetic_field_dt"),
                                                       mfem::Array<int>({1, 2, 3}),
@@ -74,10 +74,10 @@ protected:
     coefficients.scalars.Register(
         "magnetic_permeability", new mfem::ConstantCoefficient(1.0), true);
 
-    auto * dBdtSrcCoef = new mfem::VectorFunctionCoefficient(3, source_field);
+    auto * dBdtSrcCoef = new mfem::VectorFunctionCoefficient(3, SourceField);
     coefficients.vectors.Register("source", dBdtSrcCoef, true);
 
-    auto * H_exact = new mfem::VectorFunctionCoefficient(3, H_exact_expr);
+    auto * H_exact = new mfem::VectorFunctionCoefficient(3, HExactExpr);
     coefficients.vectors.Register("h_exact_coeff", H_exact, true);
 
     mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./beam-tet.mesh")).c_str(), 1, 1);
@@ -143,7 +143,7 @@ protected:
 
 TEST_CASE_METHOD(TestHFormSource, "TestHFormSource", "[CheckRun]")
 {
-  hephaestus::InputParameters params(test_params());
+  hephaestus::InputParameters params(TestParams());
   auto unrefined_pmesh(params.GetParam<mfem::ParMesh>("Mesh"));
 
   int num_conv_refinements = 3;
@@ -210,11 +210,11 @@ TEST_CASE_METHOD(TestHFormSource, "TestHFormSource", "[CheckRun]")
   double r;
   for (std::size_t i = 1; i < l2errpostprocessor.ndofs.Size(); ++i)
   {
-    r = estimate_convergence_rate(l2errpostprocessor.ndofs[i],
-                                  l2errpostprocessor.ndofs[i - 1],
-                                  l2errpostprocessor.l2_errs[i],
-                                  l2errpostprocessor.l2_errs[i - 1],
-                                  3);
+    r = EstimateConvergenceRate(l2errpostprocessor.ndofs[i],
+                                l2errpostprocessor.ndofs[i - 1],
+                                l2errpostprocessor.l2_errs[i],
+                                l2errpostprocessor.l2_errs[i - 1],
+                                3);
     std::cout << r << std::endl;
     REQUIRE(r > var_order - 0.15);
     REQUIRE(r < var_order + 1.0);

--- a/test/unit/test_auxsolvers.cpp
+++ b/test/unit/test_auxsolvers.cpp
@@ -9,13 +9,13 @@ class DummyAuxSolver : public hephaestus::AuxSolver
 {
 public:
   DummyAuxSolver(std::string & _string_to_append, std::string & _string_modified)
-    : string_to_append(_string_to_append), string_modified(_string_modified){};
+    : _string_to_append(_string_to_append), _string_modified(_string_modified){};
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override{};
 
-  void Solve(double t = 0.0) override { string_modified = string_modified + string_to_append; };
-  std::string & string_to_append;
-  std::string & string_modified;
+  void Solve(double t = 0.0) override { _string_modified = _string_modified + _string_to_append; };
+  std::string & _string_to_append;
+  std::string & _string_modified;
 };
 
 TEST_CASE("AuxSolverTest", "[CheckQueue]")

--- a/test/unit/test_bc.cpp
+++ b/test/unit/test_bc.cpp
@@ -9,7 +9,7 @@ TEST_CASE("BoundaryConditionTest", "[CheckData]")
                   new hephaestus::BoundaryCondition(std::string("boundary_1"), bdr_attrs),
                   true);
 
-  mfem::Array<int> ess_bdr = bc_map.Get("tangential_dEdt")->bdr_attributes;
+  mfem::Array<int> ess_bdr = bc_map.Get("tangential_dEdt")->_bdr_attributes;
 
   for (int i = 0; i < bdr_attrs.Size(); ++i)
     REQUIRE(bdr_attrs[i] == ess_bdr[i]);

--- a/test/unit/test_calcflux.cpp
+++ b/test/unit/test_calcflux.cpp
@@ -20,12 +20,12 @@ TEST_CASE("Flux calculation", "[CalcFlux]")
   for (int l = 0; l < par_ref_lvl; ++l)
     pmesh->UniformRefinement();
 
-  mfem::ND_FECollection HCurl_Collection(order, pmesh.get()->Dimension());
-  mfem::ParFiniteElementSpace HCurlFESpace(pmesh.get(), &HCurl_Collection);
-  mfem::ParGridFunction j(&HCurlFESpace);
+  mfem::ND_FECollection h_curl_collection(order, pmesh.get()->Dimension());
+  mfem::ParFiniteElementSpace h_curl_fe_space(pmesh.get(), &h_curl_collection);
+  mfem::ParGridFunction j(&h_curl_fe_space);
 
-  mfem::VectorFunctionCoefficient vecField(3, JExact);
-  j.ProjectCoefficient(vecField);
+  mfem::VectorFunctionCoefficient vec_field(3, JExact);
+  j.ProjectCoefficient(vec_field);
 
   double area = 0.0025;
   double theta = M_PI / 4.;

--- a/test/unit/test_coefficients.cpp
+++ b/test/unit/test_coefficients.cpp
@@ -8,12 +8,12 @@ const double eps{1e-10};
 TEST_CASE("CoefficientsTest", "[CheckData]")
 {
   hephaestus::Subdomain wire("wire", 1);
-  wire.scalar_coefficients.Register("property_one", new mfem::ConstantCoefficient(1.0), true);
-  wire.scalar_coefficients.Register("property_two", new mfem::ConstantCoefficient(150.0), true);
+  wire._scalar_coefficients.Register("property_one", new mfem::ConstantCoefficient(1.0), true);
+  wire._scalar_coefficients.Register("property_two", new mfem::ConstantCoefficient(150.0), true);
 
   hephaestus::Subdomain air("air", 2);
-  air.scalar_coefficients.Register("property_one", new mfem::ConstantCoefficient(26.0), true);
-  air.scalar_coefficients.Register("property_two", new mfem::ConstantCoefficient(152.0), true);
+  air._scalar_coefficients.Register("property_one", new mfem::ConstantCoefficient(26.0), true);
+  air._scalar_coefficients.Register("property_two", new mfem::ConstantCoefficient(152.0), true);
 
   hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
@@ -21,13 +21,13 @@ TEST_CASE("CoefficientsTest", "[CheckData]")
   mfem::IsoparametricTransformation t;
   mfem::IntegrationPoint ip;
 
-  mfem::Coefficient * pw = coefficients.scalars.Get("property_one");
+  mfem::Coefficient * pw = coefficients._scalars.Get("property_one");
   t.Attribute = 1;
   REQUIRE_THAT(pw->Eval(t, ip), Catch::Matchers::WithinAbs(1.0, eps));
   t.Attribute = 2;
   REQUIRE_THAT(pw->Eval(t, ip), Catch::Matchers::WithinAbs(26.0, eps));
 
-  pw = coefficients.scalars.Get("property_two");
+  pw = coefficients._scalars.Get("property_two");
   t.Attribute = 1;
   REQUIRE_THAT(pw->Eval(t, ip), Catch::Matchers::WithinAbs(150.0, eps));
   t.Attribute = 2;

--- a/test/unit/test_coefficients.cpp
+++ b/test/unit/test_coefficients.cpp
@@ -18,18 +18,18 @@ TEST_CASE("CoefficientsTest", "[CheckData]")
   hephaestus::Coefficients coefficients(std::vector<hephaestus::Subdomain>({wire, air}));
 
   // Verify predefined values
-  mfem::IsoparametricTransformation T;
+  mfem::IsoparametricTransformation t;
   mfem::IntegrationPoint ip;
 
   mfem::Coefficient * pw = coefficients.scalars.Get("property_one");
-  T.Attribute = 1;
-  REQUIRE_THAT(pw->Eval(T, ip), Catch::Matchers::WithinAbs(1.0, eps));
-  T.Attribute = 2;
-  REQUIRE_THAT(pw->Eval(T, ip), Catch::Matchers::WithinAbs(26.0, eps));
+  t.Attribute = 1;
+  REQUIRE_THAT(pw->Eval(t, ip), Catch::Matchers::WithinAbs(1.0, eps));
+  t.Attribute = 2;
+  REQUIRE_THAT(pw->Eval(t, ip), Catch::Matchers::WithinAbs(26.0, eps));
 
   pw = coefficients.scalars.Get("property_two");
-  T.Attribute = 1;
-  REQUIRE_THAT(pw->Eval(T, ip), Catch::Matchers::WithinAbs(150.0, eps));
-  T.Attribute = 2;
-  REQUIRE_THAT(pw->Eval(T, ip), Catch::Matchers::WithinAbs(152.0, eps));
+  t.Attribute = 1;
+  REQUIRE_THAT(pw->Eval(t, ip), Catch::Matchers::WithinAbs(150.0, eps));
+  t.Attribute = 2;
+  REQUIRE_THAT(pw->Eval(t, ip), Catch::Matchers::WithinAbs(152.0, eps));
 }

--- a/test/unit/test_conductivity_opencoil.cpp
+++ b/test/unit/test_conductivity_opencoil.cpp
@@ -36,8 +36,8 @@ TEST_CASE("ConductivityOpenCoil", "[CheckData]")
   hephaestus::BCMap bc_maps;
 
   hephaestus::Coefficients coefficients;
-  coefficients.scalars.Register(std::string("Itotal"), &itot, false);
-  coefficients.scalars.Register(std::string("Conductivity"), &conductivity, false);
+  coefficients._scalars.Register(std::string("Itotal"), &itot, false);
+  coefficients._scalars.Register(std::string("Conductivity"), &conductivity, false);
 
   hephaestus::FESpaces fespaces;
   fespaces.Register(std::string("HCurl"), &h_curl_fe_space, false);

--- a/test/unit/test_conductivity_opencoil.cpp
+++ b/test/unit/test_conductivity_opencoil.cpp
@@ -24,26 +24,26 @@ TEST_CASE("ConductivityOpenCoil", "[CheckData]")
   std::shared_ptr<mfem::ParMesh> pmesh =
       std::make_shared<mfem::ParMesh>(mfem::ParMesh(MPI_COMM_WORLD, mesh));
 
-  mfem::ND_FECollection HCurl_Collection(order, pmesh.get()->Dimension());
-  mfem::ParFiniteElementSpace HCurlFESpace(pmesh.get(), &HCurl_Collection);
-  mfem::ParGridFunction E(&HCurlFESpace);
+  mfem::ND_FECollection h_curl_collection(order, pmesh.get()->Dimension());
+  mfem::ParFiniteElementSpace h_curl_fe_space(pmesh.get(), &h_curl_collection);
+  mfem::ParGridFunction e(&h_curl_fe_space);
 
-  double Ival = 10.0;
-  mfem::ConstantCoefficient Itot(Ival);
-  mfem::FunctionCoefficient Conductivity(sigma);
+  double ival = 10.0;
+  mfem::ConstantCoefficient itot(ival);
+  mfem::FunctionCoefficient conductivity(sigma);
 
   hephaestus::InputParameters ocs_params;
   hephaestus::BCMap bc_maps;
 
   hephaestus::Coefficients coefficients;
-  coefficients.scalars.Register(std::string("Itotal"), &Itot, false);
-  coefficients.scalars.Register(std::string("Conductivity"), &Conductivity, false);
+  coefficients.scalars.Register(std::string("Itotal"), &itot, false);
+  coefficients.scalars.Register(std::string("Conductivity"), &conductivity, false);
 
   hephaestus::FESpaces fespaces;
-  fespaces.Register(std::string("HCurl"), &HCurlFESpace, false);
+  fespaces.Register(std::string("HCurl"), &h_curl_fe_space, false);
 
   hephaestus::GridFunctions gridfunctions;
-  gridfunctions.Register(std::string("E"), &E, false);
+  gridfunctions.Register(std::string("E"), &e, false);
 
   ocs_params.SetParam("GradPotentialName", std::string("E"));
   ocs_params.SetParam("IFuncCoefName", std::string("Itotal"));
@@ -57,12 +57,12 @@ TEST_CASE("ConductivityOpenCoil", "[CheckData]")
 
   hephaestus::OpenCoilSolver opencoil(ocs_params, submesh_domains, elec_attrs);
   opencoil.Init(gridfunctions, fespaces, bc_maps, coefficients);
-  mfem::ParLinearForm dummy(&HCurlFESpace);
+  mfem::ParLinearForm dummy(&h_curl_fe_space);
   opencoil.Apply(&dummy);
 
-  double flux1 = hephaestus::calcFlux(&E, 4, Conductivity);
-  double flux2 = hephaestus::calcFlux(&E, 5, Conductivity);
+  double flux1 = hephaestus::calcFlux(&e, 4, conductivity);
+  double flux2 = hephaestus::calcFlux(&e, 5, conductivity);
 
-  REQUIRE_THAT(flux1 + flux2, Catch::Matchers::WithinAbs(Ival, eps));
+  REQUIRE_THAT(flux1 + flux2, Catch::Matchers::WithinAbs(ival, eps));
   REQUIRE_THAT(flux1 / flux2, Catch::Matchers::WithinAbs(r, eps));
 }

--- a/test/unit/test_opencoil.cpp
+++ b/test/unit/test_opencoil.cpp
@@ -33,8 +33,8 @@ TEST_CASE("OpenCoilTest", "[CheckData]")
   hephaestus::BCMap bc_maps;
 
   hephaestus::Coefficients coefficients;
-  coefficients.scalars.Register(std::string("Itotal"), &itot, false);
-  coefficients.scalars.Register(std::string("Conductivity"), &conductivity, false);
+  coefficients._scalars.Register(std::string("Itotal"), &itot, false);
+  coefficients._scalars.Register(std::string("Conductivity"), &conductivity, false);
 
   hephaestus::FESpaces fespaces;
   fespaces.Register(std::string("HCurl"), &h_curl_fe_space, false);

--- a/test/unit/test_opencoil.cpp
+++ b/test/unit/test_opencoil.cpp
@@ -19,28 +19,28 @@ TEST_CASE("OpenCoilTest", "[CheckData]")
   for (int l = 0; l < par_ref_lvl; ++l)
     pmesh->UniformRefinement();
 
-  mfem::ND_FECollection HCurl_Collection(order, pmesh.get()->Dimension());
-  mfem::ParFiniteElementSpace HCurlFESpace(pmesh.get(), &HCurl_Collection);
-  mfem::ParGridFunction E(&HCurlFESpace);
+  mfem::ND_FECollection h_curl_collection(order, pmesh.get()->Dimension());
+  mfem::ParFiniteElementSpace h_curl_fe_space(pmesh.get(), &h_curl_collection);
+  mfem::ParGridFunction e(&h_curl_fe_space);
 
-  const double Ival = 10.0;
+  const double ival = 10.0;
   const double cond_val = 1e6;
 
-  mfem::ConstantCoefficient Itot(Ival);
-  mfem::ConstantCoefficient Conductivity(cond_val);
+  mfem::ConstantCoefficient itot(ival);
+  mfem::ConstantCoefficient conductivity(cond_val);
 
   hephaestus::InputParameters ocs_params;
   hephaestus::BCMap bc_maps;
 
   hephaestus::Coefficients coefficients;
-  coefficients.scalars.Register(std::string("Itotal"), &Itot, false);
-  coefficients.scalars.Register(std::string("Conductivity"), &Conductivity, false);
+  coefficients.scalars.Register(std::string("Itotal"), &itot, false);
+  coefficients.scalars.Register(std::string("Conductivity"), &conductivity, false);
 
   hephaestus::FESpaces fespaces;
-  fespaces.Register(std::string("HCurl"), &HCurlFESpace, false);
+  fespaces.Register(std::string("HCurl"), &h_curl_fe_space, false);
 
   hephaestus::GridFunctions gridfunctions;
-  gridfunctions.Register(std::string("E"), &E, false);
+  gridfunctions.Register(std::string("E"), &e, false);
 
   ocs_params.SetParam("GradPotentialName", std::string("E"));
   ocs_params.SetParam("IFuncCoefName", std::string("Itotal"));
@@ -53,10 +53,10 @@ TEST_CASE("OpenCoilTest", "[CheckData]")
 
   hephaestus::OpenCoilSolver opencoil(ocs_params, submesh_domains, elec_attrs);
   opencoil.Init(gridfunctions, fespaces, bc_maps, coefficients);
-  mfem::ParLinearForm dummy(&HCurlFESpace);
+  mfem::ParLinearForm dummy(&h_curl_fe_space);
   opencoil.Apply(&dummy);
 
-  double flux = hephaestus::calcFlux(&E, elec_attrs.first, Conductivity);
+  double flux = hephaestus::calcFlux(&e, elec_attrs.first, conductivity);
 
-  REQUIRE_THAT(flux, Catch::Matchers::WithinAbs(Ival, eps));
+  REQUIRE_THAT(flux, Catch::Matchers::WithinAbs(ival, eps));
 }

--- a/test/unit/test_variables.cpp
+++ b/test/unit/test_variables.cpp
@@ -17,8 +17,8 @@ TEST_CASE("VariablesTest", "[CheckSetup]")
 
   auto problem = problem_builder->ReturnProblem();
 
-  mfem::ParGridFunction * stored_gf = problem->gridfunctions.Get("vector_potential");
-  mfem::ParFiniteElementSpace * stored_fespace = problem->fespaces.Get("HCurl");
+  mfem::ParGridFunction * stored_gf = problem->_gridfunctions.Get("vector_potential");
+  mfem::ParFiniteElementSpace * stored_fespace = problem->_fespaces.Get("HCurl");
 
   REQUIRE(stored_fespace->GetVSize() == stored_gf->ParFESpace()->GetVSize());
   REQUIRE(stored_fespace->GetVSize() > 0);


### PR DESCRIPTION
Enforces naming conventions for names of classes, methods, member variables, and local variables with clang-tidy.
Minor variable renaming to avoid clashes has also been done in this PR

- Class names are to be in "CamelCase"
- Method names are to be in "CamelCase" for consistency with (most) MFEM methods
- Local variables are to be in "lower_case" for consistency with Apollo/MOOSE
- Member variables are to be in "lower_case" prefixed with an underscore in the hephaestus namespace, for consistency with Apollo/MOOSE