### PR TITLE
Implement solver choice on Hephaestus

### DIFF
--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -2,6 +2,12 @@
 
 const char * DATA_DIR = "../../data/";
 
+static void
+constVec(const mfem::Vector & x, mfem::Vector & V)
+{
+  V = 1.0;
+}
+
 hephaestus::Coefficients
 defineCoefficients()
 {
@@ -97,6 +103,19 @@ main(int argc, char * argv[])
 
   hephaestus::Outputs outputs = defineOutputs();
   problem_builder->SetOutputs(outputs);
+
+  mfem::Array<int> a_dbc_bdr(6);
+  a_dbc_bdr[0] = 1;
+  a_dbc_bdr[1] = 2;
+  a_dbc_bdr[2] = 3;
+  a_dbc_bdr[3] = 4;
+  a_dbc_bdr[4] = 5;
+  a_dbc_bdr[5] = 6;
+  std::shared_ptr<hephaestus::VectorDirichletBC> a_dbc =
+      std::make_shared<hephaestus::VectorDirichletBC>(
+          "magnetic_vector_potential", a_dbc_bdr, new mfem::VectorFunctionCoefficient(3, constVec));
+
+  problem_builder->AddBoundaryCondition("A_DBC", a_dbc);
 
   hephaestus::InputParameters solver_options;
   solver_options.SetParam("Tolerance", float(1.0e-14));

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -99,11 +99,12 @@ main(int argc, char * argv[])
   problem_builder->SetOutputs(outputs);
 
   hephaestus::InputParameters solver_options;
-  solver_options.SetParam("Tolerance", float(1.0e-13));
+  solver_options.SetParam("Tolerance", float(1.0e-2));
   solver_options.SetParam("AbsTolerance", float(1.0e-16));
   solver_options.SetParam("MaxIter", (unsigned int)500);
   solver_options.SetParam("PrintLevel", 2);
-  solver_options.SetParam("LinearSolver", std::string("PCG"));
+  solver_options.SetParam("LinearPreconditioner", std::string("PCG"));
+  solver_options.SetParam("LinearSolver", std::string("FGMRES"));
   problem_builder->SetSolverOptions(solver_options);
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder.get());

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -103,6 +103,7 @@ main(int argc, char * argv[])
   solver_options.SetParam("AbsTolerance", float(1.0e-16));
   solver_options.SetParam("MaxIter", (unsigned int)500);
   solver_options.SetParam("PrintLevel", 2);
+  solver_options.SetParam("Solver", std::string("HCurl_PCG"));
   problem_builder->SetSolverOptions(solver_options);
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder.get());

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -103,7 +103,7 @@ main(int argc, char * argv[])
   solver_options.SetParam("AbsTolerance", float(1.0e-16));
   solver_options.SetParam("MaxIter", (unsigned int)500);
   solver_options.SetParam("PrintLevel", 2);
-  solver_options.SetParam("Solver", std::string("HCurl_FGMRES"));
+  solver_options.SetParam("LinearSolver", std::string("PCG"));
   problem_builder->SetSolverOptions(solver_options);
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder.get());
@@ -116,7 +116,7 @@ main(int argc, char * argv[])
 
   auto executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
 
-  mfem::out << "Created executioner";
+  mfem::out << "Created executioner\n";
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -103,7 +103,7 @@ main(int argc, char * argv[])
   solver_options.SetParam("AbsTolerance", float(1.0e-16));
   solver_options.SetParam("MaxIter", (unsigned int)500);
   solver_options.SetParam("PrintLevel", 2);
-  solver_options.SetParam("Solver", std::string("HCurl_PCG"));
+  solver_options.SetParam("Solver", std::string("HCurl_FGMRES"));
   problem_builder->SetSolverOptions(solver_options);
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder.get());

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -99,11 +99,11 @@ main(int argc, char * argv[])
   problem_builder->SetOutputs(outputs);
 
   hephaestus::InputParameters solver_options;
-  solver_options.SetParam("Tolerance", float(1.0e-2));
-  solver_options.SetParam("AbsTolerance", float(1.0e-16));
+  solver_options.SetParam("Tolerance", float(1.0e-14));
+  solver_options.SetParam("AbsTolerance", float(1.0e-20));
   solver_options.SetParam("MaxIter", (unsigned int)500);
   solver_options.SetParam("PrintLevel", 2);
-  solver_options.SetParam("LinearPreconditioner", std::string("PCG"));
+  solver_options.SetParam("LinearPreconditioner", std::string("AMS"));
   solver_options.SetParam("LinearSolver", std::string("FGMRES"));
   problem_builder->SetSolverOptions(solver_options);
 

--- a/examples/magnetostatic/Main.cpp
+++ b/examples/magnetostatic/Main.cpp
@@ -178,7 +178,7 @@ main(int argc, char * argv[])
 
   auto executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
 
-  mfem::out << "Created executioner";
+  mfem::out << "Created executioner\n";
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/open_coil/Main.cpp
+++ b/examples/open_coil/Main.cpp
@@ -177,7 +177,7 @@ main(int argc, char * argv[])
 
   auto executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
 
-  mfem::out << "Created executioner";
+  mfem::out << "Created executioner\n";
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/open_coil/Main.cpp
+++ b/examples/open_coil/Main.cpp
@@ -164,6 +164,7 @@ main(int argc, char * argv[])
   solver_options.SetParam("AbsTolerance", float(1.0e-10));
   solver_options.SetParam("MaxIter", (unsigned int)1000);
   solver_options.SetParam("PrintLevel", 2);
+  solver_options.SetParam("Solver", std::string("HCurl_FGMRES"));
   problem_builder->SetSolverOptions(solver_options);
 
   hephaestus::ProblemBuildSequencer sequencer(problem_builder.get());

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -200,7 +200,7 @@ main(int argc, char * argv[])
 
   auto executioner = std::make_unique<hephaestus::TransientExecutioner>(exec_params);
 
-  mfem::out << "Created executioner";
+  mfem::out << "Created executioner\n";
   executioner->Execute();
 
   MPI_Finalize();

--- a/src/formulations/AV/av_formulation.cpp
+++ b/src/formulations/AV/av_formulation.cpp
@@ -61,13 +61,25 @@ AVFormulation::ConstructEquationSystem()
 void
 AVFormulation::ConstructOperator()
 {
+
+  // Default solver options for the AV formulation
+  hephaestus::InputParameters & solver_options = GetProblem()->_solver_options;
+  solver_options.SetParamIfEmpty("LinearSolver", std::string("GMRES"));
+  solver_options.SetParamIfEmpty("LinearPreconditioner", std::string("AMG"));
+  solver_options.SetParamIfEmpty("Tolerance", float(1.0e-12));
+  solver_options.SetParamIfEmpty("AbsTolerance", float(1.0e-16));
+  solver_options.SetParamIfEmpty("MaxIter", (unsigned int)1000);
+  solver_options.SetParamIfEmpty("PrintLevel", 1);
+  _problem->_solvers.SetSolverOptions(solver_options);
+
   _problem->_td_operator = std::make_unique<hephaestus::AVOperator>(*(_problem->_pmesh),
                                                                     _problem->_fespaces,
                                                                     _problem->_gridfunctions,
                                                                     _problem->_bc_map,
                                                                     _problem->_coefficients,
                                                                     _problem->_sources,
-                                                                    _problem->_solver_options);
+                                                                    _problem->_solver_options,
+                                                                    _problem->_solvers);
   _problem->_td_operator->SetEquationSystem(_problem->_td_equation_system.get());
   _problem->_td_operator->SetGridFunctions();
 };
@@ -212,9 +224,11 @@ AVOperator::AVOperator(mfem::ParMesh & pmesh,
                        hephaestus::BCMap & bc_map,
                        hephaestus::Coefficients & coefficients,
                        hephaestus::Sources & sources,
-                       hephaestus::InputParameters & solver_options)
+                       hephaestus::InputParameters & solver_options,
+                       hephaestus::ProblemSolvers & solvers)
   : TimeDomainEquationSystemOperator(
-        pmesh, fespaces, gridfunctions, bc_map, coefficients, sources, solver_options)
+        pmesh, fespaces, gridfunctions, bc_map, coefficients, sources, solver_options),
+    _solvers(&solvers)
 {
   // Initialize MPI gridfunctions
   MPI_Comm_size(pmesh.GetComm(), &_num_procs);
@@ -257,12 +271,10 @@ AVOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector 
 
   _equation_system->FormLinearSystem(_block_a, _true_x, _true_rhs);
 
-  _solver = std::make_unique<hephaestus::DefaultGMRESSolver>(_solver_options,
-                                                             *_block_a.As<mfem::HypreParMatrix>());
-  // solver = new hephaestus::DefaultGMRESSolver(_solver_options, *blockA,
-  //                                             pmesh_->GetComm());
+  _solvers->SetLinearPreconditioner(*_block_a.As<mfem::HypreParMatrix>());
+  _solvers->SetLinearSolver(*_block_a.As<mfem::HypreParMatrix>());
+  _solvers->_linear_solver->Mult(_true_rhs, _true_x);
 
-  _solver->Mult(_true_rhs, _true_x);
   _equation_system->RecoverFEMSolution(_true_x, _gridfunctions);
 }
 } // namespace hephaestus

--- a/src/formulations/AV/av_formulation.cpp
+++ b/src/formulations/AV/av_formulation.cpp
@@ -271,8 +271,8 @@ AVOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector 
 
   _equation_system->FormLinearSystem(_block_a, _true_x, _true_rhs);
 
-  _solvers->SetLinearPreconditioner(*_block_a.As<mfem::HypreParMatrix>());
-  _solvers->SetLinearSolver(*_block_a.As<mfem::HypreParMatrix>());
+  _solvers->SetLinearPreconditioner(_block_a.As<mfem::HypreParMatrix>());
+  _solvers->SetLinearSolver(_block_a.As<mfem::HypreParMatrix>());
   _solvers->_linear_solver->Mult(_true_rhs, _true_x);
 
   _equation_system->RecoverFEMSolution(_true_x, _gridfunctions);

--- a/src/formulations/AV/av_formulation.hpp
+++ b/src/formulations/AV/av_formulation.hpp
@@ -61,10 +61,14 @@ public:
              hephaestus::BCMap & bc_map,
              hephaestus::Coefficients & coefficients,
              hephaestus::Sources & sources,
-             hephaestus::InputParameters & solver_options);
+             hephaestus::InputParameters & solver_options,
+             hephaestus::ProblemSolvers & solvers);
 
   ~AVOperator() override = default;
 
   void ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
+
+private:
+  ProblemSolvers * _solvers;
 };
 } // namespace hephaestus

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.cpp
@@ -47,6 +47,15 @@ ComplexMaxwellOperator::Init(mfem::Vector & X)
   _loss_coef = _coefficients._scalars.Get(_loss_coef_name);
 }
 
+/////////////////////////////////////////////////////////////////////////////////////////////
+// mfem::SuperLUSolver testfunction(mfem::HypreParMatrix * mat){
+//
+//   mfem::SuperLURowLocMatrix a_super_lu(*mat);
+//   mfem::SuperLUSolver solver(a_super_lu);
+//   return solver;
+// }
+/////////////////////////////////////////////////////////////////////////////////////////////
+
 void
 ComplexMaxwellOperator::Solve(mfem::Vector & X)
 {
@@ -90,10 +99,10 @@ ComplexMaxwellOperator::Solve(mfem::Vector & X)
 
   sqlf.FormLinearSystem(_ess_bdr_tdofs, *_u, lf, jac, u, rhs);
 
-  auto * jac_z = jac.As<mfem::ComplexHypreParMatrix>();
-  // auto jac_c = std::unique_ptr<mfem::HypreParMatrix>(jac_z->GetSystemMatrix());
+  auto jac_z = std::unique_ptr<mfem::HypreParMatrix>(
+      jac.As<mfem::ComplexHypreParMatrix>()->GetSystemMatrix());
 
-  _solvers->SetLinearSolver(*(jac_z->GetSystemMatrix()));
+  _solvers->SetLinearSolver(jac_z.get());
   _solvers->_linear_solver->Mult(rhs, u);
 
   sqlf.RecoverFEMSolution(u, lf, *_u);

--- a/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_maxwell_formulation.hpp
@@ -34,7 +34,8 @@ public:
                          hephaestus::BCMap & bc_map,
                          hephaestus::Coefficients & coefficients,
                          hephaestus::Sources & sources,
-                         hephaestus::InputParameters & solver_options);
+                         hephaestus::InputParameters & solver_options,
+                         hephaestus::ProblemSolvers & solvers);
 
   ~ComplexMaxwellOperator() override = default;
 
@@ -53,6 +54,9 @@ public:
   mfem::Coefficient * _loss_coef{nullptr};  // omega sigma
 
   mfem::Array<int> _ess_bdr_tdofs;
+
+private:
+  ProblemSolvers * _solvers;
 };
 
 //

--- a/src/formulations/Dual/dual_formulation.cpp
+++ b/src/formulations/Dual/dual_formulation.cpp
@@ -73,13 +73,25 @@ DualFormulation::ConstructEquationSystem()
 void
 DualFormulation::ConstructOperator()
 {
+
+  // Default solver options for the HCurl formulation
+  hephaestus::InputParameters & solver_options = GetProblem()->_solver_options;
+  solver_options.SetParamIfEmpty("LinearSolver", std::string("PCG"));
+  solver_options.SetParamIfEmpty("LinearPreconditioner", std::string("AMS"));
+  solver_options.SetParamIfEmpty("Tolerance", float(1.0e-13));
+  solver_options.SetParamIfEmpty("AbsTolerance", float(1.0e-20));
+  solver_options.SetParamIfEmpty("MaxIter", (unsigned int)500);
+  solver_options.SetParamIfEmpty("PrintLevel", 1);
+  _problem->_solvers.SetSolverOptions(solver_options);
+
   _problem->_td_operator = std::make_unique<hephaestus::DualOperator>(*(_problem->_pmesh),
                                                                       _problem->_fespaces,
                                                                       _problem->_gridfunctions,
                                                                       _problem->_bc_map,
                                                                       _problem->_coefficients,
                                                                       _problem->_sources,
-                                                                      _problem->_solver_options);
+                                                                      _problem->_solver_options,
+                                                                      _problem->_solvers);
   _problem->_td_operator->SetEquationSystem(_problem->_td_equation_system.get());
   _problem->_td_operator->SetGridFunctions();
 };
@@ -189,9 +201,11 @@ DualOperator::DualOperator(mfem::ParMesh & pmesh,
                            hephaestus::BCMap & bc_map,
                            hephaestus::Coefficients & coefficients,
                            hephaestus::Sources & sources,
-                           hephaestus::InputParameters & solver_options)
+                           hephaestus::InputParameters & solver_options,
+                           hephaestus::ProblemSolvers & solvers)
   : TimeDomainEquationSystemOperator(
-        pmesh, fespaces, gridfunctions, bc_map, coefficients, sources, solver_options)
+        pmesh, fespaces, gridfunctions, bc_map, coefficients, sources, solver_options),
+    _solvers(&solvers)
 {
 }
 
@@ -228,12 +242,18 @@ DualOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vecto
 
   _equation_system->FormLinearSystem(_block_a, _true_x, _true_rhs);
 
-  _jacobian_solver =
-      std::make_unique<hephaestus::DefaultHCurlPCGSolver>(_solver_options,
-                                                          *_block_a.As<mfem::HypreParMatrix>(),
-                                                          _equation_system->_test_pfespaces.at(0));
+  //_jacobian_solver =
+  //    std::make_unique<hephaestus::DefaultHCurlPCGSolver>(_solver_options,
+  //                                                        *_block_a.As<mfem::HypreParMatrix>(),
+  //                                                        _equation_system->_test_pfespaces.at(0));
+  //
+  //_jacobian_solver->Mult(_true_rhs, _true_x);
 
-  _jacobian_solver->Mult(_true_rhs, _true_x);
+  _solvers->SetEdgeFESpace(_equation_system->_test_pfespaces.at(0));
+  _solvers->SetLinearPreconditioner(*_block_a.As<mfem::HypreParMatrix>());
+  _solvers->SetLinearSolver(*_block_a.As<mfem::HypreParMatrix>());
+  _solvers->_linear_solver->Mult(_true_rhs, _true_x);
+
   _equation_system->RecoverFEMSolution(_true_x, _gridfunctions);
 
   // Subtract off contribution from source

--- a/src/formulations/Dual/dual_formulation.cpp
+++ b/src/formulations/Dual/dual_formulation.cpp
@@ -242,16 +242,9 @@ DualOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vecto
 
   _equation_system->FormLinearSystem(_block_a, _true_x, _true_rhs);
 
-  //_jacobian_solver =
-  //    std::make_unique<hephaestus::DefaultHCurlPCGSolver>(_solver_options,
-  //                                                        *_block_a.As<mfem::HypreParMatrix>(),
-  //                                                        _equation_system->_test_pfespaces.at(0));
-  //
-  //_jacobian_solver->Mult(_true_rhs, _true_x);
-
   _solvers->SetEdgeFESpace(_equation_system->_test_pfespaces.at(0));
-  _solvers->SetLinearPreconditioner(*_block_a.As<mfem::HypreParMatrix>());
-  _solvers->SetLinearSolver(*_block_a.As<mfem::HypreParMatrix>());
+  _solvers->SetLinearPreconditioner(_block_a.As<mfem::HypreParMatrix>());
+  _solvers->SetLinearSolver(_block_a.As<mfem::HypreParMatrix>());
   _solvers->_linear_solver->Mult(_true_rhs, _true_x);
 
   _equation_system->RecoverFEMSolution(_true_x, _gridfunctions);

--- a/src/formulations/Dual/dual_formulation.hpp
+++ b/src/formulations/Dual/dual_formulation.hpp
@@ -56,7 +56,8 @@ public:
                hephaestus::BCMap & bc_map,
                hephaestus::Coefficients & coefficients,
                hephaestus::Sources & sources,
-               hephaestus::InputParameters & solver_options);
+               hephaestus::InputParameters & solver_options,
+               hephaestus::ProblemSolvers & solvers);
 
   ~DualOperator() override = default;
 
@@ -71,6 +72,9 @@ public:
 
   mfem::ParGridFunction * _u;  // HCurl vector field
   mfem::ParGridFunction * _dv; // HDiv vector field
+
+private:
+  ProblemSolvers * _solvers;
 
 protected:
   std::unique_ptr<mfem::ParDiscreteLinearOperator> _curl;

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -219,8 +219,8 @@ HCurlOperator::ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vect
   _equation_system->FormLinearSystem(_block_a, _true_x, _true_rhs);
 
   _solvers->SetEdgeFESpace(_equation_system->_test_pfespaces.at(0));
-  _solvers->SetLinearPreconditioner(*_block_a.As<mfem::HypreParMatrix>());
-  _solvers->SetLinearSolver(*_block_a.As<mfem::HypreParMatrix>());
+  _solvers->SetLinearPreconditioner(_block_a.As<mfem::HypreParMatrix>());
+  _solvers->SetLinearSolver(_block_a.As<mfem::HypreParMatrix>());
   _solvers->_linear_solver->Mult(_true_rhs, _true_x);
 
   _equation_system->RecoverFEMSolution(_true_x, _gridfunctions);

--- a/src/formulations/HCurl/hcurl_formulation.cpp
+++ b/src/formulations/HCurl/hcurl_formulation.cpp
@@ -68,7 +68,7 @@ HCurlFormulation::ConstructOperator()
 {
   // Default solver options for the HCurl formulation
   hephaestus::InputParameters & solver_options = GetProblem()->_solver_options;
-  solver_options.SetParamIfEmpty("LinearSolver", std::string("FGMRES"));
+  solver_options.SetParamIfEmpty("LinearSolver", std::string("GMRES"));
   solver_options.SetParamIfEmpty("LinearPreconditioner", std::string("AMS"));
   solver_options.SetParamIfEmpty("Tolerance", float(1.0e-13));
   solver_options.SetParamIfEmpty("AbsTolerance", float(1.0e-20));

--- a/src/formulations/HCurl/hcurl_formulation.hpp
+++ b/src/formulations/HCurl/hcurl_formulation.hpp
@@ -53,11 +53,15 @@ public:
                 hephaestus::BCMap & bc_map,
                 hephaestus::Coefficients & coefficients,
                 hephaestus::Sources & sources,
-                hephaestus::InputParameters & solver_options);
+                hephaestus::InputParameters & solver_options,
+                hephaestus::ProblemSolvers & solvers);
 
   ~HCurlOperator() override = default;
 
   void ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
+
+private:
+  ProblemSolvers * _solvers;
 };
 
 } // namespace hephaestus

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -56,7 +56,8 @@ StaticsFormulation::ConstructOperator()
                                                     _problem->_bc_map,
                                                     _problem->_coefficients,
                                                     _problem->_sources,
-                                                    _problem->_solver_options);
+                                                    _problem->_solver_options,
+                                                    _problem->_solvers);
   _problem->GetOperator()->SetGridFunctions();
 };
 
@@ -96,11 +97,13 @@ StaticsOperator::StaticsOperator(mfem::ParMesh & pmesh,
                                  hephaestus::BCMap & bc_map,
                                  hephaestus::Coefficients & coefficients,
                                  hephaestus::Sources & sources,
-                                 hephaestus::InputParameters & solver_options)
+                                 hephaestus::InputParameters & solver_options,
+                                 hephaestus::ProblemSolvers & solvers)
   : EquationSystemOperator(
         pmesh, fespaces, gridfunctions, bc_map, coefficients, sources, solver_options),
     _h_curl_var_name(solver_options.GetParam<std::string>("HCurlVarName")),
-    _stiffness_coef_name(solver_options.GetParam<std::string>("StiffnessCoefName"))
+    _stiffness_coef_name(solver_options.GetParam<std::string>("StiffnessCoefName")),
+    _solvers(&solvers)
 {
 }
 
@@ -151,9 +154,9 @@ StaticsOperator::Solve(mfem::Vector & X)
 
   // Define and apply a parallel solver for AX=B with the AMS
   // preconditioner from hypre.
-  // SetFEMPreconditioner(curl_mu_inv_curl);
-  // SetFEMSolver(curl_mu_inv_curl);
-  //_fem_solver->Mult(rhs_tdofs, sol_tdofs);
+  _solvers->SetFEMPreconditioner(curl_mu_inv_curl);
+  _solvers->SetFEMSolver(curl_mu_inv_curl);
+  _solvers->_fem_solver->Mult(rhs_tdofs, sol_tdofs);
   // hephaestus::DefaultHCurlFGMRESSolver a1_solver(
   //    _solver_options, curl_mu_inv_curl, gf.ParFESpace());
 

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -43,8 +43,11 @@ StaticsFormulation::ConstructOperator()
   hephaestus::InputParameters & solver_options = GetProblem()->_solver_options;
   solver_options.SetParam("HCurlVarName", _h_curl_var_name);
   solver_options.SetParam("StiffnessCoefName", _alpha_coef_name);
+
   if (!solver_options.HasParam("Solver"))
-    solver_options.SetParam("Solver", "HCurl_FGMRES");
+  {
+    solver_options.SetParam("Solver", std::string("HCurl_FGMRES"));
+  }
 
   _problem->_eq_sys_operator =
       std::make_unique<hephaestus::StaticsOperator>(*(_problem->_pmesh),

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -44,10 +44,14 @@ StaticsFormulation::ConstructOperator()
   solver_options.SetParam("HCurlVarName", _h_curl_var_name);
   solver_options.SetParam("StiffnessCoefName", _alpha_coef_name);
 
-  if (!solver_options.HasParam("FEMSolver"))
-  {
-    solver_options.SetParam("FEMSolver", std::string("HCurl_FGMRES"));
-  }
+  // Default solver options for the statics formulation
+  solver_options.SetParamIfEmpty("LinearSolver", std::string("FGMRES"));
+  solver_options.SetParamIfEmpty("LinearPreconditioner", std::string("AMS"));
+  solver_options.SetParamIfEmpty("Tolerance", float(1.0e-13));
+  solver_options.SetParamIfEmpty("AbsTolerance", float(1.0e-20));
+  solver_options.SetParamIfEmpty("MaxIter", (unsigned int)500);
+  solver_options.SetParamIfEmpty("PrintLevel", 1);
+  _problem->_solvers.SetSolverOptions(solver_options);
 
   _problem->_eq_sys_operator =
       std::make_unique<hephaestus::StaticsOperator>(*(_problem->_pmesh),

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -154,6 +154,7 @@ StaticsOperator::Solve(mfem::Vector & X)
 
   // Define and apply a parallel solver for AX=B with the AMS
   // preconditioner from hypre.
+  _solvers->SetEdgeFESpace(gf.ParFESpace());
   _solvers->SetLinearPreconditioner(curl_mu_inv_curl);
   _solvers->SetLinearSolver(curl_mu_inv_curl);
   _solvers->_linear_solver->Mult(rhs_tdofs, sol_tdofs);

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -151,10 +151,13 @@ StaticsOperator::Solve(mfem::Vector & X)
 
   // Define and apply a parallel solver for AX=B with the AMS
   // preconditioner from hypre.
-  hephaestus::DefaultHCurlFGMRESSolver a1_solver(
-      _solver_options, curl_mu_inv_curl, gf.ParFESpace());
+  // SetFEMPreconditioner(curl_mu_inv_curl);
+  // SetFEMSolver(curl_mu_inv_curl);
+  //_fem_solver->Mult(rhs_tdofs, sol_tdofs);
+  // hephaestus::DefaultHCurlFGMRESSolver a1_solver(
+  //    _solver_options, curl_mu_inv_curl, gf.ParFESpace());
 
-  a1_solver.Mult(rhs_tdofs, sol_tdofs);
+  // a1_solver.Mult(rhs_tdofs, sol_tdofs);
   blf.RecoverFEMSolution(sol_tdofs, lf, gf);
 }
 

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -154,9 +154,9 @@ StaticsOperator::Solve(mfem::Vector & X)
 
   // Define and apply a parallel solver for AX=B with the AMS
   // preconditioner from hypre.
-  _solvers->SetFEMPreconditioner(curl_mu_inv_curl);
-  _solvers->SetFEMSolver(curl_mu_inv_curl);
-  _solvers->_fem_solver->Mult(rhs_tdofs, sol_tdofs);
+  _solvers->SetLinearPreconditioner(curl_mu_inv_curl);
+  _solvers->SetLinearSolver(curl_mu_inv_curl);
+  _solvers->_linear_solver->Mult(rhs_tdofs, sol_tdofs);
   // hephaestus::DefaultHCurlFGMRESSolver a1_solver(
   //    _solver_options, curl_mu_inv_curl, gf.ParFESpace());
 

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -156,16 +156,12 @@ StaticsOperator::Solve(mfem::Vector & X)
   mfem::HypreParVector rhs_tdofs(gf.ParFESpace());
   blf.FormLinearSystem(ess_bdr_tdofs, gf, lf, curl_mu_inv_curl, sol_tdofs, rhs_tdofs);
 
-  // Define and apply a parallel solver for AX=B with the AMS
-  // preconditioner from hypre.
+  // Define and apply a parallel solver for AX=B.
   _solvers->SetEdgeFESpace(gf.ParFESpace());
   _solvers->SetLinearPreconditioner(curl_mu_inv_curl);
   _solvers->SetLinearSolver(curl_mu_inv_curl);
   _solvers->_linear_solver->Mult(rhs_tdofs, sol_tdofs);
-  // hephaestus::DefaultHCurlFGMRESSolver a1_solver(
-  //    _solver_options, curl_mu_inv_curl, gf.ParFESpace());
 
-  // a1_solver.Mult(rhs_tdofs, sol_tdofs);
   blf.RecoverFEMSolution(sol_tdofs, lf, gf);
 }
 

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -158,8 +158,8 @@ StaticsOperator::Solve(mfem::Vector & X)
 
   // Define and apply a parallel solver for AX=B.
   _solvers->SetEdgeFESpace(gf.ParFESpace());
-  _solvers->SetLinearPreconditioner(curl_mu_inv_curl);
-  _solvers->SetLinearSolver(curl_mu_inv_curl);
+  _solvers->SetLinearPreconditioner(&curl_mu_inv_curl);
+  _solvers->SetLinearSolver(&curl_mu_inv_curl);
   _solvers->_linear_solver->Mult(rhs_tdofs, sol_tdofs);
 
   blf.RecoverFEMSolution(sol_tdofs, lf, gf);

--- a/src/formulations/Magnetostatic/statics_formulation.cpp
+++ b/src/formulations/Magnetostatic/statics_formulation.cpp
@@ -44,9 +44,9 @@ StaticsFormulation::ConstructOperator()
   solver_options.SetParam("HCurlVarName", _h_curl_var_name);
   solver_options.SetParam("StiffnessCoefName", _alpha_coef_name);
 
-  if (!solver_options.HasParam("Solver"))
+  if (!solver_options.HasParam("FEMSolver"))
   {
-    solver_options.SetParam("Solver", std::string("HCurl_FGMRES"));
+    solver_options.SetParam("FEMSolver", std::string("HCurl_FGMRES"));
   }
 
   _problem->_eq_sys_operator =
@@ -151,9 +151,10 @@ StaticsOperator::Solve(mfem::Vector & X)
 
   // Define and apply a parallel solver for AX=B with the AMS
   // preconditioner from hypre.
-  SetSolver(curl_mu_inv_curl, gf.ParFESpace());
+  hephaestus::DefaultHCurlFGMRESSolver a1_solver(
+      _solver_options, curl_mu_inv_curl, gf.ParFESpace());
 
-  _solver->Mult(rhs_tdofs, sol_tdofs);
+  a1_solver.Mult(rhs_tdofs, sol_tdofs);
   blf.RecoverFEMSolution(sol_tdofs, lf, gf);
 }
 

--- a/src/formulations/Magnetostatic/statics_formulation.hpp
+++ b/src/formulations/Magnetostatic/statics_formulation.hpp
@@ -34,7 +34,8 @@ public:
                   hephaestus::BCMap & bc_map,
                   hephaestus::Coefficients & coefficients,
                   hephaestus::Sources & sources,
-                  hephaestus::InputParameters & solver_options);
+                  hephaestus::InputParameters & solver_options,
+                  hephaestus::ProblemSolvers & solvers);
 
   ~StaticsOperator() override = default;
 
@@ -44,6 +45,7 @@ public:
 
 private:
   std::string _h_curl_var_name, _stiffness_coef_name;
+  ProblemSolvers * _solvers;
 
   mfem::Coefficient * _stiff_coef; // Stiffness Material Coefficient
 };

--- a/src/formulations/equation_system_operator.cpp
+++ b/src/formulations/equation_system_operator.cpp
@@ -65,11 +65,11 @@ EquationSystemOperator::SetSolver(const mfem::HypreParMatrix & M,
 
   if (solve_type == "HCurl_PCG")
     _solver = std::make_unique<DefaultHCurlPCGSolver>(_solver_options, M, edge_fespace);
-  else if (solve_type == "HCurl_GMRES")
+  else if (solve_type == "HCurl_FGMRES")
     _solver = std::make_unique<DefaultHCurlFGMRESSolver>(_solver_options, M, edge_fespace);
   else
     mfem::mfem_error("HCurl Solver type not recognised! Please set Solver field in "
-                     "solver_options to one of the following values: HCurl_PCG, HCurl_GMRES");
+                     "solver_options to one of the following values: HCurl_PCG, HCurl_FGMRES");
 }
 
 void

--- a/src/formulations/equation_system_operator.cpp
+++ b/src/formulations/equation_system_operator.cpp
@@ -42,37 +42,6 @@ EquationSystemOperator::SetGridFunctions()
 };
 
 void
-EquationSystemOperator::SetSolver(const mfem::HypreParMatrix & M)
-{
-  auto solve_type = _solver_options.GetParam<std::string>("Solver");
-
-  if (solve_type == "PCG")
-    _solver = std::make_unique<DefaultH1PCGSolver>(_solver_options, M);
-  else if (solve_type == "GMRES")
-    _solver = std::make_unique<DefaultGMRESSolver>(_solver_options, M);
-  else if (solve_type == "Jacobi")
-    _solver = std::make_unique<DefaultJacobiPCGSolver>(_solver_options, M);
-  else
-    mfem::mfem_error("H1 Solver type not recognised! Please set Solver field in solver_options "
-                     "to one of the following values: PCG, GMRES, Jacobi");
-}
-
-void
-EquationSystemOperator::SetSolver(const mfem::HypreParMatrix & M,
-                                  mfem::ParFiniteElementSpace * edge_fespace)
-{
-  auto solve_type = _solver_options.GetParam<std::string>("Solver");
-
-  if (solve_type == "HCurl_PCG")
-    _solver = std::make_unique<DefaultHCurlPCGSolver>(_solver_options, M, edge_fespace);
-  else if (solve_type == "HCurl_FGMRES")
-    _solver = std::make_unique<DefaultHCurlFGMRESSolver>(_solver_options, M, edge_fespace);
-  else
-    mfem::mfem_error("HCurl Solver type not recognised! Please set Solver field in "
-                     "solver_options to one of the following values: HCurl_PCG, HCurl_FGMRES");
-}
-
-void
 EquationSystemOperator::Init(mfem::Vector & X)
 {
   // Define material property coefficients

--- a/src/formulations/equation_system_operator.cpp
+++ b/src/formulations/equation_system_operator.cpp
@@ -42,6 +42,37 @@ EquationSystemOperator::SetGridFunctions()
 };
 
 void
+EquationSystemOperator::SetSolver(const mfem::HypreParMatrix & M)
+{
+  auto solve_type = _solver_options.GetParam<std::string>("Solver");
+
+  if (solve_type == "PCG")
+    _solver = std::make_unique<DefaultH1PCGSolver>(_solver_options, M);
+  else if (solve_type == "GMRES")
+    _solver = std::make_unique<DefaultGMRESSolver>(_solver_options, M);
+  else if (solve_type == "Jacobi")
+    _solver = std::make_unique<DefaultJacobiPCGSolver>(_solver_options, M);
+  else
+    mfem::mfem_error("H1 Solver type not recognised! Please set Solver field in solver_options "
+                     "to one of the following values: PCG, GMRES, Jacobi");
+}
+
+void
+EquationSystemOperator::SetSolver(const mfem::HypreParMatrix & M,
+                                  mfem::ParFiniteElementSpace * edge_fespace)
+{
+  auto solve_type = _solver_options.GetParam<std::string>("Solver");
+
+  if (solve_type == "HCurl_PCG")
+    _solver = std::make_unique<DefaultHCurlPCGSolver>(_solver_options, M, edge_fespace);
+  else if (solve_type == "HCurl_GMRES")
+    _solver = std::make_unique<DefaultHCurlFGMRESSolver>(_solver_options, M, edge_fespace);
+  else
+    mfem::mfem_error("HCurl Solver type not recognised! Please set Solver field in "
+                     "solver_options to one of the following values: HCurl_PCG, HCurl_GMRES");
+}
+
+void
 EquationSystemOperator::Init(mfem::Vector & X)
 {
   // Define material property coefficients

--- a/src/formulations/equation_system_operator.hpp
+++ b/src/formulations/equation_system_operator.hpp
@@ -34,6 +34,8 @@ public:
   virtual void Init(mfem::Vector & X);
   virtual void Solve(mfem::Vector & X);
   void Mult(const mfem::Vector & x, mfem::Vector & y) const override {}
+  void SetSolver(const mfem::HypreParMatrix & M);
+  void SetSolver(const mfem::HypreParMatrix & M, mfem::ParFiniteElementSpace * edge_fespace);
 
   mfem::Array<int> _true_offsets, _block_true_offsets;
   // Vector of names of state gridfunctions used in formulation, ordered by
@@ -60,6 +62,8 @@ public:
 
   mfem::OperatorHandle _block_a;
   mfem::BlockVector _true_x, _true_rhs;
+
+  std::unique_ptr<mfem::HypreSolver> _solver{nullptr};
 };
 
 } // namespace hephaestus

--- a/src/formulations/equation_system_operator.hpp
+++ b/src/formulations/equation_system_operator.hpp
@@ -62,8 +62,6 @@ public:
 
   mfem::OperatorHandle _block_a;
   mfem::BlockVector _true_x, _true_rhs;
-
-  std::unique_ptr<mfem::HypreSolver> _solver{nullptr};
 };
 
 } // namespace hephaestus

--- a/src/io/inputs.hpp
+++ b/src/io/inputs.hpp
@@ -51,6 +51,15 @@ public:
     }
     return param;
   };
+
+  [[nodiscard]] bool HasParam(std::string param_name) const
+  {
+    bool has;
+    if (_params.find(param_name) == _params.end())
+      return false;
+    else
+      return true;
+  };
 };
 
 } // namespace hephaestus

--- a/src/io/inputs.hpp
+++ b/src/io/inputs.hpp
@@ -60,6 +60,13 @@ public:
     else
       return true;
   };
+
+  template <typename T>
+  void SetParamIfEmpty(std::string param_name, T param)
+  {
+    if (!HasParam(param_name))
+      SetParam(param_name, param);
+  }
 };
 
 } // namespace hephaestus

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -204,7 +204,7 @@ ProblemBuilder::InitializeOutputs()
 void
 ProblemSolvers::SetSolver(std::shared_ptr<mfem::Solver> & solver,
                           std::string solve_type,
-                          mfem::Operator & A)
+                          mfem::Operator * A)
 {
 
   if (!_comm_set)
@@ -220,7 +220,7 @@ ProblemSolvers::SetSolver(std::shared_ptr<mfem::Solver> & solver,
     solver_buffer->SetAbsTol(_solver_options.GetParam<float>("AbsTolerance"));
     solver_buffer->SetMaxIter(_solver_options.GetParam<unsigned int>("MaxIter"));
     solver_buffer->SetPrintLevel(_solver_options.GetParam<int>("PrintLevel"));
-    solver_buffer->SetOperator(A);
+    solver_buffer->SetOperator(*A);
 
     if (_linear_preconditioner)
       solver_buffer->SetPreconditioner(
@@ -236,7 +236,7 @@ ProblemSolvers::SetSolver(std::shared_ptr<mfem::Solver> & solver,
     solver_buffer->SetAbsTol(_solver_options.GetParam<float>("AbsTolerance"));
     solver_buffer->SetMaxIter(_solver_options.GetParam<unsigned int>("MaxIter"));
     solver_buffer->SetPrintLevel(_solver_options.GetParam<int>("PrintLevel"));
-    solver_buffer->SetOperator(A);
+    solver_buffer->SetOperator(*A);
 
     if (_linear_preconditioner)
       solver_buffer->SetPreconditioner(
@@ -251,7 +251,7 @@ ProblemSolvers::SetSolver(std::shared_ptr<mfem::Solver> & solver,
     solver_buffer->SetTol(_solver_options.GetParam<float>("Tolerance"));
     solver_buffer->SetMaxIter(_solver_options.GetParam<unsigned int>("MaxIter"));
     solver_buffer->SetPrintLevel(_solver_options.GetParam<int>("PrintLevel"));
-    solver_buffer->SetOperator(A);
+    solver_buffer->SetOperator(*A);
 
     if (_linear_preconditioner)
       solver_buffer->SetPreconditioner(
@@ -268,7 +268,7 @@ ProblemSolvers::SetSolver(std::shared_ptr<mfem::Solver> & solver,
 
     solver_buffer->SetSingularProblem();
     solver_buffer->SetPrintLevel(_solver_options.GetParam<int>("PrintLevel"));
-    solver_buffer->SetOperator(A);
+    solver_buffer->SetOperator(*A);
 
     solver = solver_buffer;
   }
@@ -279,17 +279,16 @@ ProblemSolvers::SetSolver(std::shared_ptr<mfem::Solver> & solver,
     // solver_buffer->SetTol(_solver_options.GetParam<float>("Tolerance"));
     // solver_buffer->SetMaxIter(_solver_options.GetParam<unsigned int>("MaxIter"));
     solver_buffer->SetPrintLevel(_solver_options.GetParam<int>("PrintLevel"));
-    solver_buffer->SetOperator(A);
+    solver_buffer->SetOperator(*A);
 
     solver = solver_buffer;
   }
   else if (solve_type == "SuperLU")
   {
-    std::shared_ptr<mfem::SuperLUSolver> solver_buffer{
-        std::make_shared<mfem::SuperLUSolver>(MPI_COMM_WORLD)};
+    _a_super_lu = std::make_shared<mfem::SuperLURowLocMatrix>(*A);
 
-    mfem::SuperLURowLocMatrix a_super_lu(A);
-    solver_buffer->SetOperator(a_super_lu);
+    std::shared_ptr<mfem::SuperLUSolver> solver_buffer{
+        std::make_shared<mfem::SuperLUSolver>(*_a_super_lu)};
 
     solver = solver_buffer;
   }
@@ -305,7 +304,7 @@ ProblemSolvers::SetSolver(std::shared_ptr<mfem::Solver> & solver,
 }
 
 void
-ProblemSolvers::SetLinearPreconditioner(mfem::Operator & A)
+ProblemSolvers::SetLinearPreconditioner(mfem::Operator * A)
 {
   if (!_solver_options.HasParam("LinearPreconditioner"))
   {
@@ -320,7 +319,7 @@ ProblemSolvers::SetLinearPreconditioner(mfem::Operator & A)
 }
 
 void
-ProblemSolvers::SetLinearSolver(mfem::Operator & A)
+ProblemSolvers::SetLinearSolver(mfem::Operator * A)
 {
 
   if (!_solver_options.HasParam("LinearSolver"))

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -256,6 +256,18 @@ ProblemSolvers::SetSolver(std::shared_ptr<mfem::Solver> & solver,
 
     solver = solver_buffer;
   }
+  else if (solve_type == "AMS")
+  {
+    if (!_edge_fespace)
+      mfem::mfem_error("_edge_fespace must be set within ProblemSolvers class before calling AMS!");
+
+    std::shared_ptr<mfem::HypreAMS> solver_buffer{std::make_shared<mfem::HypreAMS>(_edge_fespace)};
+
+    solver_buffer->SetSingularProblem();
+    solver_buffer->SetPrintLevel(_solver_options.GetParam<int>("PrintLevel"));
+
+    solver = solver_buffer;
+  }
 
   // Add others!
 
@@ -301,16 +313,22 @@ ProblemSolvers::SetLinearSolver(mfem::Operator & A)
 }
 
 void
-ProblemSolvers::SetComm(MPI_Comm comm)
+ProblemSolvers::SetComm(const MPI_Comm comm)
 {
   _comm = comm;
   _comm_set = true;
 }
 
 void
-ProblemSolvers::SetSolverOptions(hephaestus::InputParameters solver_options)
+ProblemSolvers::SetSolverOptions(const hephaestus::InputParameters solver_options)
 {
   _solver_options = solver_options;
+}
+
+void
+ProblemSolvers::SetEdgeFESpace(mfem::ParFiniteElementSpace * edge_fes)
+{
+  _edge_fespace = edge_fes;
 }
 
 } // namespace hephaestus

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -66,6 +66,116 @@ ProblemBuilder::SetSolverOptions(hephaestus::InputParameters & solver_options)
 }
 
 void
+ProblemBuilder::SetSolverOperator(std::unique_ptr<mfem::Solver> & solver,
+                                  std::string solve_type,
+                                  mfem::HypreParMatrix & A)
+{
+
+  if (solve_type == "PCG")
+  {
+    solver = std::make_unique<mfem::HyprePCG>(A);
+  }
+  else if (solve_type == "GMRES")
+  {
+    solver = std::make_unique<mfem::HypreGMRES>(A);
+    // GetProblem()->_jacobian_preconditioner->SetKDim(GetProblem()->_solver_options.GetParam<int>("KDim"));
+  }
+  else if (solve_type == "FGMRES")
+  {
+    solver = std::make_unique<mfem::HypreFGMRES>(A);
+    // GetProblem()->_jacobian_preconditioner->SetKDim(GetProblem()->_solver_options.GetParam<int>("KDim"));
+  }
+  // Add others!
+}
+
+void
+ProblemBuilder::SetJacobianPreconditioner(mfem::HypreParMatrix & A)
+{
+
+  auto solve_type = GetProblem()->_solver_options.GetParam<std::string>("JacobianPreconditioner");
+
+  SetSolverOperator(GetProblem()->_jacobian_preconditioner, solve_type, A);
+
+  if (!GetProblem()->_jacobian_preconditioner)
+    std::cout
+        << "Warning: Jacobian preconditioner type not recognised or not set. Proceeding without "
+           "preconditioner. If you wish to use a preconditioner, please set "
+           "JacobianPreconditioner field to one of the following values: PCG, GMRES, FGMRES"
+        << std::endl;
+
+  // if (GetProblem()->_jacobian_preconditioner)
+  //{
+  //   GetProblem()->_jacobian_preconditioner->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
+  //   GetProblem()->_jacobian_preconditioner->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
+  //   GetProblem()->_jacobian_preconditioner->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
+  //   GetProblem()->_jacobian_preconditioner->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
+  // }
+}
+
+void
+ProblemBuilder::SetJacobianSolver(mfem::HypreParMatrix & A)
+{
+
+  auto solve_type = GetProblem()->_solver_options.GetParam<std::string>("JacobianSolver");
+
+  SetSolverOperator(GetProblem()->_jacobian_solver, solve_type, A);
+
+  if (!GetProblem()->_jacobian_solver)
+    mfem::mfem_error("Jacobian solver type not recognised! Please set JacobianSolver field "
+                     "to one of the following values: PCG, GMRES, FGMRES");
+
+  // GetProblem()->_jacobian_solver->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
+  // GetProblem()->_jacobian_solver->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
+  // GetProblem()->_jacobian_solver->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
+  // GetProblem()->_jacobian_solver->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
+  // if (GetProblem()->_jacobian_preconditioner)
+  //   GetProblem()->_jacobian_solver->SetPreconditioner(GetProblem()->_jacobian_preconditioner);
+}
+
+void
+ProblemBuilder::SetFEMPreconditioner(mfem::HypreParMatrix & A)
+{
+
+  auto solve_type = GetProblem()->_solver_options.GetParam<std::string>("FEMPreconditioner");
+
+  SetSolverOperator(GetProblem()->_fem_preconditioner, solve_type, A);
+
+  if (!GetProblem()->_fem_preconditioner)
+    std::cout << "Warning: FEM preconditioner type not recognised or not set. Proceeding without "
+                 "preconditioner. If you wish to use a preconditioner, please set "
+                 "FEMPreconditioner field to one of the following values: PCG, GMRES, FGMRES"
+              << std::endl;
+
+  // if (GetProblem()->_fem_preconditioner)
+  //{
+  //   GetProblem()->_fem_preconditioner->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
+  //   GetProblem()->_fem_preconditioner->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
+  //   GetProblem()->_fem_preconditioner->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
+  //   GetProblem()->_fem_preconditioner->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
+  // }
+}
+
+void
+ProblemBuilder::SetFEMSolver(mfem::HypreParMatrix & A)
+{
+
+  auto solve_type = GetProblem()->_solver_options.GetParam<std::string>("FEMSolver");
+
+  SetSolverOperator(GetProblem()->_fem_solver, solve_type, A);
+
+  if (!GetProblem()->_fem_solver)
+    mfem::mfem_error("FEM solver type not recognised! Please set FEMSolver field "
+                     "to one of the following values: PCG, GMRES, FGMRES");
+
+  // GetProblem()->_fem_solver->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
+  // GetProblem()->_fem_solver->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
+  // GetProblem()->_fem_solver->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
+  // GetProblem()->_fem_solver->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
+  // if (GetProblem()->_fem_preconditioner)
+  //   GetProblem()->_fem_solver->SetPreconditioner(GetProblem()->_fem_preconditioner);
+}
+
+void
 ProblemBuilder::SetCoefficients(hephaestus::Coefficients & coefficients)
 {
   GetProblem()->_coefficients = coefficients;

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -14,6 +14,8 @@ void
 ProblemBuilder::SetMesh(std::shared_ptr<mfem::ParMesh> pmesh)
 {
   GetProblem()->_pmesh = pmesh;
+  GetProblem()->_solvers.SetComm(pmesh->GetComm());
+  MPI_Comm_size(pmesh->GetComm(), &(GetProblem()->_num_procs));
   MPI_Comm_rank(pmesh->GetComm(), &(GetProblem()->_myid));
 }
 
@@ -63,116 +65,7 @@ void
 ProblemBuilder::SetSolverOptions(hephaestus::InputParameters & solver_options)
 {
   GetProblem()->_solver_options = solver_options;
-}
-
-void
-ProblemBuilder::SetSolverOperator(std::unique_ptr<mfem::Solver> & solver,
-                                  std::string solve_type,
-                                  mfem::HypreParMatrix & A)
-{
-
-  if (solve_type == "PCG")
-  {
-    solver = std::make_unique<mfem::HyprePCG>(A);
-  }
-  else if (solve_type == "GMRES")
-  {
-    solver = std::make_unique<mfem::HypreGMRES>(A);
-    // GetProblem()->_jacobian_preconditioner->SetKDim(GetProblem()->_solver_options.GetParam<int>("KDim"));
-  }
-  else if (solve_type == "FGMRES")
-  {
-    solver = std::make_unique<mfem::HypreFGMRES>(A);
-    // GetProblem()->_jacobian_preconditioner->SetKDim(GetProblem()->_solver_options.GetParam<int>("KDim"));
-  }
-  // Add others!
-}
-
-void
-ProblemBuilder::SetJacobianPreconditioner(mfem::HypreParMatrix & A)
-{
-
-  auto solve_type = GetProblem()->_solver_options.GetParam<std::string>("JacobianPreconditioner");
-
-  SetSolverOperator(GetProblem()->_jacobian_preconditioner, solve_type, A);
-
-  if (!GetProblem()->_jacobian_preconditioner)
-    std::cout
-        << "Warning: Jacobian preconditioner type not recognised or not set. Proceeding without "
-           "preconditioner. If you wish to use a preconditioner, please set "
-           "JacobianPreconditioner field to one of the following values: PCG, GMRES, FGMRES"
-        << std::endl;
-
-  // if (GetProblem()->_jacobian_preconditioner)
-  //{
-  //   GetProblem()->_jacobian_preconditioner->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
-  //   GetProblem()->_jacobian_preconditioner->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
-  //   GetProblem()->_jacobian_preconditioner->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
-  //   GetProblem()->_jacobian_preconditioner->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
-  // }
-}
-
-void
-ProblemBuilder::SetJacobianSolver(mfem::HypreParMatrix & A)
-{
-
-  auto solve_type = GetProblem()->_solver_options.GetParam<std::string>("JacobianSolver");
-
-  SetSolverOperator(GetProblem()->_jacobian_solver, solve_type, A);
-
-  if (!GetProblem()->_jacobian_solver)
-    mfem::mfem_error("Jacobian solver type not recognised! Please set JacobianSolver field "
-                     "to one of the following values: PCG, GMRES, FGMRES");
-
-  // GetProblem()->_jacobian_solver->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
-  // GetProblem()->_jacobian_solver->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
-  // GetProblem()->_jacobian_solver->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
-  // GetProblem()->_jacobian_solver->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
-  // if (GetProblem()->_jacobian_preconditioner)
-  //   GetProblem()->_jacobian_solver->SetPreconditioner(GetProblem()->_jacobian_preconditioner);
-}
-
-void
-ProblemBuilder::SetFEMPreconditioner(mfem::HypreParMatrix & A)
-{
-
-  auto solve_type = GetProblem()->_solver_options.GetParam<std::string>("FEMPreconditioner");
-
-  SetSolverOperator(GetProblem()->_fem_preconditioner, solve_type, A);
-
-  if (!GetProblem()->_fem_preconditioner)
-    std::cout << "Warning: FEM preconditioner type not recognised or not set. Proceeding without "
-                 "preconditioner. If you wish to use a preconditioner, please set "
-                 "FEMPreconditioner field to one of the following values: PCG, GMRES, FGMRES"
-              << std::endl;
-
-  // if (GetProblem()->_fem_preconditioner)
-  //{
-  //   GetProblem()->_fem_preconditioner->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
-  //   GetProblem()->_fem_preconditioner->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
-  //   GetProblem()->_fem_preconditioner->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
-  //   GetProblem()->_fem_preconditioner->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
-  // }
-}
-
-void
-ProblemBuilder::SetFEMSolver(mfem::HypreParMatrix & A)
-{
-
-  auto solve_type = GetProblem()->_solver_options.GetParam<std::string>("FEMSolver");
-
-  SetSolverOperator(GetProblem()->_fem_solver, solve_type, A);
-
-  if (!GetProblem()->_fem_solver)
-    mfem::mfem_error("FEM solver type not recognised! Please set FEMSolver field "
-                     "to one of the following values: PCG, GMRES, FGMRES");
-
-  // GetProblem()->_fem_solver->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
-  // GetProblem()->_fem_solver->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
-  // GetProblem()->_fem_solver->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
-  // GetProblem()->_fem_solver->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
-  // if (GetProblem()->_fem_preconditioner)
-  //   GetProblem()->_fem_solver->SetPreconditioner(GetProblem()->_fem_preconditioner);
+  GetProblem()->_solvers.SetSolverOptions(solver_options);
 }
 
 void
@@ -306,6 +199,141 @@ void
 ProblemBuilder::InitializeOutputs()
 {
   GetProblem()->_outputs.Init(GetProblem()->_gridfunctions);
+}
+
+void
+ProblemSolvers::SetSolver(std::unique_ptr<mfem::Solver> & solver,
+                          std::string solve_type,
+                          mfem::Operator & A)
+{
+
+  if (!_comm_set)
+  {
+    mfem::mfem_error("MPI comm must be set in the solvers class before setting up solver!");
+  }
+
+  if (solve_type == "PCG")
+  {
+    solver = std::make_unique<mfem::HyprePCG>(_comm);
+  }
+  else if (solve_type == "GMRES")
+  {
+    solver = std::make_unique<mfem::HypreGMRES>(_comm);
+    // GetProblem()->_jacobian_preconditioner->SetKDim(GetProblem()->_solver_options.GetParam<int>("KDim"));
+  }
+  else if (solve_type == "FGMRES")
+  {
+    solver = std::make_unique<mfem::HypreFGMRES>(_comm);
+    // GetProblem()->_jacobian_preconditioner->SetKDim(GetProblem()->_solver_options.GetParam<int>("KDim"));
+  }
+  // Add others!
+  solver->SetOperator(A);
+}
+
+void
+ProblemSolvers::SetJacobianPreconditioner(mfem::Operator & A)
+{
+
+  auto solve_type = _solver_options.GetParam<std::string>("JacobianPreconditioner");
+
+  SetSolver(_jacobian_preconditioner, solve_type, A);
+
+  if (!_jacobian_preconditioner)
+    std::cout
+        << "Warning: Jacobian preconditioner type not recognised or not set. Proceeding without "
+           "preconditioner. If you wish to use a preconditioner, please set "
+           "JacobianPreconditioner field to one of the following values: PCG, GMRES, FGMRES"
+        << std::endl;
+
+  // if (GetProblem()->_jacobian_preconditioner)
+  //{
+  //   GetProblem()->_jacobian_preconditioner->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
+  //   GetProblem()->_jacobian_preconditioner->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
+  //   GetProblem()->_jacobian_preconditioner->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
+  //   GetProblem()->_jacobian_preconditioner->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
+  // }
+}
+
+void
+ProblemSolvers::SetJacobianSolver(mfem::Operator & A)
+{
+
+  auto solve_type = _solver_options.GetParam<std::string>("JacobianSolver");
+
+  SetSolver(_jacobian_solver, solve_type, A);
+
+  if (!_jacobian_solver)
+    mfem::mfem_error("Jacobian solver type not recognised! Please set JacobianSolver field "
+                     "to one of the following values: PCG, GMRES, FGMRES");
+
+  // if (GetProblem()->_jacobian_preconditioner)
+  //   GetProblem()->_jacobian_solver.get()->SetPreconditioner(GetProblem()->_jacobian_preconditioner);
+
+  // GetProblem()->_jacobian_solver->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
+  // GetProblem()->_jacobian_solver->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
+  // GetProblem()->_jacobian_solver->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
+  // GetProblem()->_jacobian_solver->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
+  // if (GetProblem()->_jacobian_preconditioner)
+  //   GetProblem()->_jacobian_solver->SetPreconditioner(GetProblem()->_jacobian_preconditioner);
+}
+
+void
+ProblemSolvers::SetFEMPreconditioner(mfem::Operator & A)
+{
+
+  auto solve_type = _solver_options.GetParam<std::string>("FEMPreconditioner");
+
+  SetSolver(_fem_preconditioner, solve_type, A);
+
+  if (!_fem_preconditioner)
+    std::cout << "Warning: FEM preconditioner type not recognised or not set. Proceeding without "
+                 "preconditioner. If you wish to use a preconditioner, please set "
+                 "FEMPreconditioner field to one of the following values: PCG, GMRES, FGMRES"
+              << std::endl;
+
+  // if (GetProblem()->_fem_preconditioner)
+  //{
+  //   GetProblem()->_fem_preconditioner->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
+  //   GetProblem()->_fem_preconditioner->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
+  //   GetProblem()->_fem_preconditioner->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
+  //   GetProblem()->_fem_preconditioner->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
+  // }
+}
+
+void
+ProblemSolvers::SetFEMSolver(mfem::Operator & A)
+{
+
+  auto solve_type = _solver_options.GetParam<std::string>("FEMSolver");
+
+  SetSolver(_fem_solver, solve_type, A);
+
+  if (!_fem_solver)
+    mfem::mfem_error("FEM solver type not recognised! Please set FEMSolver field "
+                     "to one of the following values: PCG, GMRES, FGMRES");
+
+  // if (GetProblem()->_fem_preconditioner)
+  //   GetProblem()->_fem_solver.get()->SetPreconditioner(GetProblem()->_fem_preconditioner);
+
+  // GetProblem()->_fem_solver->SetTol(GetProblem()->_solver_options.GetParam<float>("Tolerance"));
+  // GetProblem()->_fem_solver->SetAbsTol(GetProblem()->_solver_options.GetParam<float>("AbsTolerance"));
+  // GetProblem()->_fem_solver->SetMaxIter(GetProblem()->_solver_options.GetParam<int>("MaxIter"));
+  // GetProblem()->_fem_solver->SetPrintLevel(GetProblem()->_solver_options.GetParam<int>("PrintLevel"));
+  // if (GetProblem()->_fem_preconditioner)
+  //   GetProblem()->_fem_solver->SetPreconditioner(GetProblem()->_fem_preconditioner);
+}
+
+void
+ProblemSolvers::SetComm(MPI_Comm comm)
+{
+  _comm = comm;
+  _comm_set = true;
+}
+
+void
+ProblemSolvers::SetSolverOptions(hephaestus::InputParameters solver_options)
+{
+  _solver_options = solver_options;
 }
 
 } // namespace hephaestus

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -11,6 +11,38 @@
 namespace hephaestus
 {
 
+class ProblemSolvers
+{
+
+public:
+  ProblemSolvers() = default;
+  ProblemSolvers(hephaestus::InputParameters solver_options, MPI_Comm comm)
+    : _solver_options{std::move(solver_options)}, _comm{std::move(comm)}, _comm_set{true}
+  {
+  }
+  ~ProblemSolvers() = default;
+
+  void
+  SetSolver(std::unique_ptr<mfem::Solver> & solver, std::string solve_type, mfem::Operator & A);
+  void SetFEMPreconditioner(mfem::Operator & A);
+  void SetFEMSolver(mfem::Operator & A);
+  void SetJacobianPreconditioner(mfem::Operator & A);
+  void SetJacobianSolver(mfem::Operator & A);
+
+  void SetComm(MPI_Comm comm);
+  void SetSolverOptions(hephaestus::InputParameters solver_options);
+
+private:
+  std::unique_ptr<mfem::Solver> _fem_solver{nullptr};
+  std::unique_ptr<mfem::Solver> _fem_preconditioner{nullptr};
+  std::unique_ptr<mfem::Solver> _jacobian_solver{nullptr};
+  std::unique_ptr<mfem::Solver> _jacobian_preconditioner{nullptr};
+
+  MPI_Comm _comm;
+  bool _comm_set{false};
+  hephaestus::InputParameters _solver_options;
+};
+
 class Problem
 {
 public:
@@ -29,10 +61,7 @@ public:
   std::unique_ptr<mfem::ODESolver> _ode_solver{nullptr};
   std::unique_ptr<mfem::BlockVector> _f{nullptr};
 
-  std::unique_ptr<mfem::Solver> _fem_solver{nullptr};
-  std::unique_ptr<mfem::Solver> _fem_preconditioner{nullptr};
-  std::unique_ptr<mfem::Solver> _jacobian_solver{nullptr};
-  std::unique_ptr<mfem::Solver> _jacobian_preconditioner{nullptr};
+  ProblemSolvers _solvers;
 
   hephaestus::FECollections _fecs;
   hephaestus::FESpaces _fespaces;
@@ -66,13 +95,6 @@ public:
   void SetOutputs(hephaestus::Outputs & outputs);
   void SetSolverOptions(hephaestus::InputParameters & solver_options);
   void SetCoefficients(hephaestus::Coefficients & coefficients);
-  void SetSolverOperator(std::unique_ptr<mfem::Solver> & solver,
-                         std::string solve_type,
-                         mfem::HypreParMatrix & A);
-  void SetFEMPreconditioner(mfem::HypreParMatrix & A);
-  void SetFEMSolver(mfem::HypreParMatrix & A);
-  void SetJacobianPreconditioner(mfem::HypreParMatrix & A);
-  void SetJacobianSolver(mfem::HypreParMatrix & A);
 
   void AddFESpace(std::string fespace_name,
                   std::string fec_name,

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -27,11 +27,14 @@ public:
   void SetLinearPreconditioner(mfem::Operator & A);
   void SetLinearSolver(mfem::Operator & A);
 
-  void SetComm(MPI_Comm comm);
-  void SetSolverOptions(hephaestus::InputParameters solver_options);
+  void SetComm(const MPI_Comm comm);
+  void SetSolverOptions(const hephaestus::InputParameters solver_options);
+  void SetEdgeFESpace(mfem::ParFiniteElementSpace * edge_fes);
 
   std::shared_ptr<mfem::Solver> _linear_solver{nullptr};
   std::shared_ptr<mfem::Solver> _linear_preconditioner{nullptr};
+
+  mfem::ParFiniteElementSpace * _edge_fespace{nullptr};
 
 private:
   MPI_Comm _comm;

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -23,9 +23,9 @@ public:
   ~ProblemSolvers() = default;
 
   void
-  SetSolver(std::shared_ptr<mfem::Solver> & solver, std::string solve_type, mfem::Operator & A);
-  void SetLinearPreconditioner(mfem::Operator & A);
-  void SetLinearSolver(mfem::Operator & A);
+  SetSolver(std::shared_ptr<mfem::Solver> & solver, std::string solve_type, mfem::Operator * A);
+  void SetLinearPreconditioner(mfem::Operator * A);
+  void SetLinearSolver(mfem::Operator * A);
 
   void SetComm(const MPI_Comm comm);
   void SetSolverOptions(const hephaestus::InputParameters solver_options);
@@ -33,6 +33,9 @@ public:
 
   std::shared_ptr<mfem::Solver> _linear_solver{nullptr};
   std::shared_ptr<mfem::Solver> _linear_preconditioner{nullptr};
+
+  // In case the user chooses SuperLU
+  std::shared_ptr<mfem::SuperLURowLocMatrix> _a_super_lu{nullptr};
 
   mfem::ParFiniteElementSpace * _edge_fespace{nullptr};
 

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -29,6 +29,11 @@ public:
   std::unique_ptr<mfem::ODESolver> _ode_solver{nullptr};
   std::unique_ptr<mfem::BlockVector> _f{nullptr};
 
+  std::unique_ptr<mfem::Solver> _fem_solver{nullptr};
+  std::unique_ptr<mfem::Solver> _fem_preconditioner{nullptr};
+  std::unique_ptr<mfem::Solver> _jacobian_solver{nullptr};
+  std::unique_ptr<mfem::Solver> _jacobian_preconditioner{nullptr};
+
   hephaestus::FECollections _fecs;
   hephaestus::FESpaces _fespaces;
   hephaestus::GridFunctions _gridfunctions;
@@ -61,6 +66,13 @@ public:
   void SetOutputs(hephaestus::Outputs & outputs);
   void SetSolverOptions(hephaestus::InputParameters & solver_options);
   void SetCoefficients(hephaestus::Coefficients & coefficients);
+  void SetSolverOperator(std::unique_ptr<mfem::Solver> & solver,
+                         std::string solve_type,
+                         mfem::HypreParMatrix & A);
+  void SetFEMPreconditioner(mfem::HypreParMatrix & A);
+  void SetFEMSolver(mfem::HypreParMatrix & A);
+  void SetJacobianPreconditioner(mfem::HypreParMatrix & A);
+  void SetJacobianSolver(mfem::HypreParMatrix & A);
 
   void AddFESpace(std::string fespace_name,
                   std::string fec_name,

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -32,12 +32,12 @@ public:
   void SetComm(MPI_Comm comm);
   void SetSolverOptions(hephaestus::InputParameters solver_options);
 
-private:
   std::unique_ptr<mfem::Solver> _fem_solver{nullptr};
   std::unique_ptr<mfem::Solver> _fem_preconditioner{nullptr};
   std::unique_ptr<mfem::Solver> _jacobian_solver{nullptr};
   std::unique_ptr<mfem::Solver> _jacobian_preconditioner{nullptr};
 
+private:
   MPI_Comm _comm;
   bool _comm_set{false};
   hephaestus::InputParameters _solver_options;

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -23,19 +23,15 @@ public:
   ~ProblemSolvers() = default;
 
   void
-  SetSolver(std::unique_ptr<mfem::Solver> & solver, std::string solve_type, mfem::Operator & A);
-  void SetFEMPreconditioner(mfem::Operator & A);
-  void SetFEMSolver(mfem::Operator & A);
-  void SetJacobianPreconditioner(mfem::Operator & A);
-  void SetJacobianSolver(mfem::Operator & A);
+  SetSolver(std::shared_ptr<mfem::Solver> & solver, std::string solve_type, mfem::Operator & A);
+  void SetLinearPreconditioner(mfem::Operator & A);
+  void SetLinearSolver(mfem::Operator & A);
 
   void SetComm(MPI_Comm comm);
   void SetSolverOptions(hephaestus::InputParameters solver_options);
 
-  std::unique_ptr<mfem::Solver> _fem_solver{nullptr};
-  std::unique_ptr<mfem::Solver> _fem_preconditioner{nullptr};
-  std::unique_ptr<mfem::Solver> _jacobian_solver{nullptr};
-  std::unique_ptr<mfem::Solver> _jacobian_preconditioner{nullptr};
+  std::shared_ptr<mfem::Solver> _linear_solver{nullptr};
+  std::shared_ptr<mfem::Solver> _linear_preconditioner{nullptr};
 
 private:
   MPI_Comm _comm;


### PR DESCRIPTION
This PR allows the user to choose the desired solver and preconditioner for any given problem that is within a larger formulation in Hephaestus. Each formulation has its own default choices should the user not specify any solvers.