### PR TITLE
Add (optional) external field contributions to Formulation AuxSolvers

### DIFF
--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -35,17 +35,16 @@ defineSources()
   while (ss >> att)
     coil_domains.Append(att);
 
-  hephaestus::InputParameters coilsolver_pars;
-  coilsolver_pars.SetParam("HCurlFESpaceName", std::string("HCurl"));
-  coilsolver_pars.SetParam("GradPotentialName", std::string("source_grad_phi"));
-  coilsolver_pars.SetParam("IFuncCoefName", std::string("I"));
-  coilsolver_pars.SetParam("ConductivityCoefName", std::string("electrical_conductivity"));
-  coilsolver_pars.SetParam("H1FESpaceName", std::string("H1"));
-  coilsolver_pars.SetParam("GradPhiTransfer", true);
-
   hephaestus::Sources sources;
   sources.Register("source",
-                   new hephaestus::ClosedCoilSolver(coilsolver_pars, coil_domains, electrode_attr),
+                   new hephaestus::ClosedCoilSolver("source_grad_phi",
+                                                    "HCurl",
+                                                    "H1",
+                                                    "I",
+                                                    "electrical_conductivity",
+                                                    coil_domains,
+                                                    electrode_attr,
+                                                    true),
                    true);
   return sources;
 }

--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -107,17 +107,16 @@ defineCoefficients()
 hephaestus::Sources
 defineSources()
 {
-  hephaestus::InputParameters div_free_source_params;
-  div_free_source_params.SetParam("SourceName", std::string("source"));
-  div_free_source_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
-  div_free_source_params.SetParam("H1FESpaceName", std::string("H1"));
   hephaestus::InputParameters current_solver_options;
   current_solver_options.SetParam("Tolerance", float(1.0e-12));
   current_solver_options.SetParam("MaxIter", (unsigned int)200);
   current_solver_options.SetParam("PrintLevel", 0);
-  div_free_source_params.SetParam("SolverOptions", current_solver_options);
   hephaestus::Sources sources;
-  sources.Register("source", new hephaestus::DivFreeSource(div_free_source_params), true);
+  sources.Register(
+      "source",
+      new hephaestus::DivFreeSource(
+          "source", "source", "HCurl", "H1", "_source_potential", current_solver_options),
+      true);
   return sources;
 }
 hephaestus::Outputs

--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -179,7 +179,8 @@ main(int argc, char * argv[])
   problem_builder->RegisterJouleHeatingDensityAux("joule_heating_density",
                                                   "electric_field_real",
                                                   "electric_field_imag",
-                                                  "electrical_conductivity");
+                                                  "current_density_real",
+                                                  "current_density_imag");
 
   hephaestus::Coefficients coefficients = defineCoefficients();
   problem_builder->SetCoefficients(coefficients);

--- a/examples/magnetostatic/Main.cpp
+++ b/examples/magnetostatic/Main.cpp
@@ -103,19 +103,18 @@ defineCoefficients()
 hephaestus::Sources
 defineSources()
 {
-  hephaestus::InputParameters div_free_source_params;
-  div_free_source_params.SetParam("SourceName", std::string("source"));
-  div_free_source_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
-  div_free_source_params.SetParam("H1FESpaceName", std::string("H1"));
-
   hephaestus::InputParameters current_solver_options;
   current_solver_options.SetParam("Tolerance", float(1.0e-12));
   current_solver_options.SetParam("MaxIter", (unsigned int)200);
   current_solver_options.SetParam("PrintLevel", 0);
-  div_free_source_params.SetParam("SolverOptions", current_solver_options);
 
   hephaestus::Sources sources;
-  sources.Register("source", new hephaestus::DivFreeSource(div_free_source_params), true);
+
+  sources.Register(
+      "source",
+      new hephaestus::DivFreeSource(
+          "source", "source", "HCurl", "H1", "_source_potential", current_solver_options, false),
+      true);
 
   return sources;
 }

--- a/examples/open_coil/Main.cpp
+++ b/examples/open_coil/Main.cpp
@@ -30,10 +30,9 @@ hephaestus::Sources
 defineSources(std::pair<int, int> elec, mfem::Array<int> coil_domains)
 {
   hephaestus::Sources sources;
-  sources.Register(
-      "source",
-      std::make_shared<hephaestus::OpenCoilSolver>(
-          "grad_phi", "auxiliary_potential", "I", "electrical_conductivity", coil_domains, elec));
+  sources.Register("source",
+                   std::make_shared<hephaestus::OpenCoilSolver>(
+                       "grad_phi", "phi", "I", "electrical_conductivity", coil_domains, elec));
   return sources;
 }
 
@@ -132,6 +131,7 @@ main(int argc, char * argv[])
   problem_builder->AddFESpace(std::string("HCurl"), std::string("ND_3D_P1"));
   problem_builder->AddFESpace(std::string("HDiv"), std::string("RT_3D_P0"));
   problem_builder->AddGridFunction(std::string("magnetic_vector_potential"), std::string("HCurl"));
+  problem_builder->AddGridFunction(std::string("phi"), std::string("H1"));
   problem_builder->AddGridFunction(std::string("grad_phi"), std::string("HCurl"));
   problem_builder->AddGridFunction(std::string("magnetic_flux_density"), std::string("HDiv"));
   problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density");

--- a/examples/open_coil/Main.cpp
+++ b/examples/open_coil/Main.cpp
@@ -29,15 +29,12 @@ defineCoefficients(double Itotal)
 hephaestus::Sources
 defineSources(std::pair<int, int> elec, mfem::Array<int> coil_domains)
 {
-  hephaestus::InputParameters coilsolver_pars;
-  coilsolver_pars.SetParam("GradPotentialName", std::string("grad_phi"));
-  coilsolver_pars.SetParam("PotentialName", std::string("auxiliary_potential"));
-  coilsolver_pars.SetParam("IFuncCoefName", std::string("I"));
-  coilsolver_pars.SetParam("ConductivityCoefName", std::string("electrical_conductivity"));
-
   hephaestus::Sources sources;
   sources.Register(
-      "source", new hephaestus::OpenCoilSolver(coilsolver_pars, coil_domains, elec), true);
+      "source",
+      new hephaestus::OpenCoilSolver(
+          "grad_phi", "auxiliary_potential", "I", "electrical_conductivity", coil_domains, elec),
+      true);
   return sources;
 }
 

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -104,19 +104,18 @@ defineCoefficients()
 hephaestus::Sources
 defineSources()
 {
-  hephaestus::InputParameters div_free_source_params;
-  div_free_source_params.SetParam("SourceName", std::string("source"));
-  div_free_source_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
-  div_free_source_params.SetParam("H1FESpaceName", std::string("H1"));
-
   hephaestus::InputParameters current_solver_options;
   current_solver_options.SetParam("Tolerance", float(1.0e-12));
   current_solver_options.SetParam("MaxIter", (unsigned int)200);
   current_solver_options.SetParam("PrintLevel", 0);
-  div_free_source_params.SetParam("SolverOptions", current_solver_options);
 
   hephaestus::Sources sources;
-  sources.Register("source", new hephaestus::DivFreeSource(div_free_source_params), true);
+
+  sources.Register(
+      "source",
+      new hephaestus::DivFreeSource(
+          "source", "source", "HCurl", "H1", "_source_potential", current_solver_options, false),
+      true);
 
   return sources;
 }

--- a/src/auxsolvers/scaled_curl_vector_gridfunction_aux.cpp
+++ b/src/auxsolvers/scaled_curl_vector_gridfunction_aux.cpp
@@ -8,8 +8,11 @@ ScaledCurlVectorGridFunctionAux::ScaledCurlVectorGridFunctionAux(
     const std::string & scaled_gf_name,
     const std::string & coef_name,
     const double & aConst,
+    const double & bConst,
+    const std::string & shift_gf_name,
     const hephaestus::InputParameters & solver_options)
-  : ScaledVectorGridFunctionAux(input_gf_name, scaled_gf_name, coef_name, aConst, solver_options)
+  : ScaledVectorGridFunctionAux(
+        input_gf_name, scaled_gf_name, coef_name, aConst, bConst, shift_gf_name, solver_options)
 {
 }
 

--- a/src/auxsolvers/scaled_curl_vector_gridfunction_aux.hpp
+++ b/src/auxsolvers/scaled_curl_vector_gridfunction_aux.hpp
@@ -15,6 +15,8 @@ public:
       const std::string & scaled_gf_name,
       const std::string & coef_name,
       const double & aConst = 1.0,
+      const double & bConst = 1.0,
+      const std::string & shift_gf_name = "",
       const hephaestus::InputParameters & solver_options = hephaestus::InputParameters());
 
   ~ScaledCurlVectorGridFunctionAux() override = default;

--- a/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
+++ b/src/auxsolvers/scaled_vector_gridfunction_aux.hpp
@@ -15,6 +15,8 @@ public:
       std::string scaled_gf_name,
       std::string coef_name,
       const double & aConst = 1.0,
+      const double & bConst = 1.0,
+      std::string shift_gf_name = "",
       hephaestus::InputParameters solver_options = hephaestus::InputParameters());
 
   ~ScaledVectorGridFunctionAux() override = default;
@@ -41,8 +43,10 @@ protected:
 private:
   const std::string _input_gf_name;
   const std::string _scaled_gf_name;
+  const std::string _shift_gf_name;
   const std::string _coef_name;
   const double _a_const;
+  const double _b_const;
   const hephaestus::InputParameters _solver_options;
 
   // Input gridfunction to be scaled by a scalar coefficient
@@ -50,6 +54,9 @@ private:
 
   // Gridfunction in which to store result
   mfem::ParGridFunction * _scaled_gf{nullptr};
+
+  // Optional gridfunction in which to shift result by
+  mfem::ParGridFunction * _shift_gf{nullptr};
 
   // Operator matrices
   std::unique_ptr<mfem::HypreParMatrix> _a_mat{nullptr};

--- a/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
+++ b/src/auxsolvers/vector_gridfunction_dot_product_aux.cpp
@@ -55,13 +55,18 @@ void
 VectorGridFunctionDotProductAux::Init(const hephaestus::GridFunctions & gridfunctions,
                                       hephaestus::Coefficients & coefficients)
 {
-
-  _scaling_coef = coefficients._scalars.Get(_scaling_coef_name);
-  if (_scaling_coef == nullptr)
+  if (_scaling_coef_name.empty())
   {
-    MFEM_ABORT("Conductivity coefficient not found for Joule heating");
+    _scaling_coef = coefficients._scalars.Get("_one");
   }
-
+  else
+  {
+    _scaling_coef = coefficients._scalars.Get(_scaling_coef_name);
+    if (_scaling_coef == nullptr)
+    {
+      MFEM_ABORT("Conductivity coefficient not found for Joule heating");
+    }
+  }
   if (_complex_average)
   {
     _u_gf_re = gridfunctions.Get(_u_gf_real_name);

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
@@ -113,8 +113,8 @@ ComplexAFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_
                                                       p_field_name,
                                                       _loss_coef_name,
                                                       _magnetic_vector_potential_real_name,
-                                                      _magnetic_vector_potential_real_name,
                                                       j_field_real_name,
+                                                      _magnetic_vector_potential_imag_name,
                                                       j_field_imag_name,
                                                       true),
       true);

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
@@ -80,7 +80,8 @@ void
 ComplexAFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                                     const std::string & e_field_real_name,
                                                     const std::string & e_field_imag_name,
-                                                    const std::string & conductivity_coef_name)
+                                                    const std::string & j_field_real_name,
+                                                    const std::string & j_field_imag_name)
 {
   //* Time averaged Joule heating density = E.J
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
@@ -91,8 +92,8 @@ ComplexAFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_
                                                       _loss_coef_name,
                                                       _magnetic_vector_potential_real_name,
                                                       _magnetic_vector_potential_real_name,
-                                                      _magnetic_vector_potential_imag_name,
-                                                      _magnetic_vector_potential_imag_name,
+                                                      j_field_real_name,
+                                                      j_field_imag_name,
                                                       true),
       true);
   auxsolvers.Get(p_field_name)->SetPriority(2);

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
@@ -23,26 +23,38 @@ ComplexAFormulation::ComplexAFormulation(const std::string & magnetic_reluctivit
 // Enable auxiliary calculation of J ∈ H(div)
 void
 ComplexAFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_name,
-                                               const std::string & j_field_imag_name)
+                                               const std::string & j_field_imag_name,
+                                               const std::string & external_j_field_real_name,
+                                               const std::string & external_j_field_imag_name)
 {
   //* Current density J = Jᵉ + σE
   //* Induced current density Jind = σE = -iωσA
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       j_field_imag_name,
-      new hephaestus::ScaledVectorGridFunctionAux(
-          _magnetic_vector_potential_real_name, j_field_imag_name, _loss_coef_name, -1.0),
+      new hephaestus::ScaledVectorGridFunctionAux(_magnetic_vector_potential_real_name,
+                                                  j_field_imag_name,
+                                                  _loss_coef_name,
+                                                  -1.0,
+                                                  1.0,
+                                                  external_j_field_imag_name),
       true);
   auxsolvers.Register(
       j_field_real_name,
-      new hephaestus::ScaledVectorGridFunctionAux(
-          _magnetic_vector_potential_imag_name, j_field_real_name, _loss_coef_name, 1.0),
+      new hephaestus::ScaledVectorGridFunctionAux(_magnetic_vector_potential_imag_name,
+                                                  j_field_real_name,
+                                                  _loss_coef_name,
+                                                  1.0,
+                                                  1.0,
+                                                  external_j_field_real_name),
       true);
 };
 
 void
 ComplexAFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
-                                                    const std::string & b_field_imag_name)
+                                                    const std::string & b_field_imag_name,
+                                                    const std::string & external_b_field_real_name,
+                                                    const std::string & external_b_field_imag_name)
 {
   //* Magnetic flux density B = curl A
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
@@ -58,19 +70,29 @@ ComplexAFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_
 
 void
 ComplexAFormulation::RegisterElectricFieldAux(const std::string & e_field_real_name,
-                                              const std::string & e_field_imag_name)
+                                              const std::string & e_field_imag_name,
+                                              const std::string & external_e_field_real_name,
+                                              const std::string & external_e_field_imag_name)
 {
   //* Electric field E =-dA/dt=-iωA
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       e_field_imag_name,
-      new hephaestus::ScaledVectorGridFunctionAux(
-          _magnetic_vector_potential_real_name, e_field_imag_name, "_angular_frequency", -1.0),
+      new hephaestus::ScaledVectorGridFunctionAux(_magnetic_vector_potential_real_name,
+                                                  e_field_imag_name,
+                                                  "_angular_frequency",
+                                                  -1.0,
+                                                  1.0,
+                                                  external_e_field_imag_name),
       true);
   auxsolvers.Register(
       e_field_real_name,
-      new hephaestus::ScaledVectorGridFunctionAux(
-          _magnetic_vector_potential_imag_name, e_field_real_name, "_angular_frequency", 1.0),
+      new hephaestus::ScaledVectorGridFunctionAux(_magnetic_vector_potential_imag_name,
+                                                  e_field_real_name,
+                                                  "_angular_frequency",
+                                                  1.0,
+                                                  1.0,
+                                                  external_e_field_real_name),
       true);
 }
 

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
@@ -57,7 +57,8 @@ public:
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_real_name,
                                       const std::string & e_field_imag_name,
-                                      const std::string & conductivity_coef_name) override;
+                                      const std::string & j_field_real_name,
+                                      const std::string & j_field_imag_name) override;
 
 protected:
   const std::string & _magnetic_reluctivity_name =

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
@@ -42,15 +42,21 @@ public:
   // Enable auxiliary calculation of J ∈ H(div)
   //* Induced electric current, Jind = σE = -iωσA
   void RegisterCurrentDensityAux(const std::string & j_field_real_name,
-                                 const std::string & j_field_imag_name) override;
+                                 const std::string & j_field_imag_name,
+                                 const std::string & external_j_field_real_name = "",
+                                 const std::string & external_j_field_imag_name = "") override;
 
   //* Magnetic flux density B = curl A
   void RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
-                                      const std::string & b_field_imag_name) override;
+                                      const std::string & b_field_imag_name,
+                                      const std::string & external_b_field_real_name = "",
+                                      const std::string & external_b_field_imag_name = "") override;
 
   //* Electric field E =-dA/dt=-iωA
   void RegisterElectricFieldAux(const std::string & e_field_real_name,
-                                const std::string & e_field_imag_name) override;
+                                const std::string & e_field_imag_name,
+                                const std::string & external_e_field_real_name = "",
+                                const std::string & external_e_field_imag_name = "") override;
 
   // Enable auxiliary calculation of P ∈ L2
   // Time averaged Joule heating density E.J

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -30,22 +30,30 @@ ComplexEFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_
   //* Current density J = Jᵉ + σE
   //* Induced electric current, Jind = σE
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
-  auxsolvers.Register(j_field_real_name,
-                      new hephaestus::ScaledVectorGridFunctionAux(_electric_field_real_name,
-                                                                  j_field_real_name,
-                                                                  _electric_conductivity_name,
-                                                                  1.0,
-                                                                  1.0,
-                                                                  external_j_field_real_name),
-                      true);
-  auxsolvers.Register(j_field_imag_name,
-                      new hephaestus::ScaledVectorGridFunctionAux(_electric_field_imag_name,
-                                                                  j_field_imag_name,
-                                                                  _electric_conductivity_name,
-                                                                  1.0,
-                                                                  1.0,
-                                                                  external_j_field_imag_name),
-                      true);
+  auxsolvers.Register(
+      j_field_real_name,
+      new hephaestus::ScaledVectorGridFunctionAux(
+          _electric_field_real_name,
+          j_field_real_name,
+          _electric_conductivity_name,
+          1.0,
+          1.0,
+          external_j_field_real_name,
+          hephaestus::InputParameters(
+              {{"Tolerance", float(1.0e-12)}, {"MaxIter", (unsigned int)200}, {"PrintLevel", 1}})),
+      true);
+  auxsolvers.Register(
+      j_field_imag_name,
+      new hephaestus::ScaledVectorGridFunctionAux(
+          _electric_field_imag_name,
+          j_field_imag_name,
+          _electric_conductivity_name,
+          1.0,
+          1.0,
+          external_j_field_imag_name,
+          hephaestus::InputParameters(
+              {{"Tolerance", float(1.0e-12)}, {"MaxIter", (unsigned int)200}, {"PrintLevel", 1}})),
+      true);
 };
 
 void
@@ -90,8 +98,8 @@ ComplexEFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_
                                                                       p_field_name,
                                                                       "",
                                                                       _electric_field_real_name,
-                                                                      _electric_field_real_name,
                                                                       j_field_real_name,
+                                                                      _electric_field_imag_name,
                                                                       j_field_imag_name,
                                                                       true),
                       true);

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -64,18 +64,19 @@ void
 ComplexEFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                                     const std::string & e_field_real_name,
                                                     const std::string & e_field_imag_name,
-                                                    const std::string & conductivity_coef_name)
+                                                    const std::string & j_field_real_name,
+                                                    const std::string & j_field_imag_name)
 {
   //* Time averaged Joule heating density = E.J
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(p_field_name,
                       new hephaestus::VectorGridFunctionDotProductAux(p_field_name,
                                                                       p_field_name,
-                                                                      _electric_conductivity_name,
+                                                                      "",
                                                                       _electric_field_real_name,
                                                                       _electric_field_real_name,
-                                                                      _electric_field_imag_name,
-                                                                      _electric_field_imag_name,
+                                                                      j_field_real_name,
+                                                                      j_field_imag_name,
                                                                       true),
                       true);
   auxsolvers.Get(p_field_name)->SetPriority(2);

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -23,7 +23,9 @@ ComplexEFormulation::ComplexEFormulation(const std::string & magnetic_reluctivit
 // Enable auxiliary calculation of J ∈ H(div)
 void
 ComplexEFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_name,
-                                               const std::string & j_field_imag_name)
+                                               const std::string & j_field_imag_name,
+                                               const std::string & external_j_field_real_name,
+                                               const std::string & external_j_field_imag_name)
 {
   //* Current density J = Jᵉ + σE
   //* Induced electric current, Jind = σE
@@ -31,32 +33,46 @@ ComplexEFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_
   auxsolvers.Register(j_field_real_name,
                       new hephaestus::ScaledVectorGridFunctionAux(_electric_field_real_name,
                                                                   j_field_real_name,
-                                                                  _electric_conductivity_name),
+                                                                  _electric_conductivity_name,
+                                                                  1.0,
+                                                                  1.0,
+                                                                  external_j_field_real_name),
                       true);
   auxsolvers.Register(j_field_imag_name,
                       new hephaestus::ScaledVectorGridFunctionAux(_electric_field_imag_name,
                                                                   j_field_imag_name,
-                                                                  _electric_conductivity_name),
+                                                                  _electric_conductivity_name,
+                                                                  1.0,
+                                                                  1.0,
+                                                                  external_j_field_imag_name),
                       true);
 };
 
 void
 ComplexEFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
-                                                    const std::string & b_field_imag_name)
+                                                    const std::string & b_field_imag_name,
+                                                    const std::string & external_b_field_real_name,
+                                                    const std::string & external_b_field_imag_name)
 {
   //* Magnetic flux density B = (i/ω) curl E
   //* (∇×E = -dB/dt = -iωB)
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
-  auxsolvers.Register(
-      b_field_imag_name,
-      new hephaestus::ScaledCurlVectorGridFunctionAux(
-          _electric_field_real_name, b_field_imag_name, "_inv_angular_frequency", 1.0),
-      true);
-  auxsolvers.Register(
-      b_field_real_name,
-      new hephaestus::ScaledCurlVectorGridFunctionAux(
-          _electric_field_imag_name, b_field_real_name, "_inv_angular_frequency", -1.0),
-      true);
+  auxsolvers.Register(b_field_imag_name,
+                      new hephaestus::ScaledCurlVectorGridFunctionAux(_electric_field_real_name,
+                                                                      b_field_imag_name,
+                                                                      "_inv_angular_frequency",
+                                                                      1.0,
+                                                                      1.0,
+                                                                      external_b_field_imag_name),
+                      true);
+  auxsolvers.Register(b_field_real_name,
+                      new hephaestus::ScaledCurlVectorGridFunctionAux(_electric_field_imag_name,
+                                                                      b_field_real_name,
+                                                                      "_inv_angular_frequency",
+                                                                      -1.0,
+                                                                      1.0,
+                                                                      external_b_field_real_name),
+                      true);
 }
 
 // Enable auxiliary calculation of P ∈ L2

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
@@ -41,16 +41,22 @@ public:
   // Enable auxiliary calculation of J ∈ H(div)
   //* Induced electric current, Jind = σE
   void RegisterCurrentDensityAux(const std::string & j_field_real_name,
-                                 const std::string & j_field_imag_name) override;
+                                 const std::string & j_field_imag_name,
+                                 const std::string & external_j_field_real_name = "",
+                                 const std::string & external_j_field_imag_name = "") override;
 
   //* Magnetic flux density B = (i/ω) curl E
   //* (∇×E = -dB/dt = -iωB)
   void RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
-                                      const std::string & b_field_imag_name) override;
+                                      const std::string & b_field_imag_name,
+                                      const std::string & external_b_field_real_name = "",
+                                      const std::string & external_b_field_imag_name = "") override;
 
   //* Electric field is already a state variable solved for
   void RegisterElectricFieldAux(const std::string & e_field_real_name,
-                                const std::string & e_field_imag_name) override
+                                const std::string & e_field_imag_name,
+                                const std::string & external_e_field_real_name = "",
+                                const std::string & external_e_field_imag_name = "") override
   {
   }
 

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
@@ -59,7 +59,8 @@ public:
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_real_name,
                                       const std::string & e_field_imag_name,
-                                      const std::string & conductivity_coef_name) override;
+                                      const std::string & j_field_real_name,
+                                      const std::string & j_field_imag_name) override;
 
 protected:
   const std::string & _magnetic_reluctivity_name =

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -17,14 +17,19 @@ EBDualFormulation::EBDualFormulation(const std::string & magnetic_reluctivity_na
 }
 
 void
-EBDualFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
+EBDualFormulation::RegisterCurrentDensityAux(const std::string & j_field_name,
+                                             const std::string & external_j_field_name)
 {
   //* Current density J = Jᵉ + σE
   //* Induced electric field, Jind = σE
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(j_field_name,
-                      new hephaestus::ScaledVectorGridFunctionAux(
-                          _h_curl_var_name, j_field_name, _electric_conductivity_name),
+                      new hephaestus::ScaledVectorGridFunctionAux(_h_curl_var_name,
+                                                                  j_field_name,
+                                                                  _electric_conductivity_name,
+                                                                  1.0,
+                                                                  1.0,
+                                                                  external_j_field_name),
                       true);
 }
 

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -50,15 +50,14 @@ EBDualFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_na
 void
 EBDualFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                                   const std::string & e_field_name,
-                                                  const std::string & conductivity_coef_name)
+                                                  const std::string & j_field_name)
 {
   //* Joule heating density = E.J
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
-  auxsolvers.Register(
-      p_field_name,
-      new hephaestus::VectorGridFunctionDotProductAux(
-          p_field_name, p_field_name, _electric_conductivity_name, e_field_name, e_field_name),
-      true);
+  auxsolvers.Register(p_field_name,
+                      new hephaestus::VectorGridFunctionDotProductAux(
+                          p_field_name, p_field_name, "", e_field_name, j_field_name),
+                      true);
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }
 

--- a/src/formulations/Dual/eb_dual_formulation.hpp
+++ b/src/formulations/Dual/eb_dual_formulation.hpp
@@ -18,7 +18,8 @@ public:
   ~EBDualFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  void RegisterCurrentDensityAux(const std::string & j_field_name) override;
+  void RegisterCurrentDensityAux(const std::string & j_field_name,
+                                 const std::string & external_j_field_name = "") override;
 
   // Enable auxiliary calculation of F ∈ L2
   void RegisterLorentzForceDensityAux(const std::string & f_field_name,

--- a/src/formulations/Dual/eb_dual_formulation.hpp
+++ b/src/formulations/Dual/eb_dual_formulation.hpp
@@ -29,7 +29,7 @@ public:
   // Enable auxiliary calculation of P ∈ L2
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
-                                      const std::string & conductivity_coef_name) override;
+                                      const std::string & j_field_name) override;
 
   void RegisterCoefficients() override;
 

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -105,15 +105,14 @@ AFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_name,
 void
 AFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                              const std::string & e_field_name,
-                                             const std::string & conductivity_coef_name)
+                                             const std::string & j_field_name)
 {
   //* Joule heating density = E.J
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
-  auxsolvers.Register(
-      p_field_name,
-      new hephaestus::VectorGridFunctionDotProductAux(
-          p_field_name, p_field_name, _electric_conductivity_name, e_field_name, e_field_name),
-      true);
+  auxsolvers.Register(p_field_name,
+                      new hephaestus::VectorGridFunctionDotProductAux(
+                          p_field_name, p_field_name, "", e_field_name, j_field_name),
+                      true);
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }
 

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -31,20 +31,26 @@ AFormulation::AFormulation(const std::string & magnetic_reluctivity_name,
 }
 
 void
-AFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
+AFormulation::RegisterCurrentDensityAux(const std::string & j_field_name,
+                                        const std::string & external_j_field_name)
 {
   //* Current density J = Jᵉ -σdA/dt
   //* Induced electric field, Jind = -σdA/dt
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       j_field_name,
-      new hephaestus::ScaledVectorGridFunctionAux(
-          GetTimeDerivativeName(_h_curl_var_name), j_field_name, _electric_conductivity_name, -1.0),
+      new hephaestus::ScaledVectorGridFunctionAux(GetTimeDerivativeName(_h_curl_var_name),
+                                                  j_field_name,
+                                                  _electric_conductivity_name,
+                                                  -1.0,
+                                                  1.0,
+                                                  external_j_field_name),
       true);
 }
 
 void
-AFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
+AFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name,
+                                             const std::string & external_b_field_name)
 {
   //* Magnetic flux density, B = ∇×A
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
@@ -53,19 +59,26 @@ AFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
 }
 
 void
-AFormulation::RegisterElectricFieldAux(const std::string & e_field_name)
+AFormulation::RegisterElectricFieldAux(const std::string & e_field_name,
+                                       const std::string & external_e_field_name)
 {
   //* Total electric field, E = ρJᵉ -dA/dt
   //* Induced electric field, Eind = -dA/dt
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
-  auxsolvers.Register(e_field_name,
-                      new hephaestus::ScaledVectorGridFunctionAux(
-                          GetTimeDerivativeName(_h_curl_var_name), e_field_name, "_one", -1.0),
-                      true);
+  auxsolvers.Register(
+      e_field_name,
+      new hephaestus::ScaledVectorGridFunctionAux(GetTimeDerivativeName(_h_curl_var_name),
+                                                  e_field_name,
+                                                  "_one",
+                                                  -1.0,
+                                                  1.0,
+                                                  external_e_field_name),
+      true);
 }
 
 void
-AFormulation::RegisterMagneticFieldAux(const std::string & h_field_name)
+AFormulation::RegisterMagneticFieldAux(const std::string & h_field_name,
+                                       const std::string & external_h_field_name)
 {
   //* Magnetic field H = ν∇×A
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;

--- a/src/formulations/HCurl/a_formulation.hpp
+++ b/src/formulations/HCurl/a_formulation.hpp
@@ -17,16 +17,20 @@ public:
   ~AFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  void RegisterCurrentDensityAux(const std::string & j_field_name) override;
+  void RegisterCurrentDensityAux(const std::string & j_field_name,
+                                 const std::string & external_j_field_name = "") override;
 
   // Enable auxiliary calculation of B ∈ H(div)
-  void RegisterMagneticFluxDensityAux(const std::string & b_field_name) override;
+  void RegisterMagneticFluxDensityAux(const std::string & b_field_name,
+                                      const std::string & external_b_field_name = "") override;
 
   // Enable auxiliary calculation of E ∈ H(curl)
-  void RegisterElectricFieldAux(const std::string & e_field_name) override;
+  void RegisterElectricFieldAux(const std::string & e_field_name,
+                                const std::string & external_e_field_name = "") override;
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  void RegisterMagneticFieldAux(const std::string & h_field_name) override;
+  void RegisterMagneticFieldAux(const std::string & h_field_name,
+                                const std::string & external_h_field_name = "") override;
 
   // Enable auxiliary calculation of F ∈ L2
   void RegisterLorentzForceDensityAux(const std::string & f_field_name,

--- a/src/formulations/HCurl/a_formulation.hpp
+++ b/src/formulations/HCurl/a_formulation.hpp
@@ -40,7 +40,7 @@ public:
   // Enable auxiliary calculation of P ∈ L2
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
-                                      const std::string & conductivity_coef_name) override;
+                                      const std::string & j_field_name) override;
 
   void RegisterCoefficients() override;
 

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -48,14 +48,19 @@ EFormulation::RegisterCoefficients()
 }
 
 void
-EFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
+EFormulation::RegisterCurrentDensityAux(const std::string & j_field_name,
+                                        const std::string & external_j_field_name)
 {
   //* Current density J = Jᵉ + σE
   //* Induced electric field, Jind = σE
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(j_field_name,
-                      new hephaestus::ScaledVectorGridFunctionAux(
-                          _h_curl_var_name, j_field_name, _electric_conductivity_name),
+                      new hephaestus::ScaledVectorGridFunctionAux(_h_curl_var_name,
+                                                                  j_field_name,
+                                                                  _electric_conductivity_name,
+                                                                  1.0,
+                                                                  1.0,
+                                                                  external_j_field_name),
                       true);
 }
 

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -67,15 +67,14 @@ EFormulation::RegisterCurrentDensityAux(const std::string & j_field_name,
 void
 EFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                              const std::string & e_field_name,
-                                             const std::string & conductivity_coef_name)
+                                             const std::string & j_field_name)
 {
   //* Joule heating density = E.J
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
-  auxsolvers.Register(
-      p_field_name,
-      new hephaestus::VectorGridFunctionDotProductAux(
-          p_field_name, p_field_name, _electric_conductivity_name, e_field_name, e_field_name),
-      true);
+  auxsolvers.Register(p_field_name,
+                      new hephaestus::VectorGridFunctionDotProductAux(
+                          p_field_name, p_field_name, "", e_field_name, j_field_name),
+                      true);
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }
 

--- a/src/formulations/HCurl/e_formulation.hpp
+++ b/src/formulations/HCurl/e_formulation.hpp
@@ -25,7 +25,7 @@ public:
   // Enable auxiliary calculation of P ∈ L2
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
-                                      const std::string & conductivity_coef_name) override;
+                                      const std::string & j_field_name) override;
 
 protected:
   const std::string _magnetic_permeability_name;

--- a/src/formulations/HCurl/e_formulation.hpp
+++ b/src/formulations/HCurl/e_formulation.hpp
@@ -19,7 +19,8 @@ public:
   void RegisterCoefficients() override;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  void RegisterCurrentDensityAux(const std::string & j_field_name) override;
+  void RegisterCurrentDensityAux(const std::string & j_field_name,
+                                 const std::string & external_j_field_name = "") override;
 
   // Enable auxiliary calculation of P ∈ L2
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,

--- a/src/formulations/HCurl/h_formulation.cpp
+++ b/src/formulations/HCurl/h_formulation.cpp
@@ -91,15 +91,14 @@ HFormulation::RegisterLorentzForceDensityAux(const std::string & f_field_name,
 void
 HFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                              const std::string & e_field_name,
-                                             const std::string & conductivity_coef_name)
+                                             const std::string & j_field_name)
 {
   //* Joule heating density = E.J
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
-  auxsolvers.Register(
-      p_field_name,
-      new hephaestus::VectorGridFunctionDotProductAux(
-          p_field_name, p_field_name, _electric_conductivity_name, e_field_name, e_field_name),
-      true);
+  auxsolvers.Register(p_field_name,
+                      new hephaestus::VectorGridFunctionDotProductAux(
+                          p_field_name, p_field_name, "", e_field_name, j_field_name),
+                      true);
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }
 

--- a/src/formulations/HCurl/h_formulation.cpp
+++ b/src/formulations/HCurl/h_formulation.cpp
@@ -28,7 +28,8 @@ HFormulation::HFormulation(const std::string & electric_resistivity_name,
 }
 
 void
-HFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
+HFormulation::RegisterCurrentDensityAux(const std::string & j_field_name,
+                                        const std::string & external_j_field_name)
 {
   //* Current density J = ∇×H
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
@@ -37,19 +38,25 @@ HFormulation::RegisterCurrentDensityAux(const std::string & j_field_name)
 }
 
 void
-HFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
+HFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name,
+                                             const std::string & external_b_field_name)
 {
   //* Magnetic flux density, B = Bᵉ + μH
   //* Induced flux density, B = μH
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(b_field_name,
-                      new hephaestus::ScaledVectorGridFunctionAux(
-                          _h_curl_var_name, b_field_name, _magnetic_permeability_name),
+                      new hephaestus::ScaledVectorGridFunctionAux(_h_curl_var_name,
+                                                                  b_field_name,
+                                                                  _magnetic_permeability_name,
+                                                                  1.0,
+                                                                  1.0,
+                                                                  external_b_field_name),
                       true);
 }
 
 void
-HFormulation::RegisterElectricFieldAux(const std::string & e_field_name)
+HFormulation::RegisterElectricFieldAux(const std::string & e_field_name,
+                                       const std::string & external_e_field_name)
 {
   //* Electric field, E = ρ∇×H
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
@@ -60,7 +67,9 @@ HFormulation::RegisterElectricFieldAux(const std::string & e_field_name)
 }
 
 void
-HFormulation::RegisterMagneticFieldAux(const std::string & h_field_name)
+HFormulation::RegisterMagneticFieldAux(const std::string & h_field_name,
+                                       const std::string & external_h_field_name)
+
 {
   //* Magnetic field H is a state variable; no additional calculation needed
 }

--- a/src/formulations/HCurl/h_formulation.hpp
+++ b/src/formulations/HCurl/h_formulation.hpp
@@ -40,7 +40,7 @@ public:
   // Enable auxiliary calculation of P ∈ L2
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
-                                      const std::string & conductivity_coef_name) override;
+                                      const std::string & j_field_name) override;
 
   void RegisterCoefficients() override;
 

--- a/src/formulations/HCurl/h_formulation.hpp
+++ b/src/formulations/HCurl/h_formulation.hpp
@@ -17,16 +17,20 @@ public:
   ~HFormulation() override = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  void RegisterCurrentDensityAux(const std::string & j_field_name) override;
+  void RegisterCurrentDensityAux(const std::string & j_field_name,
+                                 const std::string & external_j_field_name = "") override;
 
   // Enable auxiliary calculation of B ∈ H(div)
-  void RegisterMagneticFluxDensityAux(const std::string & b_field_name) override;
+  void RegisterMagneticFluxDensityAux(const std::string & b_field_name,
+                                      const std::string & external_b_field_name = "") override;
 
   // Enable auxiliary calculation of E ∈ H(curl)
-  void RegisterElectricFieldAux(const std::string & e_field_name) override;
+  void RegisterElectricFieldAux(const std::string & e_field_name,
+                                const std::string & external_e_field_name = "") override;
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  void RegisterMagneticFieldAux(const std::string & h_field_name) override;
+  void RegisterMagneticFieldAux(const std::string & h_field_name,
+                                const std::string & external_h_field_name = "") override;
 
   // Enable auxiliary calculation of F ∈ L2
   void RegisterLorentzForceDensityAux(const std::string & f_field_name,

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.cpp
@@ -29,7 +29,8 @@ MagnetostaticFormulation::MagnetostaticFormulation(
 }
 
 void
-MagnetostaticFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name)
+MagnetostaticFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_name,
+                                                         const std::string & external_b_field_name)
 {
   //* Magnetic flux density, B = ∇×A
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
@@ -38,13 +39,18 @@ MagnetostaticFormulation::RegisterMagneticFluxDensityAux(const std::string & b_f
 }
 
 void
-MagnetostaticFormulation::RegisterMagneticFieldAux(const std::string & h_field_name)
+MagnetostaticFormulation::RegisterMagneticFieldAux(const std::string & h_field_name,
+                                                   const std::string & external_h_field_name)
 {
   //* Magnetic field H = ν∇×A
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(h_field_name,
-                      new hephaestus::ScaledCurlVectorGridFunctionAux(
-                          _h_curl_var_name, h_field_name, _magnetic_reluctivity_name),
+                      new hephaestus::ScaledCurlVectorGridFunctionAux(_h_curl_var_name,
+                                                                      h_field_name,
+                                                                      _magnetic_reluctivity_name,
+                                                                      1.0,
+                                                                      1.0,
+                                                                      external_h_field_name),
                       true);
 }
 

--- a/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
+++ b/src/formulations/Magnetostatic/magnetostatic_formulation.hpp
@@ -16,10 +16,12 @@ public:
   ~MagnetostaticFormulation() override = default;
 
   // Enable auxiliary calculation of B ∈ H(div)
-  void RegisterMagneticFluxDensityAux(const std::string & b_field_name) override;
+  void RegisterMagneticFluxDensityAux(const std::string & b_field_name,
+                                      const std::string & external_b_field_name = "") override;
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  void RegisterMagneticFieldAux(const std::string & h_field_name) override;
+  void RegisterMagneticFieldAux(const std::string & h_field_name,
+                                const std::string & external_h_field_name = "") override;
 
   // Enable auxiliary calculation of F ∈ L2
   void RegisterLorentzForceDensityAux(const std::string & f_field_name,

--- a/src/formulations/complex_em_formulation_interface.hpp
+++ b/src/formulations/complex_em_formulation_interface.hpp
@@ -12,28 +12,36 @@ public:
 
   // Enable auxiliary calculation of J ∈ H(div)
   virtual void RegisterCurrentDensityAux(const std::string & j_field_real_name,
-                                         const std::string & j_field_imag_name)
+                                         const std::string & j_field_imag_name,
+                                         const std::string & external_j_field_real_name = "",
+                                         const std::string & external_j_field_imag_name = "")
   {
     MFEM_ABORT("Current density auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of B ∈ H(div)
   virtual void RegisterMagneticFluxDensityAux(const std::string & b_field_real_name,
-                                              const std::string & b_field_imag_name)
+                                              const std::string & b_field_imag_name,
+                                              const std::string & external_b_field_real_name = "",
+                                              const std::string & external_b_field_imag_name = "")
   {
     MFEM_ABORT("Magnetic flux density auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of E ∈ H(curl)
   virtual void RegisterElectricFieldAux(const std::string & e_field_real_name,
-                                        const std::string & e_field_imag_name)
+                                        const std::string & e_field_imag_name,
+                                        const std::string & external_e_field_real_name = "",
+                                        const std::string & external_e_field_imag_name = "")
   {
     MFEM_ABORT("Electric field auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of H ∈ H(curl)
   virtual void RegisterMagneticFieldAux(const std::string & h_field_real_name,
-                                        const std::string & h_field_imag_name)
+                                        const std::string & h_field_imag_name,
+                                        const std::string & external_h_field_real_name = "",
+                                        const std::string & external_h_field_imag_name = "")
   {
     MFEM_ABORT("Magnetic field auxsolver not available for this formulation");
   }

--- a/src/formulations/complex_em_formulation_interface.hpp
+++ b/src/formulations/complex_em_formulation_interface.hpp
@@ -42,7 +42,8 @@ public:
   virtual void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                               const std::string & e_field_real_name,
                                               const std::string & e_field_imag_name,
-                                              const std::string & conductivity_coef_name)
+                                              const std::string & j_field_real_name,
+                                              const std::string & j_field_imag_name)
   {
     MFEM_ABORT("Joule heating auxsolver not available for this formulation");
   }

--- a/src/formulations/em_formulation_interface.hpp
+++ b/src/formulations/em_formulation_interface.hpp
@@ -49,7 +49,7 @@ public:
   // Enable auxiliary calculation of P ∈ L2
   virtual void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                               const std::string & e_field_name,
-                                              const std::string & conductivity_coef_name)
+                                              const std::string & j_field_name)
   {
     MFEM_ABORT("Joule heating auxsolver not available for this formulation");
   }

--- a/src/formulations/em_formulation_interface.hpp
+++ b/src/formulations/em_formulation_interface.hpp
@@ -11,25 +11,29 @@ public:
   EMFormulationInterface() = default;
 
   // Enable auxiliary calculation of J ∈ H(div)
-  virtual void RegisterCurrentDensityAux(const std::string & j_field_name)
+  virtual void RegisterCurrentDensityAux(const std::string & j_field_name,
+                                         const std::string & external_j_field_name = "")
   {
     MFEM_ABORT("Current density auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of B ∈ H(div)
-  virtual void RegisterMagneticFluxDensityAux(const std::string & b_field_name)
+  virtual void RegisterMagneticFluxDensityAux(const std::string & b_field_name,
+                                              const std::string & external_b_field_name = "")
   {
     MFEM_ABORT("Magnetic flux density auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of E ∈ H(curl)
-  virtual void RegisterElectricFieldAux(const std::string & e_field_name)
+  virtual void RegisterElectricFieldAux(const std::string & e_field_name,
+                                        const std::string & external_e_field_name = "")
   {
     MFEM_ABORT("Electric field auxsolver not available for this formulation");
   }
 
   // Enable auxiliary calculation of H ∈ H(curl)
-  virtual void RegisterMagneticFieldAux(const std::string & h_field_name)
+  virtual void RegisterMagneticFieldAux(const std::string & h_field_name,
+                                        const std::string & external_h_field_name = "")
   {
     MFEM_ABORT("Magnetic field auxsolver not available for this formulation");
   }

--- a/src/sources/closed_coil.cpp
+++ b/src/sources/closed_coil.cpp
@@ -383,6 +383,8 @@ ClosedCoilSolver::SolveTransition()
   opencoil.Init(gridfunctions, fespaces, bc_maps, coefs);
   opencoil.Apply(_final_lf.get());
 
+  v_parent *= -1.0;
+  *_grad_phi_parent *= -1.0;
   _mesh_coil->Transfer(v_parent, *_v_coil);
 }
 

--- a/src/sources/closed_coil.cpp
+++ b/src/sources/closed_coil.cpp
@@ -26,26 +26,24 @@ pushIfUnique(std::vector<T> & vec, const T el)
 
 // Base class methods
 
-ClosedCoilSolver::ClosedCoilSolver(const hephaestus::InputParameters & params,
+ClosedCoilSolver::ClosedCoilSolver(std::string source_efield_gf_name,
+                                   std::string hcurl_fespace_name,
+                                   std::string h1_fespace_name,
+                                   std::string i_coef_name,
+                                   std::string cond_coef_name,
                                    mfem::Array<int> coil_dom,
-                                   const int electrode_face)
-  : _hcurl_fespace_name(params.GetParam<std::string>("HCurlFESpaceName")),
-    _h1_fespace_name(params.GetParam<std::string>("H1FESpaceName")),
-    _grad_phi_name(params.GetParam<std::string>("GradPotentialName")),
-    _i_coef_name(params.GetParam<std::string>("IFuncCoefName")),
-    _cond_coef_name(params.GetParam<std::string>("ConductivityCoefName")),
-    _grad_phi_transfer(params.GetOptionalParam<bool>("GradPhiTransfer", false)),
+                                   const int electrode_face,
+                                   bool grad_phi_transfer,
+                                   std::string source_jfield_gf_name,
+                                   hephaestus::InputParameters solver_options)
+  : _hcurl_fespace_name(std::move(hcurl_fespace_name)),
+    _h1_fespace_name(std::move(h1_fespace_name)),
+    _grad_phi_name(std::move(source_efield_gf_name)),
+    _i_coef_name(std::move(i_coef_name)),
+    _cond_coef_name(std::move(cond_coef_name)),
+    _grad_phi_transfer(std::move(grad_phi_transfer)),
     _coil_domains(std::move(coil_dom))
 {
-  hephaestus::InputParameters default_pars;
-  default_pars.SetParam("Tolerance", float(1e-18));
-  default_pars.SetParam("AbsTolerance", float(1e-18));
-  default_pars.SetParam("MaxIter", (unsigned int)1000);
-  default_pars.SetParam("PrintLevel", 1);
-
-  _solver_options =
-      params.GetOptionalParam<hephaestus::InputParameters>("SolverOptions", default_pars);
-
   _elec_attrs.first = electrode_face;
 }
 
@@ -67,7 +65,6 @@ ClosedCoilSolver::Init(hephaestus::GridFunctions & gridfunctions,
                        hephaestus::BCMap & bc_map,
                        hephaestus::Coefficients & coefficients)
 {
-
   // Retrieving the parent FE space and mesh
 
   _h_curl_fe_space_parent = fespaces.Get(_hcurl_fespace_name);
@@ -154,7 +151,6 @@ ClosedCoilSolver::Init(hephaestus::GridFunctions & gridfunctions,
 void
 ClosedCoilSolver::Apply(mfem::ParLinearForm * lf)
 {
-
   // The transformation and integration points themselves are not relevant, it's
   // just so we can call Eval
   mfem::ElementTransformation * tr = _mesh_parent->GetElementTransformation(0);
@@ -361,7 +357,6 @@ ClosedCoilSolver::PrepareCoilSubmesh()
 void
 ClosedCoilSolver::SolveTransition()
 {
-
   mfem::ParGridFunction v_parent(_h1_fe_space_parent);
   v_parent = 0.0;
 
@@ -518,7 +513,6 @@ ClosedCoilSolver::RestoreAttributes()
 bool
 ClosedCoilSolver::IsInDomain(const int el, const mfem::Array<int> & dom, const mfem::ParMesh * mesh)
 {
-
   // This is for ghost elements
   if (el < 0)
     return false;
@@ -537,7 +531,6 @@ ClosedCoilSolver::IsInDomain(const int el, const mfem::Array<int> & dom, const m
 bool
 ClosedCoilSolver::IsInDomain(const int el, const int & sd, const mfem::ParMesh * mesh)
 {
-
   // This is for ghost elements
   if (el < 0)
     return false;
@@ -548,7 +541,6 @@ ClosedCoilSolver::IsInDomain(const int el, const int & sd, const mfem::ParMesh *
 mfem::Vector
 ClosedCoilSolver::ElementCentre(int el, mfem::ParMesh * pm)
 {
-
   mfem::Array<int> elem_vtx;
   mfem::Vector com(3);
   com = 0.0;
@@ -575,7 +567,6 @@ Plane3D::Plane3D()
 void
 Plane3D::Make3DPlane(const mfem::ParMesh * pm, const int face)
 {
-
   MFEM_ASSERT(pm->Dimension() == 3, "Plane3D only works in 3-dimensional meshes!");
 
   mfem::Array<int> face_vtx;

--- a/src/sources/closed_coil.cpp
+++ b/src/sources/closed_coil.cpp
@@ -375,14 +375,15 @@ ClosedCoilSolver::SolveTransition()
   gridfunctions.Register("GradPhi_parent", _grad_phi_parent, false);
   gridfunctions.Register("V_parent", &v_parent, false);
 
-  hephaestus::InputParameters ocs_params;
-  ocs_params.SetParam("GradPotentialName", std::string("GradPhi_parent"));
-  ocs_params.SetParam("ConductivityCoefName", std::string("electrical_conductivity"));
-  ocs_params.SetParam("IFuncCoefName", std::string("I"));
-  ocs_params.SetParam("PotentialName", std::string("V_parent"));
-  ocs_params.SetParam("SolverOptions", _solver_options);
-
-  hephaestus::OpenCoilSolver opencoil(ocs_params, _transition_domain, _elec_attrs);
+  hephaestus::OpenCoilSolver opencoil("GradPhi_parent",
+                                      "V_parent",
+                                      "I",
+                                      "electrical_conductivity",
+                                      _transition_domain,
+                                      _elec_attrs,
+                                      true,
+                                      "",
+                                      _solver_options);
 
   opencoil.Init(gridfunctions, fespaces, bc_maps, coefs);
   opencoil.Apply(_final_lf.get());

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -14,9 +14,20 @@ class ClosedCoilSolver : public hephaestus::Source
 {
 
 public:
-  ClosedCoilSolver(const hephaestus::InputParameters & params,
+  ClosedCoilSolver(std::string source_efield_gf_name,
+                   std::string hcurl_fespace_name,
+                   std::string h1_fespace_name,
+                   std::string i_coef_name,
+                   std::string cond_coef_name,
                    mfem::Array<int> coil_dom,
-                   const int electrode_face);
+                   const int electrode_face,
+                   bool grad_phi_transfer = false,
+                   std::string source_jfield_gf_name = "",
+                   hephaestus::InputParameters solver_options =
+                       hephaestus::InputParameters({{"Tolerance", float(1.0e-18)},
+                                                    {"AbsTolerance", float(1.0e-18)},
+                                                    {"MaxIter", (unsigned int)1000},
+                                                    {"PrintLevel", 1}}));
 
   // Override virtual Source destructor to avoid leaks.
   ~ClosedCoilSolver() override;

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -21,7 +21,7 @@ public:
                    std::string cond_coef_name,
                    mfem::Array<int> coil_dom,
                    const int electrode_face,
-                   bool grad_phi_transfer = false,
+                   bool electric_field_transfer = false,
                    std::string source_jfield_gf_name = "",
                    hephaestus::InputParameters solver_options =
                        hephaestus::InputParameters({{"Tolerance", float(1.0e-18)},
@@ -84,27 +84,29 @@ private:
 
   bool _owns_sigma{false};
   bool _owns_itotal{false};
-  bool _owns_grad_phi_parent{false};
+  bool _owns_source_electric_field{false};
   bool _owns_h1_fe_space_parent{false};
 
   // Here, we are solving for -(σ∇Va,∇ψ) = (σ∇Vt,∇ψ), where ∇Vt is grad_phi_t (within its relevant
   // mesh), ∇Va is grad_phi_aux, and their sum ∇Vt+∇Va is the full grad_phi, which is, up to an
-  // overall sign, equal to the electric field in the electrostatic case. Seting grad_phi_transfer_
-  // to true will negatively affect performance, but the final grad_phi function will be transferred
-  // to a GridFunction for viewing purposes. Only set to true if you wish to visualise the final
-  // grad_phi.
-  bool _grad_phi_transfer{false};
+  // overall sign, equal to the electric field in the electrostatic case. Setting
+  // _electric_field_transfer to true will negatively affect performance, but the final electric
+  // field function will be transferred to a GridFunction for viewing purposes. Only set to true if
+  // you wish to visualise the final electric field.
+  bool _electric_field_transfer{false};
 
   // Names
   std::string _hcurl_fespace_name;
   std::string _cond_coef_name;
   std::string _h1_fespace_name;
-  std::string _grad_phi_name;
+  std::string _source_electric_field_name;
+  std::string _source_current_density_name;
   std::string _i_coef_name;
 
   // Parent mesh, FE space, and current
   mfem::ParMesh * _mesh_parent{nullptr};
-  mfem::ParGridFunction * _grad_phi_parent{nullptr};
+  mfem::ParGridFunction * _source_electric_field{nullptr};
+  mfem::ParGridFunction * _source_current_density{nullptr};
   mfem::ParFiniteElementSpace * _h_curl_fe_space_parent{nullptr};
   mfem::ParFiniteElementSpace * _h1_fe_space_parent{nullptr};
 
@@ -113,17 +115,17 @@ private:
   std::unique_ptr<mfem::H1_FECollection> _h1_fe_space_coil_fec{nullptr};
 
   // In case J transfer is true
-  std::unique_ptr<mfem::ParGridFunction> _grad_phi_t_parent{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _electric_field_t_parent{nullptr};
 
   // Coil mesh, FE Space, and current
   std::unique_ptr<mfem::ParSubMesh> _mesh_coil{nullptr};
   std::unique_ptr<mfem::ParSubMesh> _mesh_t{nullptr};
   std::unique_ptr<mfem::ParFiniteElementSpace> _h1_fe_space_coil{nullptr};
-  std::unique_ptr<mfem::ParGridFunction> _grad_phi_aux_coil{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _electric_field_aux_coil{nullptr};
   std::unique_ptr<mfem::ParGridFunction> _v_coil{nullptr};
 
-  std::unique_ptr<mfem::ND_FECollection> _grad_phi_aux_coil_fec{nullptr};
-  std::unique_ptr<mfem::ParFiniteElementSpace> _grad_phi_aux_coil_fes{nullptr};
+  std::unique_ptr<mfem::ND_FECollection> _electric_field_aux_coil_fec{nullptr};
+  std::unique_ptr<mfem::ParFiniteElementSpace> _electric_field_aux_coil_fes{nullptr};
 
   // Final LinearForm
   std::unique_ptr<mfem::ParLinearForm> _final_lf{nullptr};

--- a/src/sources/div_free_source.cpp
+++ b/src/sources/div_free_source.cpp
@@ -15,16 +15,20 @@ P(g) = g + β∇p - ∇×M
 via the weak form:
 (g, ∇q) - (∇Q, ∇q) - <P(g).n, q> = 0
 */
-DivFreeSource::DivFreeSource(const hephaestus::InputParameters & params)
-  : _src_coef_name(params.GetParam<std::string>("SourceName")),
-    _src_gf_name(params.GetParam<std::string>("SourceName")),
-    _hcurl_fespace_name(params.GetParam<std::string>("HCurlFESpaceName")),
-    _h1_fespace_name(params.GetParam<std::string>("H1FESpaceName")),
-    _potential_gf_name(
-        params.GetOptionalParam<std::string>("PotentialName", std::string("_source_potential"))),
-    _solver_options(params.GetOptionalParam<hephaestus::InputParameters>(
-        "SolverOptions", hephaestus::InputParameters())),
-    _perform_helmholtz_projection(params.GetOptionalParam<bool>("HelmholtzProjection", true)),
+DivFreeSource::DivFreeSource(std::string src_coef_name,
+                             std::string src_gf_name,
+                             std::string hcurl_fespace_name,
+                             std::string h1_fespace_name,
+                             std::string potential_gf_name,
+                             hephaestus::InputParameters solver_options,
+                             bool perform_helmholtz_projection)
+  : _src_coef_name(std::move(src_coef_name)),
+    _src_gf_name(std::move(src_gf_name)),
+    _hcurl_fespace_name(std::move(hcurl_fespace_name)),
+    _h1_fespace_name(std::move(h1_fespace_name)),
+    _potential_gf_name(std::move(potential_gf_name)),
+    _solver_options(std::move(solver_options)),
+    _perform_helmholtz_projection(std::move(perform_helmholtz_projection)),
     _h_curl_mass(nullptr)
 {
 }

--- a/src/sources/div_free_source.hpp
+++ b/src/sources/div_free_source.hpp
@@ -7,7 +7,13 @@ namespace hephaestus
 class DivFreeSource : public hephaestus::Source
 {
 public:
-  DivFreeSource(const hephaestus::InputParameters & params);
+  DivFreeSource(std::string src_coef_name,
+                std::string src_gf_name,
+                std::string hcurl_fespace_name,
+                std::string h1_fespace_name,
+                std::string potential_gf_name = "_source_potential",
+                hephaestus::InputParameters solver_options = hephaestus::InputParameters(),
+                bool perform_helmholtz_projection = true);
 
   // Override virtual Source destructor to avoid leaks.
   ~DivFreeSource() override = default;

--- a/src/sources/open_coil.cpp
+++ b/src/sources/open_coil.cpp
@@ -420,7 +420,7 @@ OpenCoilSolver::SPSCurrent()
   coefs._scalars.Register("electric_conductivity", _sigma, false);
 
   hephaestus::ScalarPotentialSource sps(
-      "GradPhi", "V", "HCurl", "H1", "electric_conductivity", _solver_options);
+      "GradPhi", "V", "HCurl", "H1", "electric_conductivity", 1, _solver_options);
   sps.Init(gridfunctions, fespaces, _bc_maps, coefs);
 
   mfem::ParLinearForm dummy(_h_curl_fe_space_child.get());

--- a/src/sources/open_coil.cpp
+++ b/src/sources/open_coil.cpp
@@ -416,18 +416,11 @@ OpenCoilSolver::SPSCurrent()
   gridfunctions.Register(std::string("GradPhi"), _grad_phi_child.get(), false);
   gridfunctions.Register(std::string("V"), _phi_child.get(), false);
 
-  hephaestus::InputParameters sps_params;
-  sps_params.SetParam("GradPotentialName", std::string("GradPhi"));
-  sps_params.SetParam("PotentialName", std::string("V"));
-  sps_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
-  sps_params.SetParam("H1FESpaceName", std::string("H1"));
-  sps_params.SetParam("SolverOptions", _solver_options);
-  sps_params.SetParam("ConductivityCoefName", std::string("electric_conductivity"));
-
   hephaestus::Coefficients coefs;
   coefs._scalars.Register("electric_conductivity", _sigma, false);
 
-  hephaestus::ScalarPotentialSource sps(sps_params);
+  hephaestus::ScalarPotentialSource sps(
+      "GradPhi", "V", "HCurl", "H1", "electric_conductivity", _solver_options);
   sps.Init(gridfunctions, fespaces, _bc_maps, coefs);
 
   mfem::ParLinearForm dummy(_h_curl_fe_space_child.get());

--- a/src/sources/open_coil.cpp
+++ b/src/sources/open_coil.cpp
@@ -314,7 +314,7 @@ OpenCoilSolver::Apply(mfem::ParLinearForm * lf)
   if (_grad_phi_transfer)
   {
     *_source_electric_field = 0.0;
-    _source_electric_field->Add(i, *_grad_phi_t_parent);
+    _source_electric_field->Add(-i, *_grad_phi_t_parent);
   }
 
   if (_phi_parent != nullptr)
@@ -333,7 +333,7 @@ OpenCoilSolver::Apply(mfem::ParLinearForm * lf)
     aux_coef._scalars.Register("electrical_conductivity", _sigma, false);
 
     hephaestus::ScaledVectorGridFunctionAux current_density_auxsolver(
-        "source_electric_field", "source_current_density", "electrical_conductivity", -1.0);
+        "source_electric_field", "source_current_density", "electrical_conductivity", 1.0);
     current_density_auxsolver.Init(aux_gf, aux_coef);
     current_density_auxsolver.Solve();
   }
@@ -440,7 +440,7 @@ OpenCoilSolver::SPSCurrent()
 
   _final_lf = std::make_unique<mfem::ParLinearForm>(_grad_phi_t_parent->ParFESpace());
   *_final_lf = 0.0;
-  _m1->AddMult(*_grad_phi_t_parent, *_final_lf, 1.0);
+  _m1->AddMult(*_grad_phi_t_parent, *_final_lf, -1.0);
 }
 
 void

--- a/src/sources/open_coil.cpp
+++ b/src/sources/open_coil.cpp
@@ -181,7 +181,7 @@ OpenCoilSolver::OpenCoilSolver(std::string source_efield_gf_name,
                                std::string cond_coef_name,
                                mfem::Array<int> coil_dom,
                                const std::pair<int, int> electrodes,
-                               bool grad_phi_transfer,
+                               bool electric_field_transfer,
                                std::string source_jfield_gf_name,
                                hephaestus::InputParameters solver_options)
   : _source_efield_gf_name(std::move(source_efield_gf_name)),
@@ -189,7 +189,7 @@ OpenCoilSolver::OpenCoilSolver(std::string source_efield_gf_name,
     _phi_gf_name(std::move(phi_gf_name)),
     _i_coef_name(std::move(i_coef_name)),
     _cond_coef_name(std::move(cond_coef_name)),
-    _grad_phi_transfer(std::move(grad_phi_transfer)),
+    _electric_field_transfer(std::move(electric_field_transfer)),
     _solver_options(std::move(solver_options)),
     _coil_domains(std::move(coil_dom)),
     _elec_attrs(electrodes),
@@ -237,7 +237,7 @@ OpenCoilSolver::Init(hephaestus::GridFunctions & gridfunctions,
     _sigma = new mfem::ConstantCoefficient(1.0);
     _owns_sigma = true;
 
-    _grad_phi_transfer = false;
+    _electric_field_transfer = false;
   }
 
   _source_electric_field = gridfunctions.Get(_source_efield_gf_name);
@@ -311,7 +311,7 @@ OpenCoilSolver::Apply(mfem::ParLinearForm * lf)
 
   double i = _itotal->Eval(*tr, ip);
 
-  if (_grad_phi_transfer)
+  if (_electric_field_transfer)
   {
     *_source_electric_field = 0.0;
     _source_electric_field->Add(-i, *_grad_phi_t_parent);

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -90,6 +90,7 @@ private:
 
   int _order_h1;
   int _order_hcurl;
+  int _order_hdiv;
   int _ref_face;
   bool _electric_field_transfer;
 
@@ -116,6 +117,9 @@ private:
   mfem::ParGridFunction * _phi_parent{nullptr};
   std::unique_ptr<mfem::ParGridFunction> _phi_t_parent{nullptr};
 
+  mfem::ParGridFunction * _j_parent{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _j_t_parent{nullptr};
+
   mfem::ParGridFunction * _source_electric_field{nullptr};
   mfem::ParGridFunction * _source_current_density{nullptr};
 
@@ -128,9 +132,13 @@ private:
   std::unique_ptr<mfem::ParFiniteElementSpace> _h_curl_fe_space_child{nullptr};
   std::unique_ptr<mfem::ND_FECollection> _h_curl_fe_space_fec_child{nullptr};
 
+  std::unique_ptr<mfem::ParFiniteElementSpace> _h_div_fe_space_child{nullptr};
+  std::unique_ptr<mfem::RT_FECollection> _h_div_fe_space_fec_child{nullptr};
+
   // Child GridFunctions
   std::unique_ptr<mfem::ParGridFunction> _grad_phi_child{nullptr};
   std::unique_ptr<mfem::ParGridFunction> _phi_child{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _j_child{nullptr};
 
   // Child boundary condition objects
   mfem::FunctionCoefficient _high_src;

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -39,7 +39,7 @@ public:
                  std::string cond_coef_name,
                  mfem::Array<int> coil_dom,
                  const std::pair<int, int> electrodes,
-                 bool grad_phi_transfer = true,
+                 bool electric_field_transfer = true,
                  std::string source_jfield_gf_name = "",
                  hephaestus::InputParameters solver_options =
                      hephaestus::InputParameters({{"Tolerance", float(1.0e-20)},
@@ -91,7 +91,7 @@ private:
   int _order_h1;
   int _order_hcurl;
   int _ref_face;
-  bool _grad_phi_transfer;
+  bool _electric_field_transfer;
 
   mfem::Coefficient * _sigma{nullptr};
   mfem::Coefficient * _itotal{nullptr};

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -33,9 +33,19 @@ class OpenCoilSolver : public hephaestus::Source
 {
 
 public:
-  OpenCoilSolver(const hephaestus::InputParameters & params,
+  OpenCoilSolver(std::string source_efield_gf_name,
+                 std::string phi_gf_name,
+                 std::string i_coef_name,
+                 std::string cond_coef_name,
                  mfem::Array<int> coil_dom,
-                 const std::pair<int, int> electrodes);
+                 const std::pair<int, int> electrodes,
+                 bool grad_phi_transfer = true,
+                 std::string source_jfield_gf_name = "",
+                 hephaestus::InputParameters solver_options =
+                     hephaestus::InputParameters({{"Tolerance", float(1.0e-20)},
+                                                  {"AbsTolerance", float(1.0e-20)},
+                                                  {"MaxIter", (unsigned int)1000},
+                                                  {"PrintLevel", 1}}));
 
   ~OpenCoilSolver() override;
 
@@ -44,7 +54,7 @@ public:
             hephaestus::BCMap & bc_map,
             hephaestus::Coefficients & coefficients) override;
   void Apply(mfem::ParLinearForm * lf) override;
-  void SubtractSource(mfem::ParGridFunction * gf) override;
+  void SubtractSource(mfem::ParGridFunction * gf) override{};
 
   // Initialises the child submesh.
   void InitChildMesh();
@@ -73,15 +83,15 @@ public:
 
 private:
   // Parameters
-  int _order_h1;
-  int _order_hcurl;
-  int _ref_face;
-  bool _grad_phi_transfer;
-
   std::pair<int, int> _elec_attrs;
   mfem::Array<int> _coil_domains;
   mfem::Array<int> _coil_markers;
   hephaestus::InputParameters _solver_options;
+
+  int _order_h1;
+  int _order_hcurl;
+  int _ref_face;
+  bool _grad_phi_transfer;
 
   mfem::Coefficient * _sigma{nullptr};
   mfem::Coefficient * _itotal{nullptr};
@@ -91,7 +101,7 @@ private:
 
   // Names
   std::string _grad_phi_name;
-  std::string _v_gf_name;
+  std::string _phi_gf_name;
   std::string _i_coef_name;
   std::string _cond_coef_name;
   std::string _source_efield_gf_name;
@@ -103,24 +113,24 @@ private:
   mfem::ParGridFunction * _grad_phi_parent{nullptr};
   std::unique_ptr<mfem::ParGridFunction> _grad_phi_t_parent{nullptr};
 
-  mfem::ParGridFunction * _v_parent{nullptr};
-  std::unique_ptr<mfem::ParGridFunction> _vt_parent{nullptr};
+  mfem::ParGridFunction * _phi_parent{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _phi_t_parent{nullptr};
 
   mfem::ParGridFunction * _source_electric_field{nullptr};
   mfem::ParGridFunction * _source_current_density{nullptr};
 
   // Child mesh and FE spaces
-  std::unique_ptr<mfem::ParSubMesh> _mesh{nullptr};
+  std::unique_ptr<mfem::ParSubMesh> _mesh_child{nullptr};
 
-  std::unique_ptr<mfem::ParFiniteElementSpace> _h1_fe_space{nullptr};
-  std::unique_ptr<mfem::H1_FECollection> _h1_fe_space_fec{nullptr};
+  std::unique_ptr<mfem::ParFiniteElementSpace> _h1_fe_space_child{nullptr};
+  std::unique_ptr<mfem::H1_FECollection> _h1_fe_space_fec_child{nullptr};
 
-  std::unique_ptr<mfem::ParFiniteElementSpace> _h_curl_fe_space{nullptr};
-  std::unique_ptr<mfem::ND_FECollection> _h_curl_fe_space_fec{nullptr};
+  std::unique_ptr<mfem::ParFiniteElementSpace> _h_curl_fe_space_child{nullptr};
+  std::unique_ptr<mfem::ND_FECollection> _h_curl_fe_space_fec_child{nullptr};
 
   // Child GridFunctions
-  std::unique_ptr<mfem::ParGridFunction> _grad_phi{nullptr};
-  std::unique_ptr<mfem::ParGridFunction> _v{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _grad_phi_child{nullptr};
+  std::unique_ptr<mfem::ParGridFunction> _phi_child{nullptr};
 
   // Child boundary condition objects
   mfem::FunctionCoefficient _high_src;

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -34,7 +34,7 @@ class OpenCoilSolver : public hephaestus::Source
 
 public:
   OpenCoilSolver(std::string source_efield_gf_name,
-                 std::string phi_gf_name,
+                 std::string electric_potential_name,
                  std::string i_coef_name,
                  std::string cond_coef_name,
                  mfem::Array<int> coil_dom,

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "helmholtz_projector.hpp"
 #include "scalar_potential_source.hpp"
+#include "scaled_vector_gridfunction_aux.hpp"
 #include "source_base.hpp"
 
 namespace hephaestus
@@ -93,6 +94,8 @@ private:
   std::string _v_gf_name;
   std::string _i_coef_name;
   std::string _cond_coef_name;
+  std::string _source_efield_gf_name;
+  std::string _source_jfield_gf_name;
 
   // Parent mesh, FE space, and current
   mfem::ParMesh * _mesh_parent{nullptr};
@@ -102,6 +105,9 @@ private:
 
   mfem::ParGridFunction * _v_parent{nullptr};
   std::unique_ptr<mfem::ParGridFunction> _vt_parent{nullptr};
+
+  mfem::ParGridFunction * _source_electric_field{nullptr};
+  mfem::ParGridFunction * _source_current_density{nullptr};
 
   // Child mesh and FE spaces
   std::unique_ptr<mfem::ParSubMesh> _mesh{nullptr};

--- a/src/sources/scalar_potential_source.cpp
+++ b/src/sources/scalar_potential_source.cpp
@@ -11,12 +11,14 @@ ScalarPotentialSource::ScalarPotentialSource(std::string grad_phi_gf_name,
                                              std::string hcurl_fespace_name,
                                              std::string h1_fespace_name,
                                              std::string coef_name,
+                                             int source_sign,
                                              hephaestus::InputParameters solver_options)
   : _grad_phi_gf_name(std::move(grad_phi_gf_name)),
     _phi_gf_name(std::move(phi_gf_name)),
     _hcurl_fespace_name(std::move(hcurl_fespace_name)),
     _h1_fespace_name(std::move(h1_fespace_name)),
     _coef_name(std::move(coef_name)),
+    _source_sign(std::move(source_sign)),
     _solver_options(std::move(solver_options))
 {
 }
@@ -135,13 +137,13 @@ ScalarPotentialSource::Apply(mfem::ParLinearForm * lf)
 
   _m1->Update();
   _m1->Assemble();
-  _m1->AddMult(*_grad_phi, *lf, 1.0);
+  _m1->AddMult(*_grad_phi, *lf, _source_sign);
 }
 
 void
 ScalarPotentialSource::SubtractSource(mfem::ParGridFunction * gf)
 {
-  _grad->AddMult(*_phi, *gf, -1.0);
+  _grad->AddMult(*_phi, *gf, -_source_sign);
 }
 
 } // namespace hephaestus

--- a/src/sources/scalar_potential_source.hpp
+++ b/src/sources/scalar_potential_source.hpp
@@ -12,6 +12,7 @@ public:
                         std::string hcurl_fespace_name,
                         std::string h1_fespace_name,
                         std::string coef_name,
+                        int source_sign = -1,
                         hephaestus::InputParameters solver_options = hephaestus::InputParameters());
 
   // Override virtual Source destructor to prevent leaks.
@@ -34,7 +35,7 @@ public:
   std::string _hcurl_fespace_name;
   std::string _h1_fespace_name;
   std::string _coef_name;
-
+  int _source_sign;
   const hephaestus::InputParameters _solver_options;
 
   mfem::ParFiniteElementSpace * _h1_fe_space;

--- a/src/sources/scalar_potential_source.hpp
+++ b/src/sources/scalar_potential_source.hpp
@@ -7,7 +7,12 @@ namespace hephaestus
 class ScalarPotentialSource : public hephaestus::Source
 {
 public:
-  ScalarPotentialSource(const hephaestus::InputParameters & params);
+  ScalarPotentialSource(std::string grad_phi_gf_name,
+                        std::string phi_gf_name,
+                        std::string hcurl_fespace_name,
+                        std::string h1_fespace_name,
+                        std::string coef_name,
+                        hephaestus::InputParameters solver_options = hephaestus::InputParameters());
 
   // Override virtual Source destructor to prevent leaks.
   ~ScalarPotentialSource() override;
@@ -24,18 +29,17 @@ public:
   void BuildWeakDiv();
   void BuildGrad();
 
-  std::string _grad_phi_name;
-  std::string _src_coef_name;
-  std::string _potential_gf_name;
+  std::string _grad_phi_gf_name;
+  std::string _phi_gf_name;
   std::string _hcurl_fespace_name;
   std::string _h1_fespace_name;
-  std::string _beta_coef_name;
+  std::string _coef_name;
 
   const hephaestus::InputParameters _solver_options;
 
   mfem::ParFiniteElementSpace * _h1_fe_space;
   mfem::ParFiniteElementSpace * _h_curl_fe_space;
-  mfem::ParGridFunction * _p; // Potential
+  mfem::ParGridFunction * _phi; // Potential
   hephaestus::BCMap * _bc_map;
   mfem::Coefficient * _beta_coef;
 
@@ -56,7 +60,7 @@ public:
   mutable std::unique_ptr<hephaestus::DefaultH1PCGSolver> _a0_solver{nullptr};
 
   std::unique_ptr<mfem::ParLinearForm> _b0{nullptr};
-  mfem::ParGridFunction *_grad_p, *_x_div;
+  mfem::ParGridFunction *_grad_phi, *_x_div;
 
   mfem::VectorCoefficient * _source_vec_coef;
   mfem::ParGridFunction * _div_free_src_gf; // Source field

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -94,17 +94,20 @@ protected:
     hephaestus::Sources sources;
     auto * j_src_coef = new mfem::VectorFunctionCoefficient(3, SourceField);
     coefficients._vectors.Register("source", j_src_coef, true);
-    hephaestus::InputParameters div_free_source_params;
-    div_free_source_params.SetParam("SourceName", std::string("source"));
-    div_free_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));
-    div_free_source_params.SetParam("H1FESpaceName", std::string("H1"));
     hephaestus::InputParameters current_solver_options;
     current_solver_options.SetParam("Tolerance", float(1.0e-12));
     current_solver_options.SetParam("MaxIter", (unsigned int)200);
     current_solver_options.SetParam("PrintLevel", 0);
-    div_free_source_params.SetParam("SolverOptions", current_solver_options);
-    div_free_source_params.SetParam("HelmholtzProjection", false);
-    sources.Register("source", new hephaestus::DivFreeSource(div_free_source_params), true);
+
+    sources.Register("source",
+                     new hephaestus::DivFreeSource("source",
+                                                   "source",
+                                                   "_HCurlFESpace",
+                                                   "H1",
+                                                   "_source_potential",
+                                                   current_solver_options,
+                                                   false),
+                     true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-16));

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -105,12 +105,16 @@ protected:
     hephaestus::Sources sources;
     auto * j_src_coef = new mfem::VectorFunctionCoefficient(3, SourceField);
     coefficients._vectors.Register("source", j_src_coef, true);
-    hephaestus::InputParameters div_free_source_params;
-    div_free_source_params.SetParam("SourceName", std::string("source"));
-    div_free_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));
-    div_free_source_params.SetParam("H1FESpaceName", std::string("_H1FESpace"));
-    div_free_source_params.SetParam("HelmholtzProjection", false);
-    sources.Register("source", new hephaestus::DivFreeSource(div_free_source_params), true);
+
+    sources.Register("source",
+                     new hephaestus::DivFreeSource("source",
+                                                   "source",
+                                                   "_HCurlFESpace",
+                                                   "_H1FESpace",
+                                                   "_source_potential",
+                                                   hephaestus::InputParameters(),
+                                                   false),
+                     true);
 
     hephaestus::InputParameters params;
     params.SetParam("TimeStep", float(0.05));

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -86,20 +86,18 @@ protected:
     hephaestus::AuxSolvers preprocessors;
     hephaestus::AuxSolvers postprocessors;
     hephaestus::Sources sources;
-    hephaestus::InputParameters scalar_potential_source_params;
-    scalar_potential_source_params.SetParam("GradPotentialName", std::string("source"));
-    scalar_potential_source_params.SetParam("PotentialName", std::string("electric_potential"));
-    scalar_potential_source_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
-    scalar_potential_source_params.SetParam("H1FESpaceName", std::string("H1"));
-    scalar_potential_source_params.SetParam("ConductivityCoefName",
-                                            std::string("electrical_conductivity"));
     hephaestus::InputParameters current_solver_options;
     current_solver_options.SetParam("Tolerance", float(1.0e-9));
     current_solver_options.SetParam("MaxIter", (unsigned int)1000);
     current_solver_options.SetParam("PrintLevel", -1);
-    scalar_potential_source_params.SetParam("SolverOptions", current_solver_options);
-    sources.Register(
-        "source", new hephaestus::ScalarPotentialSource(scalar_potential_source_params), true);
+    sources.Register("source",
+                     new hephaestus::ScalarPotentialSource("source",
+                                                           "electric_potential",
+                                                           "HCurl",
+                                                           "H1",
+                                                           "electrical_conductivity",
+                                                           current_solver_options),
+                     true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-9));

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -175,7 +175,8 @@ TEST_CASE_METHOD(TestComplexAFormRod, "TestComplexAFormRod", "[CheckRun]")
   problem_builder->RegisterJouleHeatingDensityAux("joule_heating_density",
                                                   "electric_field_real",
                                                   "electric_field_imag",
-                                                  "electrical_conductivity");
+                                                  "current_density_real",
+                                                  "current_density_imag");
 
   problem_builder->SetSources(sources);
   problem_builder->SetOutputs(outputs);

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -96,6 +96,7 @@ protected:
                                                            "HCurl",
                                                            "H1",
                                                            "electrical_conductivity",
+                                                           -1,
                                                            current_solver_options),
                      true);
 

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -163,7 +163,8 @@ TEST_CASE_METHOD(TestComplexIrisWaveguide, "TestComplexIrisWaveguide", "[CheckRu
   problem_builder->RegisterJouleHeatingDensityAux("joule_heating_density",
                                                   "electric_field_real",
                                                   "electric_field_imag",
-                                                  "electrical_conductivity");
+                                                  "current_density_real",
+                                                  "current_density_imag");
 
   problem_builder->SetCoefficients(coefficients);
   problem_builder->SetPostprocessors(postprocessors);

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -123,18 +123,16 @@ protected:
     auto * j_src_restricted = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
     coefficients._vectors.Register("source", j_src_restricted, true);
 
-    hephaestus::InputParameters div_free_source_params;
-    div_free_source_params.SetParam("SourceName", std::string("source"));
-    div_free_source_params.SetParam("PotentialName", std::string("electric_potential"));
-    div_free_source_params.SetParam("ConductivityCoefName", std::string("electrical_conductivity"));
-    div_free_source_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
-    div_free_source_params.SetParam("H1FESpaceName", std::string("H1"));
     hephaestus::InputParameters current_solver_options;
     current_solver_options.SetParam("Tolerance", float(1.0e-12));
     current_solver_options.SetParam("MaxIter", (unsigned int)200);
     current_solver_options.SetParam("PrintLevel", 1);
-    div_free_source_params.SetParam("SolverOptions", current_solver_options);
-    sources.Register("source", new hephaestus::DivFreeSource(div_free_source_params), true);
+
+    sources.Register(
+        "source",
+        new hephaestus::DivFreeSource(
+            "source", "source", "HCurl", "H1", "electric_potential", current_solver_options),
+        true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-16));

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -105,14 +105,6 @@ protected:
         "ParaViewDataCollection", new mfem::ParaViewDataCollection("EBFormParaView"), true);
 
     hephaestus::AuxSolvers postprocessors;
-    postprocessors.Register(
-        "JouleHeatingAux",
-        new hephaestus::VectorGridFunctionDotProductAux("joule_heating_load",
-                                                        "JouleHeating",
-                                                        "electrical_conductivity",
-                                                        "electric_field",
-                                                        "electric_field"),
-        true);
 
     hephaestus::Sources sources;
 
@@ -175,10 +167,16 @@ TEST_CASE_METHOD(TestEBFormCoupled, "TestEBFormCoupled", "[CheckRun]")
   problem_builder->SetMesh(pmesh);
   problem_builder->AddFESpace(std::string("L2"), std::string("L2_3D_P1"));
   problem_builder->AddFESpace(std::string("H1"), std::string("H1_3D_P1"));
+  problem_builder->AddFESpace(std::string("HDiv"), std::string("RT_3D_P0"));
+  problem_builder->AddFESpace(std::string("HCurl"), std::string("ND_3D_P1"));
   problem_builder->AddFESpace(std::string("H1Source"), std::string("H1_3D_P2"));
   problem_builder->AddFESpace(std::string("HCurlSource"), std::string("ND_3D_P2"));
+  problem_builder->AddGridFunction(std::string("current_density"), std::string("L2"));
   problem_builder->AddGridFunction(std::string("joule_heating_load"), std::string("L2"));
   problem_builder->AddGridFunction(std::string("temperature"), std::string("H1"));
+  problem_builder->RegisterCurrentDensityAux("current_density");
+  problem_builder->RegisterJouleHeatingDensityAux(
+      "joule_heating_load", "electric_field", "current_density");
   problem_builder->SetBoundaryConditions(bc_map);
   problem_builder->SetAuxSolvers(preprocessors);
   problem_builder->SetCoefficients(coefficients);

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -115,20 +115,19 @@ protected:
         true);
 
     hephaestus::Sources sources;
-    hephaestus::InputParameters scalar_potential_source_params;
-    scalar_potential_source_params.SetParam("GradPotentialName", std::string("source"));
-    scalar_potential_source_params.SetParam("PotentialName", std::string("electric_potential"));
-    scalar_potential_source_params.SetParam("HCurlFESpaceName", std::string("HCurlSource"));
-    scalar_potential_source_params.SetParam("H1FESpaceName", std::string("H1Source"));
-    scalar_potential_source_params.SetParam("ConductivityCoefName",
-                                            std::string("electrical_conductivity"));
+
     hephaestus::InputParameters current_solver_options;
     current_solver_options.SetParam("Tolerance", float(1.0e-9));
     current_solver_options.SetParam("MaxIter", (unsigned int)1000);
     current_solver_options.SetParam("PrintLevel", -1);
-    scalar_potential_source_params.SetParam("SolverOptions", current_solver_options);
-    sources.Register(
-        "source", new hephaestus::ScalarPotentialSource(scalar_potential_source_params), true);
+    sources.Register("source",
+                     new hephaestus::ScalarPotentialSource("source",
+                                                           "electric_potential",
+                                                           "HCurlSource",
+                                                           "H1Source",
+                                                           "electrical_conductivity",
+                                                           current_solver_options),
+                     true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-9));

--- a/test/integration/test_ebform_coupled.cpp
+++ b/test/integration/test_ebform_coupled.cpp
@@ -126,6 +126,7 @@ protected:
                                                            "HCurlSource",
                                                            "H1Source",
                                                            "electrical_conductivity",
+                                                           -1,
                                                            current_solver_options),
                      true);
 

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -95,6 +95,7 @@ protected:
                                                            "HCurl",
                                                            "H1",
                                                            "electrical_conductivity",
+                                                           -1,
                                                            current_solver_options),
                      true);
 

--- a/test/integration/test_ebform_rod.cpp
+++ b/test/integration/test_ebform_rod.cpp
@@ -84,20 +84,19 @@ protected:
     hephaestus::AuxSolvers preprocessors;
     hephaestus::AuxSolvers postprocessors;
     hephaestus::Sources sources;
-    hephaestus::InputParameters scalar_potential_source_params;
-    scalar_potential_source_params.SetParam("GradPotentialName", std::string("source"));
-    scalar_potential_source_params.SetParam("PotentialName", std::string("electric_potential"));
-    scalar_potential_source_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
-    scalar_potential_source_params.SetParam("H1FESpaceName", std::string("H1"));
-    scalar_potential_source_params.SetParam("ConductivityCoefName",
-                                            std::string("electrical_conductivity"));
+
     hephaestus::InputParameters current_solver_options;
     current_solver_options.SetParam("Tolerance", float(1.0e-9));
     current_solver_options.SetParam("MaxIter", (unsigned int)1000);
     current_solver_options.SetParam("PrintLevel", -1);
-    scalar_potential_source_params.SetParam("SolverOptions", current_solver_options);
-    sources.Register(
-        "source", new hephaestus::ScalarPotentialSource(scalar_potential_source_params), true);
+    sources.Register("source",
+                     new hephaestus::ScalarPotentialSource("source",
+                                                           "electric_potential",
+                                                           "HCurl",
+                                                           "H1",
+                                                           "electrical_conductivity",
+                                                           current_solver_options),
+                     true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-9));

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -100,6 +100,7 @@ protected:
                                                            "_HCurlFESpace",
                                                            "H1",
                                                            "magnetic_permeability",
+                                                           1,
                                                            current_solver_options),
                      true);
 

--- a/test/integration/test_hform_rod.cpp
+++ b/test/integration/test_hform_rod.cpp
@@ -89,20 +89,19 @@ protected:
     hephaestus::AuxSolvers preprocessors;
     hephaestus::AuxSolvers postprocessors;
     hephaestus::Sources sources;
-    hephaestus::InputParameters scalar_potential_source_params;
-    scalar_potential_source_params.SetParam("GradPotentialName", std::string("source"));
-    scalar_potential_source_params.SetParam("PotentialName", std::string("magnetic_potential"));
-    scalar_potential_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));
-    scalar_potential_source_params.SetParam("H1FESpaceName", std::string("H1"));
-    scalar_potential_source_params.SetParam("ConductivityCoefName",
-                                            std::string("magnetic_permeability"));
+
     hephaestus::InputParameters current_solver_options;
     current_solver_options.SetParam("Tolerance", float(1.0e-12));
     current_solver_options.SetParam("MaxIter", (unsigned int)200);
     current_solver_options.SetParam("PrintLevel", 0);
-    scalar_potential_source_params.SetParam("SolverOptions", current_solver_options);
-    sources.Register(
-        "source", new hephaestus::ScalarPotentialSource(scalar_potential_source_params), true);
+    sources.Register("source",
+                     new hephaestus::ScalarPotentialSource("source",
+                                                           "magnetic_potential",
+                                                           "_HCurlFESpace",
+                                                           "H1",
+                                                           "magnetic_permeability",
+                                                           current_solver_options),
+                     true);
 
     hephaestus::InputParameters params;
     params.SetParam("Mesh", mfem::ParMesh(MPI_COMM_WORLD, mesh));

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -102,19 +102,20 @@ protected:
         true);
 
     hephaestus::Sources sources;
-    hephaestus::InputParameters div_free_source_params;
-    div_free_source_params.SetParam("SourceName", std::string("source"));
-    div_free_source_params.SetParam("PotentialName", std::string("magnetic_potential"));
-    div_free_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));
-    div_free_source_params.SetParam("ConductivityCoefName", std::string("electrical_conductivity"));
-    div_free_source_params.SetParam("H1FESpaceName", std::string("H1"));
     hephaestus::InputParameters current_solver_options;
     current_solver_options.SetParam("Tolerance", float(1.0e-12));
     current_solver_options.SetParam("MaxIter", (unsigned int)200);
     current_solver_options.SetParam("PrintLevel", 0);
-    div_free_source_params.SetParam("SolverOptions", current_solver_options);
-    div_free_source_params.SetParam("HelmholtzProjection", false);
-    sources.Register("source", new hephaestus::DivFreeSource(div_free_source_params), true);
+
+    sources.Register("source",
+                     new hephaestus::DivFreeSource("source",
+                                                   "source",
+                                                   "_HCurlFESpace",
+                                                   "H1",
+                                                   "magnetic_potential",
+                                                   current_solver_options,
+                                                   false),
+                     true);
 
     hephaestus::InputParameters solver_options;
     solver_options.SetParam("Tolerance", float(1.0e-16));

--- a/test/unit/test_closedcoil.cpp
+++ b/test/unit/test_closedcoil.cpp
@@ -25,7 +25,6 @@ TEST_CASE("ClosedCoilTest", "[CheckData]")
   mfem::ConstantCoefficient itot(ival);
   mfem::ConstantCoefficient conductivity(cond_val);
 
-  hephaestus::InputParameters ccs_params;
   hephaestus::BCMap bc_maps;
 
   hephaestus::Coefficients coefficients;
@@ -38,17 +37,11 @@ TEST_CASE("ClosedCoilTest", "[CheckData]")
   hephaestus::GridFunctions gridfunctions;
   gridfunctions.Register(std::string("GradPhi"), &grad_phi, false);
 
-  ccs_params.SetParam("H1FESpaceName", std::string("H1"));
-  ccs_params.SetParam("HCurlFESpaceName", std::string("HCurl"));
-  ccs_params.SetParam("GradPotentialName", std::string("GradPhi"));
-  ccs_params.SetParam("IFuncCoefName", std::string("Itotal"));
-  ccs_params.SetParam("ConductivityCoefName", std::string("Conductivity"));
-  ccs_params.SetParam("GradPhiTransfer", true);
-
   int elec_attr = 7;
   mfem::Array<int> submesh_domains({3, 4, 5, 6});
 
-  hephaestus::ClosedCoilSolver closedcoil(ccs_params, submesh_domains, elec_attr);
+  hephaestus::ClosedCoilSolver closedcoil(
+      "GradPhi", "HCurl", "H1", "Itotal", "Conductivity", submesh_domains, elec_attr, true);
   closedcoil.Init(gridfunctions, fespaces, bc_maps, coefficients);
   mfem::ParLinearForm dummy(&h_curl_fe_space);
   closedcoil.Apply(&dummy);

--- a/test/unit/test_conductivity_opencoil.cpp
+++ b/test/unit/test_conductivity_opencoil.cpp
@@ -54,8 +54,9 @@ TEST_CASE("ConductivityOpenCoil", "[CheckData]")
   mfem::ParLinearForm dummy(&h_curl_fe_space);
   opencoil.Apply(&dummy);
 
-  double flux1 = hephaestus::calcFlux(&e, 4, conductivity);
-  double flux2 = hephaestus::calcFlux(&e, 5, conductivity);
+  //- sign comes from the direction of the outward facing normal relative to elec_attrs order
+  double flux1 = -hephaestus::calcFlux(&e, 4, conductivity);
+  double flux2 = -hephaestus::calcFlux(&e, 5, conductivity);
 
   REQUIRE_THAT(flux1 + flux2, Catch::Matchers::WithinAbs(ival, eps));
   REQUIRE_THAT(flux1 / flux2, Catch::Matchers::WithinAbs(r, eps));

--- a/test/unit/test_conductivity_opencoil.cpp
+++ b/test/unit/test_conductivity_opencoil.cpp
@@ -32,7 +32,6 @@ TEST_CASE("ConductivityOpenCoil", "[CheckData]")
   mfem::ConstantCoefficient itot(ival);
   mfem::FunctionCoefficient conductivity(sigma);
 
-  hephaestus::InputParameters ocs_params;
   hephaestus::BCMap bc_maps;
 
   hephaestus::Coefficients coefficients;
@@ -45,17 +44,12 @@ TEST_CASE("ConductivityOpenCoil", "[CheckData]")
   hephaestus::GridFunctions gridfunctions;
   gridfunctions.Register(std::string("E"), &e, false);
 
-  ocs_params.SetParam("GradPotentialName", std::string("E"));
-  ocs_params.SetParam("IFuncCoefName", std::string("Itotal"));
-  ocs_params.SetParam("PotentialName", std::string("V"));
-  ocs_params.SetParam("ConductivityCoefName", std::string("Conductivity"));
-  ocs_params.SetParam("GradPhiTransfer", true);
-
   std::pair<int, int> elec_attrs{2, 3};
   mfem::Array<int> submesh_domains;
   submesh_domains.Append(1);
 
-  hephaestus::OpenCoilSolver opencoil(ocs_params, submesh_domains, elec_attrs);
+  hephaestus::OpenCoilSolver opencoil(
+      "E", "V", "Itotal", "Conductivity", submesh_domains, elec_attrs, true);
   opencoil.Init(gridfunctions, fespaces, bc_maps, coefficients);
   mfem::ParLinearForm dummy(&h_curl_fe_space);
   opencoil.Apply(&dummy);

--- a/test/unit/test_opencoil.cpp
+++ b/test/unit/test_opencoil.cpp
@@ -51,7 +51,8 @@ TEST_CASE("OpenCoilTest", "[CheckData]")
   mfem::ParLinearForm dummy(&h_curl_fe_space);
   opencoil.Apply(&dummy);
 
-  double flux = hephaestus::calcFlux(&e, elec_attrs.first, conductivity);
+  //- sign comes from the direction of the outward facing normal relative to elec_attrs order
+  double flux = -hephaestus::calcFlux(&e, elec_attrs.first, conductivity);
 
   REQUIRE_THAT(flux, Catch::Matchers::WithinAbs(ival, eps));
 }

--- a/test/unit/test_opencoil.cpp
+++ b/test/unit/test_opencoil.cpp
@@ -29,7 +29,6 @@ TEST_CASE("OpenCoilTest", "[CheckData]")
   mfem::ConstantCoefficient itot(ival);
   mfem::ConstantCoefficient conductivity(cond_val);
 
-  hephaestus::InputParameters ocs_params;
   hephaestus::BCMap bc_maps;
 
   hephaestus::Coefficients coefficients;
@@ -42,16 +41,12 @@ TEST_CASE("OpenCoilTest", "[CheckData]")
   hephaestus::GridFunctions gridfunctions;
   gridfunctions.Register(std::string("E"), &e, false);
 
-  ocs_params.SetParam("GradPotentialName", std::string("E"));
-  ocs_params.SetParam("IFuncCoefName", std::string("Itotal"));
-  ocs_params.SetParam("PotentialName", std::string("V"));
-  ocs_params.SetParam("ConductivityCoefName", std::string("Conductivity"));
-
   std::pair<int, int> elec_attrs{1, 2};
   mfem::Array<int> submesh_domains;
   submesh_domains.Append(1);
 
-  hephaestus::OpenCoilSolver opencoil(ocs_params, submesh_domains, elec_attrs);
+  hephaestus::OpenCoilSolver opencoil(
+      "E", "V", "Itotal", "Conductivity", submesh_domains, elec_attrs);
   opencoil.Init(gridfunctions, fespaces, bc_maps, coefficients);
   mfem::ParLinearForm dummy(&h_curl_fe_space);
   opencoil.Apply(&dummy);


### PR DESCRIPTION
Updates default AuxSolvers for EM formulations to (optionally) add on external fields during calculation.

Also:
- `hephaestus::OpenCoilSolver` can now (optionally) calculate the source current density in a H(div) conforming space.
-  Joule heating formulation AuxSolvers now require electric fields and current densities rather than electric fields and conductivity coefficients; a related issue where Joule heating loads would be being calculated as nonzero in elements adjacent to conducting volumes has also been resolved.
- `OpenCoilSolver`, `ClosedCoilSolver`, `ScalarPotentialSource` and `DivFreeSource` Sources now have explicit constructors rather than using `hephaestus::InputParameters` to pass in inputs, since the latter was a major source of bugs
- `ScalarPotentialSource` can apply an optional sign flip before application of the source to a LinearForm, making identification of the scalar potential with the sign conventions typical for electric or magnetic potentials simpler.