### PR TITLE
Adds alternative Joule heating auxsolver guaranteed to be positive definite

### DIFF
--- a/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.cpp
@@ -114,4 +114,24 @@ ComplexAFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }
 
+//* Time averaged Joule heating density = σ|E|^2
+void
+ComplexAFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                                    const std::string & e_field_real_name,
+                                                    const std::string & e_field_imag_name)
+{
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
+  auxsolvers.Register(
+      p_field_name,
+      std::make_shared<hephaestus::VectorGridFunctionDotProductAux>(p_field_name,
+                                                                    p_field_name,
+                                                                    _electric_conductivity_name,
+                                                                    e_field_real_name,
+                                                                    e_field_real_name,
+                                                                    e_field_imag_name,
+                                                                    e_field_imag_name,
+                                                                    true));
+  auxsolvers.Get(p_field_name)->SetPriority(2);
+}
+
 } // namespace hephaestus

--- a/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_a_formulation.hpp
@@ -66,6 +66,11 @@ public:
                                       const std::string & j_field_real_name,
                                       const std::string & j_field_imag_name) override;
 
+  // Time averaged Joule heating density σ|E|^2
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                      const std::string & e_field_real_name,
+                                      const std::string & e_field_imag_name) override;
+
 protected:
   const std::string & _magnetic_reluctivity_name =
       hephaestus::ComplexMaxwellFormulation::_alpha_coef_name;

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -81,7 +81,8 @@ ComplexEFormulation::RegisterMagneticFluxDensityAux(const std::string & b_field_
                                                                     external_b_field_real_name));
 }
 
-// Enable auxiliary calculation of P ∈ L2
+//* Enable auxiliary calculation of P ∈ L2
+//* Time averaged Joule heating density = E.J
 void
 ComplexEFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                                     const std::string & e_field_real_name,
@@ -89,7 +90,7 @@ ComplexEFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_
                                                     const std::string & j_field_real_name,
                                                     const std::string & j_field_imag_name)
 {
-  //* Time averaged Joule heating density = E.J
+
   hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
   auxsolvers.Register(
       p_field_name,
@@ -100,6 +101,27 @@ ComplexEFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_
                                                                     j_field_real_name,
                                                                     _electric_field_imag_name,
                                                                     j_field_imag_name,
+                                                                    true));
+  auxsolvers.Get(p_field_name)->SetPriority(2);
+}
+
+//* Enable auxiliary calculation of P ∈ L2
+//* Time averaged Joule heating density σ|E|^2
+void
+ComplexEFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                                    const std::string & e_field_real_name,
+                                                    const std::string & e_field_imag_name)
+{
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
+  auxsolvers.Register(
+      p_field_name,
+      std::make_shared<hephaestus::VectorGridFunctionDotProductAux>(p_field_name,
+                                                                    p_field_name,
+                                                                    _electric_conductivity_name,
+                                                                    _electric_field_real_name,
+                                                                    _electric_field_real_name,
+                                                                    _electric_field_imag_name,
+                                                                    _electric_field_imag_name,
                                                                     true));
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.hpp
@@ -68,6 +68,11 @@ public:
                                       const std::string & j_field_real_name,
                                       const std::string & j_field_imag_name) override;
 
+  // Time averaged Joule heating density σ|E|^2
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                      const std::string & e_field_real_name,
+                                      const std::string & e_field_imag_name) override;
+
 protected:
   const std::string & _magnetic_reluctivity_name =
       hephaestus::ComplexMaxwellFormulation::_alpha_coef_name;

--- a/src/formulations/Dual/eb_dual_formulation.cpp
+++ b/src/formulations/Dual/eb_dual_formulation.cpp
@@ -61,6 +61,19 @@ EBDualFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_na
 }
 
 void
+EBDualFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                                  const std::string & e_field_name)
+{
+  //* Joule heating density = E.J
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
+  auxsolvers.Register(
+      p_field_name,
+      std::make_shared<hephaestus::VectorGridFunctionDotProductAux>(
+          p_field_name, p_field_name, _electric_conductivity_name, e_field_name, e_field_name));
+  auxsolvers.Get(p_field_name)->SetPriority(2);
+}
+
+void
 EBDualFormulation::RegisterCoefficients()
 {
   hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;

--- a/src/formulations/Dual/eb_dual_formulation.hpp
+++ b/src/formulations/Dual/eb_dual_formulation.hpp
@@ -30,6 +30,8 @@ public:
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
                                       const std::string & j_field_name) override;
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                      const std::string & e_field_name) override;
 
   void RegisterCoefficients() override;
 

--- a/src/formulations/HCurl/a_formulation.cpp
+++ b/src/formulations/HCurl/a_formulation.cpp
@@ -113,6 +113,19 @@ AFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
 }
 
 void
+AFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                             const std::string & e_field_name)
+{
+  //* Joule heating density = E.J
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
+  auxsolvers.Register(
+      p_field_name,
+      std::make_shared<hephaestus::VectorGridFunctionDotProductAux>(
+          p_field_name, p_field_name, _electric_conductivity_name, e_field_name, e_field_name));
+  auxsolvers.Get(p_field_name)->SetPriority(2);
+}
+
+void
 AFormulation::RegisterCoefficients()
 {
   hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;

--- a/src/formulations/HCurl/a_formulation.hpp
+++ b/src/formulations/HCurl/a_formulation.hpp
@@ -42,6 +42,9 @@ public:
                                       const std::string & e_field_name,
                                       const std::string & j_field_name) override;
 
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                      const std::string & e_field_name) override;
+
   void RegisterCoefficients() override;
 
 protected:

--- a/src/formulations/HCurl/e_formulation.cpp
+++ b/src/formulations/HCurl/e_formulation.cpp
@@ -75,5 +75,17 @@ EFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                           p_field_name, p_field_name, "", e_field_name, j_field_name));
   auxsolvers.Get(p_field_name)->SetPriority(2);
 }
+void
+EFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                             const std::string & e_field_name)
+{
+  //* Joule heating density = E.J
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
+  auxsolvers.Register(
+      p_field_name,
+      std::make_shared<hephaestus::VectorGridFunctionDotProductAux>(
+          p_field_name, p_field_name, _electric_conductivity_name, e_field_name, e_field_name));
+  auxsolvers.Get(p_field_name)->SetPriority(2);
+}
 
 } // namespace hephaestus

--- a/src/formulations/HCurl/e_formulation.hpp
+++ b/src/formulations/HCurl/e_formulation.hpp
@@ -26,6 +26,8 @@ public:
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
                                       const std::string & j_field_name) override;
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                      const std::string & e_field_name) override;
 
 protected:
   const std::string _magnetic_permeability_name;

--- a/src/formulations/HCurl/h_formulation.cpp
+++ b/src/formulations/HCurl/h_formulation.cpp
@@ -101,6 +101,19 @@ HFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
 }
 
 void
+HFormulation::RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                             const std::string & e_field_name)
+{
+  //* Joule heating density = E.J
+  hephaestus::AuxSolvers & auxsolvers = GetProblem()->_postprocessors;
+  auxsolvers.Register(
+      p_field_name,
+      std::make_shared<hephaestus::VectorGridFunctionDotProductAux>(
+          p_field_name, p_field_name, _electric_conductivity_name, e_field_name, e_field_name));
+  auxsolvers.Get(p_field_name)->SetPriority(2);
+}
+
+void
 HFormulation::RegisterCoefficients()
 {
   hephaestus::Coefficients & coefficients = GetProblem()->_coefficients;

--- a/src/formulations/HCurl/h_formulation.hpp
+++ b/src/formulations/HCurl/h_formulation.hpp
@@ -41,6 +41,8 @@ public:
   void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
                                       const std::string & e_field_name,
                                       const std::string & j_field_name) override;
+  void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                      const std::string & e_field_name) override;
 
   void RegisterCoefficients() override;
 

--- a/src/formulations/complex_em_formulation_interface.hpp
+++ b/src/formulations/complex_em_formulation_interface.hpp
@@ -55,5 +55,12 @@ public:
   {
     MFEM_ABORT("Joule heating auxsolver not available for this formulation");
   }
+
+  virtual void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                              const std::string & e_field_real_name,
+                                              const std::string & e_field_imag_name)
+  {
+    MFEM_ABORT("Joule heating auxsolver not available for this formulation");
+  }
 };
 } // namespace hephaestus

--- a/src/formulations/em_formulation_interface.hpp
+++ b/src/formulations/em_formulation_interface.hpp
@@ -53,5 +53,11 @@ public:
   {
     MFEM_ABORT("Joule heating auxsolver not available for this formulation");
   }
+
+  virtual void RegisterJouleHeatingDensityAux(const std::string & p_field_name,
+                                              const std::string & e_field_name)
+  {
+    MFEM_ABORT("Joule heating auxsolver not available for this formulation");
+  }
 };
 } // namespace hephaestus


### PR DESCRIPTION
Currently, Joule heating auxsolvers in formulations calculate E.J given discretised representations of E and J, which may not be positive definite for some elements and low order solves due to interpolation. The resultant small negative Joule heating terms can cause issues when coupling to thermal solvers. This adds an alternative set of Joule heating auxsolvers that calculate the Joule heating via sigma*|E|^2 instead. 