### PR TITLE
Hotfix for ClosedCoilSolver

### DIFF
--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -5,13 +5,31 @@ const char * DATA_DIR = "../../data/";
 hephaestus::Coefficients
 defineCoefficients()
 {
-  hephaestus::Coefficients coefficients;
-
+  hephaestus::Subdomain air("air", 1);
+  air._scalar_coefficients.Register("electrical_conductivity",
+                                    std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Subdomain plate("plate", 2);
+  plate._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(3.526e7));
+  hephaestus::Subdomain coil1("coil1", 3);
+  coil1._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Subdomain coil2("coil2", 4);
+  coil2._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Subdomain coil3("coil3", 5);
+  coil3._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Subdomain coil4("coil4", 6);
+  coil4._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Coefficients coefficients(
+      std::vector<hephaestus::Subdomain>({air, plate, coil1, coil2, coil3, coil4}));
+  coefficients._scalars.Register("frequency", std::make_shared<mfem::ConstantCoefficient>(200.0));
   coefficients._scalars.Register("magnetic_permeability",
                                  std::make_shared<mfem::ConstantCoefficient>(M_PI * 4.0e-7));
-
-  coefficients._scalars.Register("electrical_conductivity",
-                                 std::make_shared<mfem::ConstantCoefficient>(1.0e6));
+  coefficients._scalars.Register("dielectric_permittivity",
+                                 std::make_shared<mfem::ConstantCoefficient>(8.854e-12));
 
   coefficients._scalars.Register("I", std::make_shared<mfem::ConstantCoefficient>(2742));
 

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -37,14 +37,15 @@ defineSources()
 
   hephaestus::Sources sources;
   sources.Register("source",
-                   std::make_shared<hephaestus::ClosedCoilSolver>("source_grad_phi",
+                   std::make_shared<hephaestus::ClosedCoilSolver>("source_electric_field",
                                                                   "HCurl",
                                                                   "H1",
                                                                   "I",
                                                                   "electrical_conductivity",
                                                                   coil_domains,
                                                                   electrode_attr,
-                                                                  true));
+                                                                  true,
+                                                                  "source_current_density"));
   return sources;
 }
 
@@ -79,12 +80,13 @@ main(int argc, char * argv[])
     pmesh->UniformRefinement();
 
   problem_builder->SetMesh(pmesh);
-  problem_builder->AddFESpace(std::string("H1"), std::string("H1_3D_P1"));
-  problem_builder->AddFESpace(std::string("HCurl"), std::string("ND_3D_P1"));
-  problem_builder->AddFESpace(std::string("HDiv"), std::string("RT_3D_P0"));
-  problem_builder->AddGridFunction(std::string("magnetic_vector_potential"), std::string("HCurl"));
-  problem_builder->AddGridFunction(std::string("source_grad_phi"), std::string("HCurl"));
-  problem_builder->AddGridFunction(std::string("magnetic_flux_density"), std::string("HDiv"));
+  problem_builder->AddFESpace("H1", "H1_3D_P1");
+  problem_builder->AddFESpace("HCurl", "ND_3D_P1");
+  problem_builder->AddFESpace("HDiv", "RT_3D_P0");
+  problem_builder->AddGridFunction("magnetic_vector_potential", "HCurl");
+  problem_builder->AddGridFunction("source_electric_field", "HCurl");
+  problem_builder->AddGridFunction("magnetic_flux_density", "HDiv");
+  problem_builder->AddGridFunction("source_current_density", "HDiv");
   problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density");
 
   hephaestus::Coefficients coefficients = defineCoefficients();

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -11,7 +11,7 @@ defineCoefficients()
                                  std::make_shared<mfem::ConstantCoefficient>(M_PI * 4.0e-7));
 
   coefficients._scalars.Register("electrical_conductivity",
-                                 std::make_shared<mfem::ConstantCoefficient>(1.0));
+                                 std::make_shared<mfem::ConstantCoefficient>(1.0e6));
 
   coefficients._scalars.Register("I", std::make_shared<mfem::ConstantCoefficient>(2742));
 


### PR DESCRIPTION
ClosedCoilSolver appears to have been broken in #74 by commit 7495867 when resolving merge conflicts. A current was generated in the transition region, but was zero in the rest of the coil. This appears to be due to the electrical conductivity being inconsistently set inside and outside the transition region. As the flux across the transition region was still correct, it was not being picked up in the existing ClosedCoilSolver test.

This PR provides a fix for this.