### PR TITLE
ClosedCoilSolver Fixes

### DIFF
--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -5,13 +5,31 @@ const char * DATA_DIR = "../../data/";
 hephaestus::Coefficients
 defineCoefficients()
 {
-  hephaestus::Coefficients coefficients;
-
+  hephaestus::Subdomain air("air", 1);
+  air._scalar_coefficients.Register("electrical_conductivity",
+                                    std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Subdomain plate("plate", 2);
+  plate._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(3.526e7));
+  hephaestus::Subdomain coil1("coil1", 3);
+  coil1._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Subdomain coil2("coil2", 4);
+  coil2._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Subdomain coil3("coil3", 5);
+  coil3._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Subdomain coil4("coil4", 6);
+  coil4._scalar_coefficients.Register("electrical_conductivity",
+                                      std::make_shared<mfem::ConstantCoefficient>(1.0));
+  hephaestus::Coefficients coefficients(
+      std::vector<hephaestus::Subdomain>({air, plate, coil1, coil2, coil3, coil4}));
+  coefficients._scalars.Register("frequency", std::make_shared<mfem::ConstantCoefficient>(200.0));
   coefficients._scalars.Register("magnetic_permeability",
                                  std::make_shared<mfem::ConstantCoefficient>(M_PI * 4.0e-7));
-
-  coefficients._scalars.Register("electrical_conductivity",
-                                 std::make_shared<mfem::ConstantCoefficient>(1.0));
+  coefficients._scalars.Register("dielectric_permittivity",
+                                 std::make_shared<mfem::ConstantCoefficient>(8.854e-12));
 
   coefficients._scalars.Register("I", std::make_shared<mfem::ConstantCoefficient>(2742));
 

--- a/src/sources/closed_coil.cpp
+++ b/src/sources/closed_coil.cpp
@@ -275,12 +275,10 @@ ClosedCoilSolver::MakeWedge()
 
   // If we are dealing with a piecewise-defined conductivity, we need to
   // add the new wedge domain to the coefficient
-
-  // This is to avoid a compiler warning
-  auto sig_ptr = _sigma.get();
-  if (typeid(*sig_ptr) == typeid(mfem::PWCoefficient))
+  std::shared_ptr<mfem::PWCoefficient> id_test =
+      std::dynamic_pointer_cast<mfem::PWCoefficient>(_sigma);
+  if (id_test != nullptr)
   {
-
     std::vector<hephaestus::Subdomain> subdomains = _ccs_coefs._subdomains;
     hephaestus::Subdomain new_domain("wedge", _new_domain_attr);
     int wedge_old_att = _mesh_parent->GetAttribute(wedge_els[0]);
@@ -316,7 +314,6 @@ ClosedCoilSolver::MakeWedge()
     _ccs_coefs.AddGlobalCoefficientsFromSubdomains();
     _sigma = _ccs_coefs._scalars.GetShared(_cond_coef_name);
   }
-
   // Now we set the second electrode boundary attribute. Start with a list of
   // all the faces of the wedge elements and eliminate mesh and coil boundaries,
   // the first electrode, and faces between wedge elements

--- a/src/sources/closed_coil.cpp
+++ b/src/sources/closed_coil.cpp
@@ -556,8 +556,8 @@ ClosedCoilSolver::SolveCoil()
   _mesh_t->Transfer(*_source_electric_field, *electric_field_aux_t);
 
   // The total flux across the electrode face is Φ_t + Φ_aux
-  // where Φ_t is the transition flux, already normalised to be 1
-  double flux = 1.0 + calcFlux(electric_field_aux_t.get(), _elec_attrs.first, *_sigma);
+  // where Φ_t is the transition flux, already normalised to be -1
+  double flux = -1.0 + calcFlux(electric_field_aux_t.get(), _elec_attrs.first, *_sigma);
 
   if (_electric_field_transfer)
   {

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -43,7 +43,7 @@ public:
   // 1-element layer adjacent to it. Applies a different domain attribute to
   // other elements in the coil. Also applies different boundary attributes on
   // the two opposing faces of the layer, to act as Dirichlet BCs.
-  void MakeWedge();
+  void MakeWedge(hephaestus::Coefficients & coefficients);
 
   // Extracts the coil submesh and prepares the gridfunctions and FE spaces
   // for being passed to the OpenCoilSolver in the transition region

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -43,7 +43,7 @@ public:
   // 1-element layer adjacent to it. Applies a different domain attribute to
   // other elements in the coil. Also applies different boundary attributes on
   // the two opposing faces of the layer, to act as Dirichlet BCs.
-  void MakeWedge(hephaestus::Coefficients & coefficients);
+  void MakeWedge();
 
   // Extracts the coil submesh and prepares the gridfunctions and FE spaces
   // for being passed to the OpenCoilSolver in the transition region
@@ -81,6 +81,7 @@ private:
   std::shared_ptr<mfem::Coefficient> _itotal{nullptr};
   std::vector<int> _old_dom_attrs;
   hephaestus::InputParameters _solver_options;
+  hephaestus::Coefficients _ccs_coefs;
 
   // Here, we are solving for -(σ∇Va,∇ψ) = (σ∇Vt,∇ψ), where ∇Vt is grad_phi_t (within its relevant
   // mesh), ∇Va is grad_phi_aux, and their sum ∇Vt+∇Va is the full grad_phi, which is, up to an

--- a/test/unit/test_closedcoil.cpp
+++ b/test/unit/test_closedcoil.cpp
@@ -7,8 +7,8 @@ extern const char * DATA_DIR;
 TEST_CASE("ClosedCoilTest", "[CheckData]")
 {
 
-  // Floating point error tolerance
-  const double eps{1e-10};
+  // Error tolerance
+  const double eps{1e-2};
 
   int order = 1;
 
@@ -51,5 +51,5 @@ TEST_CASE("ClosedCoilTest", "[CheckData]")
 
   double flux = hephaestus::calcFlux(grad_phi.get(), test_attr, *conductivity);
 
-  REQUIRE_THAT(flux, Catch::Matchers::WithinAbs(ival, eps));
+  REQUIRE_THAT(-flux, Catch::Matchers::WithinAbs(ival, eps));
 }

--- a/test/unit/test_closedcoil.cpp
+++ b/test/unit/test_closedcoil.cpp
@@ -40,6 +40,7 @@ TEST_CASE("ClosedCoilTest", "[CheckData]")
   gridfunctions.Register(std::string("GradPhi"), grad_phi);
 
   int elec_attr = 7;
+  int test_attr = 8;
   mfem::Array<int> submesh_domains({3, 4, 5, 6});
 
   hephaestus::ClosedCoilSolver closedcoil(
@@ -48,7 +49,7 @@ TEST_CASE("ClosedCoilTest", "[CheckData]")
   mfem::ParLinearForm dummy(h_curl_fe_space.get());
   closedcoil.Apply(&dummy);
 
-  double flux = hephaestus::calcFlux(grad_phi.get(), elec_attr, *conductivity);
+  double flux = hephaestus::calcFlux(grad_phi.get(), test_attr, *conductivity);
 
   REQUIRE_THAT(flux, Catch::Matchers::WithinAbs(ival, eps));
 }


### PR DESCRIPTION
With the intense repo activity in the last few weeks, some sign changes seeped into CCS, breaking the calculation. This PR seeks to fix these issues by closely following the minus sign conventions used in the derivation of the Dular method.