### PR TITLE
Conservative mappings in CoefficientAux and VectorCoefficientAux

### DIFF
--- a/examples/team4/Main.cpp
+++ b/examples/team4/Main.cpp
@@ -114,8 +114,8 @@ main(int argc, char * argv[])
   problem_builder->AddFESpace("H1", "H1_3D_P1");
   problem_builder->AddFESpace("HCurl", "ND_3D_P1");
   problem_builder->AddFESpace("HDiv", "RT_3D_P0");
-  problem_builder->AddFESpace("Scalar_L2", "L2Int_3D_P0");
-  problem_builder->AddFESpace("Vector_L2", "L2Int_3D_P0", 3);
+  problem_builder->AddFESpace("Scalar_L2", "L2_3D_P0");
+  problem_builder->AddFESpace("Vector_L2", "L2_3D_P0", 3);
   problem_builder->AddGridFunction("magnetic_field", "HCurl");
 
   problem_builder->AddGridFunction("dmagnetic_potential_dt", "H1");

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -158,8 +158,8 @@ main(int argc, char * argv[])
   problem_builder->AddFESpace("H1", "H1_3D_P1");
   problem_builder->AddFESpace("HCurl", "ND_3D_P1");
   problem_builder->AddFESpace("HDiv", "RT_3D_P0");
-  problem_builder->AddFESpace("Scalar_L2", "L2Int_3D_P0");
-  problem_builder->AddFESpace("Vector_L2", "L2Int_3D_P0", 3);
+  problem_builder->AddFESpace("Scalar_L2", "L2_3D_P0");
+  problem_builder->AddFESpace("Vector_L2", "L2_3D_P0", 3);
   problem_builder->AddGridFunction("magnetic_vector_potential", "HCurl");
 
   problem_builder->AddGridFunction("magnetic_flux_density", "HDiv");

--- a/src/auxsolvers/coefficient_aux.cpp
+++ b/src/auxsolvers/coefficient_aux.cpp
@@ -5,8 +5,12 @@
 namespace hephaestus
 {
 
-CoefficientAux::CoefficientAux(std::string gf_name, std::string coef_name)
-  : _gf_name(std::move(gf_name)), _coef_name(std::move(coef_name))
+CoefficientAux::CoefficientAux(std::string gf_name,
+                               std::string coef_name,
+                               hephaestus::InputParameters solver_options)
+  : _gf_name(std::move(gf_name)),
+    _coef_name(std::move(coef_name)),
+    _solver_options(std::move(solver_options))
 {
 }
 
@@ -16,12 +20,44 @@ CoefficientAux::Init(const hephaestus::GridFunctions & gridfunctions,
 {
   _gf = gridfunctions.Get(_gf_name);
   _coef = coefficients._scalars.Get(_coef_name);
+  _test_fes = _gf->ParFESpace();
+
+  BuildBilinearForm();
+  BuildLinearForm();
+  _a_mat = std::unique_ptr<mfem::HypreParMatrix>(_a->ParallelAssemble());
+  _solver = std::make_unique<hephaestus::DefaultJacobiPCGSolver>(_solver_options, *_a_mat);
+}
+
+void
+CoefficientAux::BuildBilinearForm()
+{
+  _a = std::make_unique<mfem::ParBilinearForm>(_test_fes);
+  _a->AddDomainIntegrator(new mfem::MassIntegrator());
+  _a->Assemble();
+  _a->Finalize();
+}
+
+void
+CoefficientAux::BuildLinearForm()
+{
+  _b = std::make_unique<mfem::ParLinearForm>(_test_fes);
+  _b->AddDomainIntegrator(new mfem::DomainLFIntegrator(*_coef));
+  _b->Assemble();
 }
 
 void
 CoefficientAux::Solve(double t)
 {
-  _gf->ProjectCoefficient(*_coef);
+  mfem::Vector x(_test_fes->GetTrueVSize()); // Gridfunction true DOFs
+  _gf->ProjectCoefficient(*_coef);           // Initial condition
+  _gf->GetTrueDofs(x);
+
+  // Reassemble in case coef has changed
+  _b->Update();
+  _b->Assemble();
+
+  _solver->Mult(*_b, x);
+  _gf->SetFromTrueDofs(x);
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/coefficient_aux.hpp
+++ b/src/auxsolvers/coefficient_aux.hpp
@@ -4,17 +4,22 @@
 namespace hephaestus
 {
 
-// Project a stored scalar Coefficient onto a (scalar) GridFunction
+// Interpolate a stored scalar Coefficient onto a (scalar) GridFunction
+// by solving (p, q) = (λ, q)
 class CoefficientAux : public AuxSolver
 {
 public:
-  CoefficientAux(std::string gf_name, std::string coef_name);
+  CoefficientAux(std::string gf_name,
+                 std::string coef_name,
+                 hephaestus::InputParameters solver_options = hephaestus::InputParameters());
 
   ~CoefficientAux() override = default;
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;
 
+  virtual void BuildBilinearForm();
+  virtual void BuildLinearForm();
   void Solve(double t = 0.0) override;
 
 protected:
@@ -23,6 +28,22 @@ protected:
 
   mfem::ParGridFunction * _gf{nullptr};
   mfem::Coefficient * _coef{nullptr};
+
+  // Pointer to store test FE space. Assumed to be same as trial FE space.
+  mfem::ParFiniteElementSpace * _test_fes{nullptr};
+
+  // Bilinear and linear forms
+  std::unique_ptr<mfem::ParBilinearForm> _a{nullptr};
+  std::unique_ptr<mfem::ParLinearForm> _b{nullptr};
+
+private:
+  const hephaestus::InputParameters _solver_options;
+
+  // Operator matrices
+  std::unique_ptr<mfem::HypreParMatrix> _a_mat{nullptr};
+
+  // Solver
+  std::unique_ptr<hephaestus::DefaultJacobiPCGSolver> _solver{nullptr};
 };
 
 } // namespace hephaestus

--- a/src/auxsolvers/vector_coefficient_aux.cpp
+++ b/src/auxsolvers/vector_coefficient_aux.cpp
@@ -5,8 +5,12 @@
 namespace hephaestus
 {
 
-VectorCoefficientAux::VectorCoefficientAux(std::string gf_name, std::string vec_coef_name)
-  : _gf_name(std::move(gf_name)), _vec_coef_name(std::move(vec_coef_name))
+VectorCoefficientAux::VectorCoefficientAux(std::string gf_name,
+                                           std::string vec_coef_name,
+                                           hephaestus::InputParameters solver_options)
+  : _gf_name(std::move(gf_name)),
+    _vec_coef_name(std::move(vec_coef_name)),
+    _solver_options(std::move(solver_options))
 {
 }
 
@@ -16,13 +20,58 @@ VectorCoefficientAux::Init(const hephaestus::GridFunctions & gridfunctions,
 {
   _gf = gridfunctions.Get(_gf_name);
   _vec_coef = coefficients._vectors.Get(_vec_coef_name);
+  _test_fes = _gf->ParFESpace();
+
+  BuildBilinearForm();
+  BuildLinearForm();
+  _a_mat = std::unique_ptr<mfem::HypreParMatrix>(_a->ParallelAssemble());
+  _solver = std::make_unique<hephaestus::DefaultJacobiPCGSolver>(_solver_options, *_a_mat);
+}
+
+void
+VectorCoefficientAux::BuildBilinearForm()
+{
+  _a = std::make_unique<mfem::ParBilinearForm>(_test_fes);
+  if (_test_fes->FEColl()->GetRangeType(3) == mfem::FiniteElement::SCALAR)
+  {
+    _a->AddDomainIntegrator(new mfem::VectorMassIntegrator());
+  }
+  else
+  {
+    _a->AddDomainIntegrator(new mfem::VectorFEMassIntegrator());
+  }
+  _a->Assemble();
+  _a->Finalize();
+}
+
+void
+VectorCoefficientAux::BuildLinearForm()
+{
+  _b = std::make_unique<mfem::ParLinearForm>(_test_fes);
+  if (_test_fes->FEColl()->GetRangeType(3) == mfem::FiniteElement::SCALAR)
+  {
+    _b->AddDomainIntegrator(new mfem::VectorDomainLFIntegrator(*_vec_coef));
+  }
+  else
+  {
+    _b->AddDomainIntegrator(new mfem::VectorFEDomainLFIntegrator(*_vec_coef));
+  }
+  _b->Assemble();
 }
 
 void
 VectorCoefficientAux::Solve(double t)
 {
-  _vec_coef->SetTime(t);
-  _gf->ProjectCoefficient(*_vec_coef);
+  mfem::Vector x(_test_fes->GetTrueVSize()); // Gridfunction true DOFs
+  _gf->ProjectCoefficient(*_vec_coef);       // Initial condition
+  _gf->GetTrueDofs(x);
+
+  // Reassemble in case coef has changed
+  _b->Update();
+  _b->Assemble();
+
+  _solver->Mult(*_b, x);
+  _gf->SetFromTrueDofs(x);
 }
 
 } // namespace hephaestus

--- a/src/auxsolvers/vector_coefficient_aux.hpp
+++ b/src/auxsolvers/vector_coefficient_aux.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "auxsolver_base.hpp"
+#include "coefficient_aux.hpp"
 
 namespace hephaestus
 {
@@ -8,13 +8,17 @@ namespace hephaestus
 class VectorCoefficientAux : public AuxSolver
 {
 public:
-  VectorCoefficientAux(std::string gf_name, std::string vec_coef_name);
+  VectorCoefficientAux(std::string gf_name,
+                       std::string vec_coef_name,
+                       hephaestus::InputParameters solver_options = hephaestus::InputParameters());
 
   ~VectorCoefficientAux() override = default;
 
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;
 
+  virtual void BuildBilinearForm();
+  virtual void BuildLinearForm();
   void Solve(double t = 0.0) override;
 
 protected:
@@ -23,6 +27,22 @@ protected:
 
   mfem::ParGridFunction * _gf{nullptr};
   mfem::VectorCoefficient * _vec_coef{nullptr};
+
+  // Pointer to store test FE space. Assumed to be same as trial FE space.
+  mfem::ParFiniteElementSpace * _test_fes{nullptr};
+
+  // Bilinear and linear forms
+  std::unique_ptr<mfem::ParBilinearForm> _a{nullptr};
+  std::unique_ptr<mfem::ParLinearForm> _b{nullptr};
+
+private:
+  const hephaestus::InputParameters _solver_options;
+
+  // Operator matrices
+  std::unique_ptr<mfem::HypreParMatrix> _a_mat{nullptr};
+
+  // Solver
+  std::unique_ptr<hephaestus::DefaultJacobiPCGSolver> _solver{nullptr};
 };
 
 } // namespace hephaestus

--- a/src/io/logging.cpp
+++ b/src/io/logging.cpp
@@ -25,4 +25,4 @@ MpiSink<Mutex>::flush_()
 }
 
 // Global logger
-spdlog::logger logger("Hephaestus Logger", std::make_shared<spdlog::sinks::MpiSink_st>());
+spdlog::logger logger("Hephaestus", std::make_shared<spdlog::sinks::MpiSink_st>());

--- a/test/integration/test_complex_aform_rod.cpp
+++ b/test/integration/test_complex_aform_rod.cpp
@@ -163,7 +163,7 @@ TEST_CASE_METHOD(TestComplexAFormRod, "TestComplexAFormRod", "[CheckRun]")
   problem_builder->SetPostprocessors(postprocessors);
 
   problem_builder->AddFESpace("HDiv", "RT_3D_P0");
-  problem_builder->AddFESpace("Scalar_L2", "L2Int_3D_P0");
+  problem_builder->AddFESpace("Scalar_L2", "L2_3D_P0");
 
   problem_builder->AddGridFunction("electric_field_real", "HCurl");
   problem_builder->AddGridFunction("electric_field_imag", "HCurl");

--- a/test/integration/test_complex_iris_wg.cpp
+++ b/test/integration/test_complex_iris_wg.cpp
@@ -150,7 +150,7 @@ TEST_CASE_METHOD(TestComplexIrisWaveguide, "TestComplexIrisWaveguide", "[CheckRu
   problem_builder->SetAuxSolvers(preprocessors);
 
   problem_builder->AddFESpace("HDiv", "RT_3D_P0");
-  problem_builder->AddFESpace("Scalar_L2", "L2Int_3D_P0");
+  problem_builder->AddFESpace("Scalar_L2", "L2_3D_P0");
 
   problem_builder->AddGridFunction("magnetic_flux_density_real", "HDiv");
   problem_builder->AddGridFunction("magnetic_flux_density_imag", "HDiv");

--- a/test/integration/test_team4_hform.cpp
+++ b/test/integration/test_team4_hform.cpp
@@ -108,8 +108,8 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HForm", "[CheckRun]")
   problem_builder->AddFESpace("H1", "H1_3D_P1");
   problem_builder->AddFESpace("HCurl", "ND_3D_P1");
   problem_builder->AddFESpace("HDiv", "RT_3D_P0");
-  problem_builder->AddFESpace("Scalar_L2", "L2Int_3D_P0");
-  problem_builder->AddFESpace("Vector_L2", "L2Int_3D_P0", 3);
+  problem_builder->AddFESpace("Scalar_L2", "L2_3D_P0");
+  problem_builder->AddFESpace("Vector_L2", "L2_3D_P0", 3);
   problem_builder->AddGridFunction("magnetic_field", "HCurl");
 
   problem_builder->AddGridFunction("dmagnetic_potential_dt", "H1");


### PR DESCRIPTION
Previously, `CoefficientAux` and `VectorCoefficientAux` were using `ProjectCoefficient` to set the values of the auxiliary `GridFunction`, which will not (usually) be a conservative mapping, unlike the strategy used in other `AuxSolvers`.  This PR addresses this by explicitly interpolating the input coefficient onto the `GridFunction` via a solve.

`ProjectCoefficient` is still used to provide the initial guess for the iterative solver.