### PR TITLE
Move logger into hephaestus namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ find_package(Boost REQUIRED COMPONENTS ${Boost_PACKAGES})
 #  * mfem_DIR - absolute path to where MFEMConfig.cmake is.
 message(STATUS "Looking for mfem ...")
 
-set(MFEM_DIR "${PROJECT_SOURCE_DIR}/../mfem_build" CACHE PATH "Path to the MFEM build or install prefix.")
-set(MFEM_COMMON_INCLUDES "${PROJECT_SOURCE_DIR}/../mfem/miniapps/common" CACHE PATH "Path to the MFEM common miniapp headers.")
+set(MFEM_DIR "${PROJECT_SOURCE_DIR}/../mfem/build" CACHE PATH "Path to the MFEM build or install prefix.")
+set(MFEM_COMMON_INCLUDES "${MFEM_DIR}/../mfem/miniapps/common" CACHE PATH "Path to the MFEM common miniapp headers.")
 
 if (MFEM_DIR)
    find_package(mfem REQUIRED NAMES MFEM HINTS "${MFEM_DIR}"

--- a/examples/closed_coil/Main.cpp
+++ b/examples/closed_coil/Main.cpp
@@ -100,7 +100,7 @@ main(int argc, char * argv[])
   args.Parse();
   MPI_Init(&argc, &argv);
 
-  logger.set_level(spdlog::level::info);
+  hephaestus::logger.set_level(spdlog::level::info);
 
   // Create Formulation
   auto problem_builder = std::make_unique<hephaestus::MagnetostaticFormulation>(
@@ -148,7 +148,7 @@ main(int argc, char * argv[])
 
   auto executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
 
-  logger.info("Created executioner");
+  hephaestus::logger.info("Created executioner");
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/complex_team7/Main.cpp
+++ b/examples/complex_team7/Main.cpp
@@ -212,7 +212,7 @@ main(int argc, char * argv[])
 
   auto executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
 
-  logger.info("Created exec ");
+  hephaestus::logger.info("Created exec ");
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/magnetostatic/Main.cpp
+++ b/examples/magnetostatic/Main.cpp
@@ -175,7 +175,7 @@ main(int argc, char * argv[])
 
   auto executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
 
-  logger.info("Created executioner");
+  hephaestus::logger.info("Created executioner");
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/open_coil/Main.cpp
+++ b/examples/open_coil/Main.cpp
@@ -175,7 +175,7 @@ main(int argc, char * argv[])
 
   auto executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
 
-  logger.info("Created executioner");
+  hephaestus::logger.info("Created executioner");
   executioner->Execute();
 
   MPI_Finalize();

--- a/examples/team4/Main.cpp
+++ b/examples/team4/Main.cpp
@@ -184,7 +184,7 @@ main(int argc, char * argv[])
     {
       current = -2 * fluxmonitor->_fluxes[i];
       t = fluxmonitor->_times[i];
-      logger.info("t = {} s, I = {} A", t, current);
+      hephaestus::logger.info("t = {} s, I = {} A", t, current);
     }
   }
 

--- a/examples/team7/Main.cpp
+++ b/examples/team7/Main.cpp
@@ -205,7 +205,7 @@ main(int argc, char * argv[])
 
   auto executioner = std::make_unique<hephaestus::TransientExecutioner>(exec_params);
 
-  logger.info("Created executioner");
+  hephaestus::logger.info("Created executioner");
   executioner->Execute();
 
   MPI_Finalize();

--- a/src/auxsolvers/helmholtz_projector.cpp
+++ b/src/auxsolvers/helmholtz_projector.cpp
@@ -21,7 +21,7 @@ HelmholtzProjector::HelmholtzProjector(const hephaestus::InputParameters & param
   default_pars.SetParam("Tolerance", float(1.0e-20));
   default_pars.SetParam("AbsTolerance", float(1.0e-20));
   default_pars.SetParam("MaxIter", (unsigned int)1000);
-  default_pars.SetParam("PrintLevel", logger.level());
+  default_pars.SetParam("PrintLevel", GetGlobalPrintLevel());
 
   _solver_options =
       params.GetOptionalParam<hephaestus::InputParameters>("SolverOptions", default_pars);

--- a/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
+++ b/src/formulations/ComplexMaxwell/complex_e_formulation.cpp
@@ -40,7 +40,7 @@ ComplexEFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_
                           external_j_field_real_name,
                           hephaestus::InputParameters({{"Tolerance", float(1.0e-12)},
                                                        {"MaxIter", (unsigned int)200},
-                                                       {"PrintLevel", logger.level()}})));
+                                                       {"PrintLevel", GetGlobalPrintLevel()}})));
   auxsolvers.Register(j_field_imag_name,
                       std::make_shared<hephaestus::ScaledVectorGridFunctionAux>(
                           _electric_field_imag_name,
@@ -51,7 +51,7 @@ ComplexEFormulation::RegisterCurrentDensityAux(const std::string & j_field_real_
                           external_j_field_imag_name,
                           hephaestus::InputParameters({{"Tolerance", float(1.0e-12)},
                                                        {"MaxIter", (unsigned int)200},
-                                                       {"PrintLevel", logger.level()}})));
+                                                       {"PrintLevel", GetGlobalPrintLevel()}})));
 };
 
 void

--- a/src/io/logging.cpp
+++ b/src/io/logging.cpp
@@ -28,4 +28,28 @@ MpiSink<Mutex>::flush_()
 namespace hephaestus
 {
 spdlog::logger logger("Hephaestus", std::make_shared<spdlog::sinks::MpiSink_st>());
+
+int
+GetGlobalPrintLevel()
+{
+  int global_print_level;
+  if (logger.level() >= SPDLOG_LEVEL_WARN)
+  {
+    global_print_level = 0;
+  }
+  else if (logger.level() == SPDLOG_LEVEL_INFO)
+  {
+    global_print_level = 1;
+  }
+  else if (logger.level() == SPDLOG_LEVEL_DEBUG)
+  {
+    global_print_level = 2;
+  }
+  else
+  {
+    global_print_level = 3;
+  }
+
+  return global_print_level;
+}
 }

--- a/src/io/logging.cpp
+++ b/src/io/logging.cpp
@@ -25,4 +25,7 @@ MpiSink<Mutex>::flush_()
 }
 
 // Global logger
+namespace hephaestus
+{
 spdlog::logger logger("Hephaestus", std::make_shared<spdlog::sinks::MpiSink_st>());
+}

--- a/src/io/logging.hpp
+++ b/src/io/logging.hpp
@@ -23,4 +23,7 @@ using MpiSink_st = MpiSink<spdlog::details::null_mutex>;
 } // namespace spdlog::sinks
 
 // Global logger
+namespace hephaestus
+{
 extern spdlog::logger logger;
+}

--- a/src/io/logging.hpp
+++ b/src/io/logging.hpp
@@ -26,4 +26,5 @@ using MpiSink_st = MpiSink<spdlog::details::null_mutex>;
 namespace hephaestus
 {
 extern spdlog::logger logger;
+extern int GetGlobalPrintLevel();
 }

--- a/src/problem_builders/problem_builder_base.cpp
+++ b/src/problem_builders/problem_builder_base.cpp
@@ -206,7 +206,7 @@ void
 ProblemBuilder::ConstructJacobianPreconditioner()
 {
   auto precond = std::make_shared<mfem::HypreBoomerAMG>();
-  precond->SetPrintLevel(logger.level());
+  precond->SetPrintLevel(GetGlobalPrintLevel());
 
   GetProblem()->_jacobian_preconditioner = precond;
 }

--- a/src/problem_builders/problem_builder_base.hpp
+++ b/src/problem_builders/problem_builder_base.hpp
@@ -137,7 +137,7 @@ protected:
                                               ._tolerance = 1e-16,
                                               ._abs_tolerance = 1e-16,
                                               ._max_iteration = 1000,
-                                              ._print_level = logger.level(),
+                                              ._print_level = GetGlobalPrintLevel(),
                                               ._k_dim = 10});
 };
 

--- a/src/solvers/hephaestus_solvers.hpp
+++ b/src/solvers/hephaestus_solvers.hpp
@@ -14,7 +14,7 @@ public:
       _tol(params.GetOptionalParam<float>("Tolerance", 1.0e-9)),
       _abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
       _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
-      _print_level(params.GetOptionalParam<int>("PrintLevel", logger.level()))
+      _print_level(params.GetOptionalParam<int>("PrintLevel", GetGlobalPrintLevel()))
   {
 
     _amg.SetPrintLevel(_print_level);
@@ -40,7 +40,7 @@ public:
       _tol(params.GetOptionalParam<float>("Tolerance", 1.0e-9)),
       _abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
       _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
-      _print_level(params.GetOptionalParam<int>("PrintLevel", logger.level()))
+      _print_level(params.GetOptionalParam<int>("PrintLevel", GetGlobalPrintLevel()))
   {
 
     SetTol(_tol);
@@ -67,7 +67,7 @@ public:
       _tol(params.GetOptionalParam<float>("Tolerance", 1.0e-16)),
       _abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
       _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
-      _print_level(params.GetOptionalParam<int>("PrintLevel", logger.level()))
+      _print_level(params.GetOptionalParam<int>("PrintLevel", GetGlobalPrintLevel()))
   {
 
     _ams.SetSingularProblem();
@@ -96,7 +96,7 @@ public:
       _tol(params.GetOptionalParam<float>("Tolerance", 1e-16)),
       _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 100)),
       _k_dim(params.GetOptionalParam<unsigned int>("KDim", 10)),
-      _print_level(params.GetOptionalParam<int>("PrintLevel", logger.level()))
+      _print_level(params.GetOptionalParam<int>("PrintLevel", GetGlobalPrintLevel()))
   {
 
     _ams.SetSingularProblem();
@@ -123,7 +123,7 @@ public:
       _tol(params.GetOptionalParam<float>("Tolerance", 1e-16)),
       _abstol(params.GetOptionalParam<float>("AbsTolerance", 1e-16)),
       _max_iter(params.GetOptionalParam<unsigned int>("MaxIter", 1000)),
-      _print_level(params.GetOptionalParam<int>("PrintLevel", logger.level()))
+      _print_level(params.GetOptionalParam<int>("PrintLevel", GetGlobalPrintLevel()))
   {
 
     _amg.SetPrintLevel(_print_level);

--- a/src/sources/closed_coil.hpp
+++ b/src/sources/closed_coil.hpp
@@ -27,7 +27,7 @@ public:
                        hephaestus::InputParameters({{"Tolerance", float(1.0e-18)},
                                                     {"AbsTolerance", float(1.0e-18)},
                                                     {"MaxIter", (unsigned int)1000},
-                                                    {"PrintLevel", logger.level()}}));
+                                                    {"PrintLevel", GetGlobalPrintLevel()}}));
 
   // Override virtual Source destructor to avoid leaks.
   ~ClosedCoilSolver() override = default;

--- a/src/sources/open_coil.hpp
+++ b/src/sources/open_coil.hpp
@@ -41,7 +41,7 @@ public:
                      hephaestus::InputParameters({{"Tolerance", float(1.0e-20)},
                                                   {"AbsTolerance", float(1.0e-20)},
                                                   {"MaxIter", (unsigned int)1000},
-                                                  {"PrintLevel", logger.level()}}));
+                                                  {"PrintLevel", GetGlobalPrintLevel()}}));
 
   ~OpenCoilSolver() override = default;
 

--- a/test/integration/test_aform_source.cpp
+++ b/test/integration/test_aform_source.cpp
@@ -199,7 +199,7 @@ TEST_CASE_METHOD(TestAFormSource, "TestAForm", "[CheckRun]")
                                 l2errpostprocessor->_l2_errs[i],
                                 l2errpostprocessor->_l2_errs[i - 1],
                                 3);
-    logger.info("{}", r);
+    hephaestus::logger.info("{}", r);
     REQUIRE(r > 2 - 0.15);
     REQUIRE(r < 2 + 1.0);
   }

--- a/test/integration/test_avform_source.cpp
+++ b/test/integration/test_avform_source.cpp
@@ -215,7 +215,7 @@ TEST_CASE_METHOD(TestAVFormSource, "TestAVFormSource", "[CheckRun]")
                                 l2errpostprocessor->_l2_errs[i],
                                 l2errpostprocessor->_l2_errs[i - 1],
                                 3);
-    logger.info("{}", r);
+    hephaestus::logger.info("{}", r);
     REQUIRE(r > _var_order - 0.15);
     REQUIRE(r < _var_order + 1.0);
   }

--- a/test/integration/test_complex_team7.cpp
+++ b/test/integration/test_complex_team7.cpp
@@ -153,7 +153,7 @@ protected:
     params.SetParam("Outputs", outputs);
     params.SetParam("Sources", sources);
     params.SetParam("SolverOptions", solver_options);
-    logger.info("Created params ");
+    hephaestus::logger.info("Created params ");
     return params;
   }
 };
@@ -207,7 +207,7 @@ TEST_CASE_METHOD(TestComplexTeam7, "TestComplexTeam7", "[CheckRun]")
 
   auto executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
 
-  logger.info("Created exec ");
+  hephaestus::logger.info("Created exec ");
 
   executioner->Execute();
 }

--- a/test/integration/test_hform_source.cpp
+++ b/test/integration/test_hform_source.cpp
@@ -214,7 +214,7 @@ TEST_CASE_METHOD(TestHFormSource, "TestHFormSource", "[CheckRun]")
                                 l2errpostprocessor->_l2_errs[i],
                                 l2errpostprocessor->_l2_errs[i - 1],
                                 3);
-    logger.info("{}", r);
+    hephaestus::logger.info("{}", r);
     REQUIRE(r > _var_order - 0.15);
     REQUIRE(r < _var_order + 1.0);
   }


### PR DESCRIPTION
Moves logger into hephaestus namespace and provides a helper function to fetch a log level dependent print level for use in defaults for setting verbosity of Hypre solvers.