### PR TITLE
Calcflux fix for OCS

### DIFF
--- a/src/auxsolvers/flux_monitor_aux.cpp
+++ b/src/auxsolvers/flux_monitor_aux.cpp
@@ -28,6 +28,7 @@ calcFlux(mfem::GridFunction * v_field, int face_attr, mfem::Coefficient & q)
       continue;
 
     const mfem::FiniteElement & elem = *fes->GetFE(f_tr->Elem1No);
+    f_tr->Attribute = mesh->GetAttribute(f_tr->Elem1No);
     const int int_order = 2 * elem.GetOrder() + 3;
     const mfem::IntegrationRule & ir = mfem::IntRules.Get(f_tr->FaceGeom, int_order);
 


### PR DESCRIPTION
The `mfem::GetFaceElementTransformations` function isn't setting the correct domain attribute on `FaceElementTransformations`, leading `CalcFlux` to use the wrong sigma to compute fluxes. This is a workaround where the domain attribute is obtained directly from the mesh object and manually set onto the `FaceElementTransformations` object.