### PR TITLE
Change Catch2 test discovery mode to PRE_TEST

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(integration_tests ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY}
 
 include(CTest)
 include(Catch)
-catch_discover_tests(integration_tests WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
+catch_discover_tests(integration_tests WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/bin" DISCOVERY_MODE PRE_TEST)

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(regression_tests ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY} 
 
 include(CTest)
 include(Catch)
-catch_discover_tests(regression_tests)
+catch_discover_tests(regression_tests DISCOVERY_MODE PRE_TEST)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(unit_tests ${MFEM_LIBRARIES} ${MFEM_COMMON_LIBRARY} -lrt)
 
 include(CTest)
 include(Catch)
-catch_discover_tests(unit_tests WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
+catch_discover_tests(unit_tests WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/bin" DISCOVERY_MODE PRE_TEST)


### PR DESCRIPTION
Minor change to Catch2 test discovery in order to workaround build issue on CSD3 Sapphire Rapids nodes.