### PR TITLE
Run build tests on all PRs and reschedule docker build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
     branches:
        - master
   pull_request:
-    branches:
-       - master
 
 jobs:
   docker-build-test-ubuntu:

--- a/.github/workflows/weekly_build.yml
+++ b/.github/workflows/weekly_build.yml
@@ -2,8 +2,8 @@ name: Publish Docker Images
 on:
   workflow_dispatch:
   schedule:
-    # Schedule to update image every Monday morning at 04:00.
-    - cron:  '00 4 * * 1'
+    # Schedule to update image every Monday morning at 02:00.
+    - cron:  '00 2 * * 1'
 
 jobs:
   push-hephaestus-deps-image-to-docker-hub:


### PR DESCRIPTION
Run build tests on all PRs rather than just PRs to master, and and schedule docker builds for 02:00 Monday morning to avoid downstream clashes