### PR TITLE
Add TEAM4 HForm Mesh Uniform Refinement Test Case

### DIFF
--- a/src/auxsolvers/flux_monitor_aux.cpp
+++ b/src/auxsolvers/flux_monitor_aux.cpp
@@ -90,6 +90,13 @@ FluxMonitorAux::Init(const hephaestus::GridFunctions & gridfunctions,
 }
 
 void
+FluxMonitorAux::Reset()
+{
+  _times.DeleteAll();
+  _fluxes.DeleteAll();
+}
+
+void
 FluxMonitorAux::Solve(double t)
 {
   double flux;

--- a/src/auxsolvers/flux_monitor_aux.hpp
+++ b/src/auxsolvers/flux_monitor_aux.hpp
@@ -23,6 +23,8 @@ public:
   void Init(const hephaestus::GridFunctions & gridfunctions,
             hephaestus::Coefficients & coefficients) override;
 
+  void Reset();
+
   void Update() override {}
 
   void Solve(double t = 0.0) override;

--- a/src/sources/scalar_potential_source.cpp
+++ b/src/sources/scalar_potential_source.cpp
@@ -117,11 +117,8 @@ ScalarPotentialSource::Apply(mfem::ParLinearForm * lf)
   _a0->FormLinearSystem(
       poisson_ess_tdof_list, phi_gf, *_b0, *_diffusion_mat, *_p_tdofs, *_b0_tdofs);
 
-  if (_a0_solver == nullptr)
-  {
-    _a0_solver = std::make_unique<hephaestus::DefaultH1PCGSolver>(_solver_options, *_diffusion_mat);
-  }
   // Solve
+  _a0_solver = std::make_unique<hephaestus::DefaultH1PCGSolver>(_solver_options, *_diffusion_mat);
   _a0_solver->Mult(*_b0_tdofs, *_p_tdofs);
 
   // "undo" the static condensation saving result in grid function dP

--- a/test/integration/test_team4_hform.cpp
+++ b/test/integration/test_team4_hform.cpp
@@ -228,8 +228,8 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HForm", "[CheckRun]")
 
   hephaestus::InputParameters exec_params = DefineExecutionerParameters(*problem);
 
-  auto executioner = std::make_unique<hephaestus::TransientExecutioner>(exec_params);
-  executioner->Execute();
+  hephaestus::TransientExecutioner executioner(exec_params);
+  executioner.Execute();
 
   double peak_current, peak_current_time;
   ExtractPeakCurrentAndTime(*problem, peak_current, peak_current_time);

--- a/test/integration/test_team4_hform.cpp
+++ b/test/integration/test_team4_hform.cpp
@@ -43,6 +43,7 @@ protected:
     dh_dt(2) = 0.0;
   }
 
+  /// Returns a unique pointer to the constructed problem builder.
   std::unique_ptr<hephaestus::HFormulation> ConfigureProblem()
   {
     // Create Formulation
@@ -171,6 +172,7 @@ protected:
     return outputs;
   }
 
+  /// Sets the peak current and time using the flux monitor.
   void ExtractPeakCurrentAndTime(hephaestus::TimeDomainProblem & problem,
                                  double & peak_current,
                                  double & peak_current_time)
@@ -194,6 +196,7 @@ protected:
     }
   }
 
+  /// Checks peak current and time are within expected range.
   void VerifyPeakCurrentAndTimeWithinTolerances(double & peak_current, double & peak_current_time)
   {
     const double min_peak_current = 3.2e3;
@@ -212,7 +215,6 @@ protected:
 
 TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HForm", "[CheckRun]")
 {
-  // Create Formulation
   auto problem_builder = ConfigureProblem();
 
   auto problem = problem_builder->ReturnProblem();
@@ -262,6 +264,7 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HFormMeshUpdates", "[CheckRun][!bench
 
     VerifyPeakCurrentAndTimeWithinTolerances(peak_current, peak_current_time);
 
+    // Refine if we have another iteration.
     if (irefinement != (imax_refinement - 1))
     {
       problem->_pmesh->UniformRefinement();

--- a/test/integration/test_team4_hform.cpp
+++ b/test/integration/test_team4_hform.cpp
@@ -184,7 +184,7 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HForm", "[CheckRun]")
 }
 
 /// Test case for checking "Updates" work as expected following a mesh refinement.
-TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HFormMeshUpdates", "[CheckRun]")
+TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HFormMeshUpdates", "[CheckRun][!benchmark]")
 {
   // Create Formulation
   auto problem_builder = std::make_unique<hephaestus::HFormulation>(

--- a/test/integration/test_team4_hform.cpp
+++ b/test/integration/test_team4_hform.cpp
@@ -193,6 +193,21 @@ protected:
       }
     }
   }
+
+  void VerifyPeakCurrentAndTimeWithinTolerances(double & peak_current, double & peak_current_time)
+  {
+    const double min_peak_current = 3.2e3;
+    const double max_peak_current = 3.6e3;
+
+    const double min_peak_current_time = 0.010;
+    const double max_peak_current_time = 0.012;
+
+    REQUIRE(peak_current > min_peak_current);
+    REQUIRE(peak_current < max_peak_current);
+
+    REQUIRE(peak_current_time > min_peak_current_time);
+    REQUIRE(peak_current_time < max_peak_current_time);
+  }
 };
 
 TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HForm", "[CheckRun]")
@@ -211,10 +226,7 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HForm", "[CheckRun]")
   double peak_current, peak_current_time;
   ExtractPeakCurrentAndTime(*problem, peak_current, peak_current_time);
 
-  REQUIRE(peak_current > 3.2e3);
-  REQUIRE(peak_current < 3.6e3);
-  REQUIRE(peak_current_time < 0.012);
-  REQUIRE(peak_current_time > 0.01);
+  VerifyPeakCurrentAndTimeWithinTolerances(peak_current, peak_current_time);
 }
 
 /// Test case for checking "Updates" work as expected following a mesh refinement.
@@ -248,10 +260,7 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HFormMeshUpdates", "[CheckRun][!bench
                             peak_current,
                             peak_current_time);
 
-    REQUIRE(peak_current > 3.2e3);
-    REQUIRE(peak_current < 3.6e3);
-    REQUIRE(peak_current_time < 0.012);
-    REQUIRE(peak_current_time > 0.01);
+    VerifyPeakCurrentAndTimeWithinTolerances(peak_current, peak_current_time);
 
     if (irefinement != (imax_refinement - 1))
     {

--- a/test/integration/test_team4_hform.cpp
+++ b/test/integration/test_team4_hform.cpp
@@ -43,6 +43,70 @@ protected:
     dh_dt(2) = 0.0;
   }
 
+  std::unique_ptr<hephaestus::HFormulation> ConfigureProblem()
+  {
+    // Create Formulation
+    auto problem_builder = std::make_unique<hephaestus::HFormulation>(
+        "electric_resistivity", "electric_conductivity", "magnetic_permeability", "magnetic_field");
+    // Set Mesh
+    mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./team4_symmetrized.g")).c_str(), 1, 1);
+    auto pmesh = std::make_shared<mfem::ParMesh>(MPI_COMM_WORLD, mesh);
+
+    problem_builder->SetMesh(pmesh);
+    problem_builder->AddFESpace("H1", "H1_3D_P1");
+    problem_builder->AddFESpace("HCurl", "ND_3D_P1");
+    problem_builder->AddFESpace("HDiv", "RT_3D_P0");
+    problem_builder->AddFESpace("Scalar_L2", "L2_3D_P0");
+    problem_builder->AddFESpace("Vector_L2", "L2_3D_P0", 3);
+    problem_builder->AddGridFunction("magnetic_field", "HCurl");
+
+    problem_builder->AddGridFunction("dmagnetic_potential_dt", "H1");
+    problem_builder->AddGridFunction("magnetic_flux_density", "HDiv");
+    problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density");
+
+    problem_builder->AddGridFunction("current_density", "HDiv");
+    problem_builder->RegisterCurrentDensityAux("current_density");
+
+    problem_builder->AddGridFunction("electric_field", "HCurl");
+    problem_builder->RegisterElectricFieldAux("electric_field");
+
+    hephaestus::Coefficients coefficients = DefineCoefficients();
+    problem_builder->SetCoefficients(coefficients);
+
+    hephaestus::Sources sources = DefineSources();
+    problem_builder->SetSources(sources);
+
+    hephaestus::Outputs outputs = DefineOutputs();
+    problem_builder->SetOutputs(outputs);
+
+    problem_builder->AddBoundaryCondition(
+        "tangential_dhdt_bc",
+        std::make_shared<hephaestus::VectorDirichletBC>(
+            "dmagnetic_field_dt",
+            mfem::Array<int>({1, 2, 5, 6}),
+            coefficients._vectors.Get("surface_tangential_dHdt")));
+    problem_builder->AddBoundaryCondition(
+        "magnetic_potential_bc",
+        std::make_shared<hephaestus::ScalarDirichletBC>(
+            "dmagnetic_potential_dt",
+            mfem::Array<int>({1, 2}),
+            coefficients._scalars.Get("magnetic_potential_time_derivative")));
+
+    auto fluxmonitor = std::make_shared<hephaestus::FluxMonitorAux>("current_density", 3);
+    fluxmonitor->SetPriority(2);
+    problem_builder->AddPostprocessor("FluxMonitor", fluxmonitor);
+
+    hephaestus::InputParameters solver_options;
+    solver_options.SetParam("AbsTolerance", float(1.0e-20));
+    solver_options.SetParam("Tolerance", float(1.0e-20));
+    solver_options.SetParam("MaxIter", (unsigned int)500);
+    problem_builder->SetSolverOptions(solver_options);
+
+    problem_builder->FinalizeProblem();
+
+    return problem_builder;
+  }
+
   hephaestus::Coefficients DefineCoefficients()
   {
     hephaestus::Subdomain brick("brick", 1);
@@ -98,64 +162,12 @@ protected:
 TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HForm", "[CheckRun]")
 {
   // Create Formulation
-  auto problem_builder = std::make_unique<hephaestus::HFormulation>(
-      "electric_resistivity", "electric_conductivity", "magnetic_permeability", "magnetic_field");
-  // Set Mesh
-  mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./team4_symmetrized.g")).c_str(), 1, 1);
-  auto pmesh = std::make_shared<mfem::ParMesh>(MPI_COMM_WORLD, mesh);
-
-  problem_builder->SetMesh(pmesh);
-  problem_builder->AddFESpace("H1", "H1_3D_P1");
-  problem_builder->AddFESpace("HCurl", "ND_3D_P1");
-  problem_builder->AddFESpace("HDiv", "RT_3D_P0");
-  problem_builder->AddFESpace("Scalar_L2", "L2_3D_P0");
-  problem_builder->AddFESpace("Vector_L2", "L2_3D_P0", 3);
-  problem_builder->AddGridFunction("magnetic_field", "HCurl");
-
-  problem_builder->AddGridFunction("dmagnetic_potential_dt", "H1");
-  problem_builder->AddGridFunction("magnetic_flux_density", "HDiv");
-  problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density");
-
-  problem_builder->AddGridFunction("current_density", "HDiv");
-  problem_builder->RegisterCurrentDensityAux("current_density");
-
-  problem_builder->AddGridFunction("electric_field", "HCurl");
-  problem_builder->RegisterElectricFieldAux("electric_field");
-
-  hephaestus::Coefficients coefficients = DefineCoefficients();
-  problem_builder->SetCoefficients(coefficients);
-
-  hephaestus::Sources sources = DefineSources();
-  problem_builder->SetSources(sources);
-
-  hephaestus::Outputs outputs = DefineOutputs();
-  problem_builder->SetOutputs(outputs);
-
-  problem_builder->AddBoundaryCondition("tangential_dhdt_bc",
-                                        std::make_shared<hephaestus::VectorDirichletBC>(
-                                            "dmagnetic_field_dt",
-                                            mfem::Array<int>({1, 2, 5, 6}),
-                                            coefficients._vectors.Get("surface_tangential_dHdt")));
-  problem_builder->AddBoundaryCondition(
-      "magnetic_potential_bc",
-      std::make_shared<hephaestus::ScalarDirichletBC>(
-          "dmagnetic_potential_dt",
-          mfem::Array<int>({1, 2}),
-          coefficients._scalars.Get("magnetic_potential_time_derivative")));
-
-  auto fluxmonitor = std::make_shared<hephaestus::FluxMonitorAux>("current_density", 3);
-  fluxmonitor->SetPriority(2);
-  problem_builder->AddPostprocessor("FluxMonitor", fluxmonitor);
-
-  hephaestus::InputParameters solver_options;
-  solver_options.SetParam("AbsTolerance", float(1.0e-20));
-  solver_options.SetParam("Tolerance", float(1.0e-20));
-  solver_options.SetParam("MaxIter", (unsigned int)500);
-  problem_builder->SetSolverOptions(solver_options);
-
-  problem_builder->FinalizeProblem();
+  auto problem_builder = ConfigureProblem();
 
   auto problem = problem_builder->ReturnProblem();
+
+  auto fluxmonitor = problem->_postprocessors.Get<hephaestus::FluxMonitorAux>("FluxMonitor");
+
   hephaestus::InputParameters exec_params;
   exec_params.SetParam("TimeStep", float(0.001));
   exec_params.SetParam("StartTime", float(0.00));
@@ -186,65 +198,12 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HForm", "[CheckRun]")
 /// Test case for checking "Updates" work as expected following a mesh refinement.
 TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HFormMeshUpdates", "[CheckRun][!benchmark]")
 {
-  // Create Formulation
-  auto problem_builder = std::make_unique<hephaestus::HFormulation>(
-      "electric_resistivity", "electric_conductivity", "magnetic_permeability", "magnetic_field");
-  // Set Mesh
-  mfem::Mesh mesh((std::string(DATA_DIR) + std::string("./team4_symmetrized.g")).c_str(), 1, 1);
-  auto pmesh = std::make_shared<mfem::ParMesh>(MPI_COMM_WORLD, mesh);
-
-  problem_builder->SetMesh(pmesh);
-  problem_builder->AddFESpace("H1", "H1_3D_P1");
-  problem_builder->AddFESpace("HCurl", "ND_3D_P1");
-  problem_builder->AddFESpace("HDiv", "RT_3D_P0");
-  problem_builder->AddFESpace("Scalar_L2", "L2_3D_P0");
-  problem_builder->AddFESpace("Vector_L2", "L2_3D_P0", 3);
-  problem_builder->AddGridFunction("magnetic_field", "HCurl");
-
-  problem_builder->AddGridFunction("dmagnetic_potential_dt", "H1");
-  problem_builder->AddGridFunction("magnetic_flux_density", "HDiv");
-  problem_builder->RegisterMagneticFluxDensityAux("magnetic_flux_density");
-
-  problem_builder->AddGridFunction("current_density", "HDiv");
-  problem_builder->RegisterCurrentDensityAux("current_density");
-
-  problem_builder->AddGridFunction("electric_field", "HCurl");
-  problem_builder->RegisterElectricFieldAux("electric_field");
-
-  hephaestus::Coefficients coefficients = DefineCoefficients();
-  problem_builder->SetCoefficients(coefficients);
-
-  hephaestus::Sources sources = DefineSources();
-  problem_builder->SetSources(sources);
-
-  hephaestus::Outputs outputs = DefineOutputs();
-  problem_builder->SetOutputs(outputs);
-
-  problem_builder->AddBoundaryCondition("tangential_dhdt_bc",
-                                        std::make_shared<hephaestus::VectorDirichletBC>(
-                                            "dmagnetic_field_dt",
-                                            mfem::Array<int>({1, 2, 5, 6}),
-                                            coefficients._vectors.Get("surface_tangential_dHdt")));
-  problem_builder->AddBoundaryCondition(
-      "magnetic_potential_bc",
-      std::make_shared<hephaestus::ScalarDirichletBC>(
-          "dmagnetic_potential_dt",
-          mfem::Array<int>({1, 2}),
-          coefficients._scalars.Get("magnetic_potential_time_derivative")));
-
-  auto fluxmonitor = std::make_shared<hephaestus::FluxMonitorAux>("current_density", 3);
-  fluxmonitor->SetPriority(2);
-  problem_builder->AddPostprocessor("FluxMonitor", fluxmonitor);
-
-  hephaestus::InputParameters solver_options;
-  solver_options.SetParam("AbsTolerance", float(1.0e-20));
-  solver_options.SetParam("Tolerance", float(1.0e-20));
-  solver_options.SetParam("MaxIter", (unsigned int)500);
-  problem_builder->SetSolverOptions(solver_options);
-
-  problem_builder->FinalizeProblem();
+  auto problem_builder = ConfigureProblem();
 
   auto problem = problem_builder->ReturnProblem();
+
+  auto fluxmonitor = problem->_postprocessors.Get<hephaestus::FluxMonitorAux>("FluxMonitor");
+
   hephaestus::InputParameters exec_params;
   exec_params.SetParam("TimeStep", float(0.001));
   exec_params.SetParam("StartTime", float(0.00));
@@ -286,7 +245,7 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HFormMeshUpdates", "[CheckRun][!bench
 
     if (irefinement != (imax_refinement - 1))
     {
-      pmesh->UniformRefinement();
+      problem->_pmesh->UniformRefinement();
       problem->Update();
     }
   }

--- a/test/integration/test_team4_hform.cpp
+++ b/test/integration/test_team4_hform.cpp
@@ -254,7 +254,7 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HFormMeshUpdates", "[CheckRun]")
 
   hephaestus::logger.set_level(spdlog::level::info);
 
-  const int imax_refinement = 3;
+  const int imax_refinement = 2;
   for (int irefinement = 0; irefinement < imax_refinement; irefinement++)
   {
     // Remove any stored fluxes.

--- a/test/integration/test_team4_hform.cpp
+++ b/test/integration/test_team4_hform.cpp
@@ -107,6 +107,19 @@ protected:
     return problem_builder;
   }
 
+  hephaestus::InputParameters DefineExecutionerParameters(hephaestus::TimeDomainProblem & problem)
+  {
+    hephaestus::InputParameters exec_params;
+
+    exec_params.SetParam("TimeStep", float(0.001));
+    exec_params.SetParam("StartTime", float(0.00));
+    exec_params.SetParam("EndTime", float(0.015));
+    exec_params.SetParam("VisualisationSteps", int(1));
+    exec_params.SetParam("Problem", &problem);
+
+    return exec_params;
+  }
+
   hephaestus::Coefficients DefineCoefficients()
   {
     hephaestus::Subdomain brick("brick", 1);
@@ -168,12 +181,7 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HForm", "[CheckRun]")
 
   auto fluxmonitor = problem->_postprocessors.Get<hephaestus::FluxMonitorAux>("FluxMonitor");
 
-  hephaestus::InputParameters exec_params;
-  exec_params.SetParam("TimeStep", float(0.001));
-  exec_params.SetParam("StartTime", float(0.00));
-  exec_params.SetParam("EndTime", float(0.015));
-  exec_params.SetParam("VisualisationSteps", int(1));
-  exec_params.SetParam("Problem", static_cast<hephaestus::TimeDomainProblem *>(problem.get()));
+  hephaestus::InputParameters exec_params = DefineExecutionerParameters(*problem);
 
   auto executioner = std::make_unique<hephaestus::TransientExecutioner>(exec_params);
 
@@ -204,12 +212,7 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HFormMeshUpdates", "[CheckRun][!bench
 
   auto fluxmonitor = problem->_postprocessors.Get<hephaestus::FluxMonitorAux>("FluxMonitor");
 
-  hephaestus::InputParameters exec_params;
-  exec_params.SetParam("TimeStep", float(0.001));
-  exec_params.SetParam("StartTime", float(0.00));
-  exec_params.SetParam("EndTime", float(0.015));
-  exec_params.SetParam("VisualisationSteps", int(1));
-  exec_params.SetParam("Problem", static_cast<hephaestus::TimeDomainProblem *>(problem.get()));
+  hephaestus::InputParameters exec_params = DefineExecutionerParameters(*problem);
 
   hephaestus::logger.set_level(spdlog::level::info);
 

--- a/test/integration/test_team4_hform.cpp
+++ b/test/integration/test_team4_hform.cpp
@@ -286,7 +286,7 @@ TEST_CASE_METHOD(TestTEAM4HForm, "TestTEAM4HFormMeshUpdates", "[CheckRun]")
 
     if (irefinement != (imax_refinement - 1))
     {
-      mesh.UniformRefinement();
+      pmesh->UniformRefinement();
       problem->Update();
     }
   }


### PR DESCRIPTION
- Adds **Reset** method to FluxMonitorAux.
- Adds a second test case named "TestTEAM4HFormMeshUpdates" which is identical to "TestTEAM4HForm" but solves for two different refinement levels.